### PR TITLE
Add ZFS scrub and replication modules, CI, and a docs site

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.sh]
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: shellcheck + smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        run: |
+          command -v shellcheck >/dev/null || {
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends shellcheck
+          }
+          shellcheck --version
+
+      - run: make lint
+
+      - run: make test
+
+  debian:
+    name: smoke test on debian 13 (pve target)
+    runs-on: ubuntu-latest
+    container: debian:13
+    steps:
+      - name: Install build deps
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends make git ca-certificates
+
+      - uses: actions/checkout@v4
+
+      - run: make test

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: mkdocs build --strict
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
+
+      - run: pip install -r docs/requirements.txt
+
+      # --strict turns broken internal links and nav typos into failures.
+      - run: mkdocs build --strict
+
+      - uses: actions/upload-pages-artifact@v3
+        if: github.ref == 'refs/heads/main'
+        with:
+          path: site
+
+  deploy:
+    name: GitHub Pages
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.bak.*
+*.prev
+.codegraph/
+site/
+.idea/
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+SHELL := /bin/bash
+FILES := pve-toolbox $(sort $(wildcard lib/*.sh)) $(sort $(wildcard modules/*/*.sh))
+
+.PHONY: lint syntax test
+
+lint: syntax
+	@command -v shellcheck >/dev/null || { echo "shellcheck not installed: apt install shellcheck"; exit 1; }
+	shellcheck -x -S warning $(FILES)
+
+syntax:
+	@for f in $(FILES); do bash -n $$f && echo "ok  $$f"; done
+
+test: syntax
+	@TOOLBOX_BIN_DIR=$$(mktemp -d) TOOLBOX_STATE_DIR=$$(mktemp -d) \
+	 TOOLBOX_SYSTEMD_DIR=$$(mktemp -d) TOOLBOX_CONF_DIR=$$(mktemp -d) \
+	 ./pve-toolbox list >/dev/null && echo "ok  launcher smoke test"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,102 @@
+# pve-toolbox
+
+[![CI](https://github.com/quwisky/pve-toolbox/actions/workflows/ci.yml/badge.svg)](https://github.com/quwisky/pve-toolbox/actions/workflows/ci.yml)
+[![Docs](https://github.com/quwisky/pve-toolbox/actions/workflows/docs.yml/badge.svg)](https://github.com/quwisky/pve-toolbox/actions/workflows/docs.yml)
+
+Custom Proxmox VE host scripts behind one interactive launcher.
+
+**📖 [Documentation](https://quwisky.github.io/pve-toolbox/)**
+
+Each script is a *module*: a self-contained directory that knows how to install,
+update, report on, and remove itself. The launcher discovers modules at runtime,
+so adding a new script means dropping in a directory — no registry to edit.
+
+```
+pve-toolbox/
+├── pve-toolbox              # launcher
+├── lib/
+│   ├── common.sh            # output, prompts, releases, systemd, state, conf
+│   └── discord.sh           # webhook reporting, also installed for helper scripts
+├── modules/
+│   ├── _template/           # copy this to start a new module (underscore = hidden)
+│   ├── scrutiny-collectors/ # SMART/ZFS/MDADM collectors for a remote Scrutiny
+│   ├── zfs-scrub/           # scheduled scrub per pool, reported to Discord
+│   └── zfs-replication/     # syncoid jobs on a timer, reported to Discord
+├── docs/                    # mkdocs-material sources
+└── Makefile                 # make syntax / lint / test
+```
+
+## Install
+
+```bash
+git clone https://github.com/quwisky/pve-toolbox.git /opt/pve-toolbox
+cd /opt/pve-toolbox
+./pve-toolbox link     # symlink into /usr/local/bin
+pve-toolbox            # interactive menu
+```
+
+Run it on the PVE host as root. Modules that need raw disk or `zpool` access
+declare `MODULE_HOST_ONLY=1` and warn if they detect an LXC.
+
+## Usage
+
+```
+pve-toolbox                    interactive menu
+pve-toolbox list [tag]         list modules and their status
+pve-toolbox install <mod>...   install specific modules
+pve-toolbox update [mod]...    update (all installed if none given)
+pve-toolbox check [mod]...     report available updates, change nothing
+pve-toolbox status [mod]       detailed status
+pve-toolbox uninstall <mod>...
+pve-toolbox self-update        git pull this checkout
+```
+
+Flags: `-y` non-interactive (modules read their env vars instead of prompting),
+`-f` force, `-h` help.
+
+## Modules
+
+| Module | What it does |
+| --- | --- |
+| [zfs-scrub](https://quwisky.github.io/pve-toolbox/modules/zfs-scrub/) | Scrubs each pool on its own timer, reports start and result to Discord |
+| [zfs-replication](https://quwisky.github.io/pve-toolbox/modules/zfs-replication/) | Runs `syncoid` jobs on timers, reports duration and size to Discord |
+| [scrutiny-collectors](https://quwisky.github.io/pve-toolbox/modules/scrutiny-collectors/) | SMART / ZFS / MDADM collectors feeding a remote Scrutiny instance |
+
+## Writing a module
+
+```bash
+cp -r modules/_template modules/my-thing
+$EDITOR modules/my-thing/module.sh
+```
+
+Set the metadata (`MODULE_NAME` must match the directory name) and implement
+`module_install`, `module_update`, `module_status`, `module_uninstall`.
+`module_status_long` is optional and falls back to `module_status`.
+
+Two rules:
+
+- **Keep the file side-effect free at source time.** The launcher sources every
+  module just to read its metadata for the menu.
+- **State is `0644`, config is `0600`.** Facts go through `state_set` into
+  `/var/lib/pve-toolbox/`; secrets go through `conf_set` into
+  `/etc/pve-toolbox/`.
+
+Full contract, helper reference and the Discord reporting API:
+**[Writing a module](https://quwisky.github.io/pve-toolbox/writing-a-module/)**.
+
+## Development
+
+```bash
+make syntax  # bash -n everything
+make lint    # shellcheck everything
+make test    # syntax + launcher smoke test against throwaway dirs
+```
+
+CI runs all three on every push and pull request, plus the smoke test again
+inside a `debian:13` container to match the PVE 9 host. The docs build with
+`mkdocs build --strict`, so a broken internal link fails the build.
+
+```bash
+pip install -r docs/requirements.txt
+mkdocs serve
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,80 @@
+# Getting started
+
+## Install
+
+```bash
+git clone https://github.com/quwisky/pve-toolbox.git /opt/pve-toolbox
+cd /opt/pve-toolbox
+./pve-toolbox link     # symlink into /usr/local/bin
+pve-toolbox            # interactive menu
+```
+
+Run it on the PVE host as root. Modules that need raw disk or `zpool` access
+declare `MODULE_HOST_ONLY=1` and warn if they detect an LXC.
+
+## Commands
+
+```
+pve-toolbox                    interactive menu
+pve-toolbox list [tag]         list modules and their status
+pve-toolbox install <mod>...   install specific modules
+pve-toolbox update [mod]...    update (all installed if none given)
+pve-toolbox check [mod]...     report available updates, change nothing
+pve-toolbox status [mod]       detailed status
+pve-toolbox uninstall <mod>...
+pve-toolbox self-update        git pull this checkout
+```
+
+Flags: `-y` non-interactive (modules read their env vars instead of
+prompting), `-f` force, `-h` help.
+
+## The menu
+
+Type numbers to toggle selection, then a letter for the action:
+
+```
+    #  MODULE                   STATUS      DESCRIPTION
+ *  1) Scrutiny collectors      v1.67.0     SMART / ZFS / MDADM collectors...
+    2) ZFS scrub + Discord      pools:3     scheduled scrub per pool...
+    3) ZFS replication          jobs:1      syncoid jobs on a timer...
+
+  i install/reconfigure selected   u update all installed
+  c check for updates              s status of selected
+  x uninstall selected             q quit
+```
+
+## Unattended checks
+
+`check` changes nothing, which makes it safe on a timer:
+
+```bash
+DISCORD_WEBHOOK=https://discord.com/api/webhooks/<id>/<token>
+
+pve-toolbox check 2>&1 | grep -q 'update available' && \
+  curl -sf -X POST "$DISCORD_WEBHOOK" \
+       -H 'Content-Type: application/json' \
+       -d "{\"content\": \"pve-toolbox updates available on $(hostname -s)\"}"
+```
+
+## Non-interactive install
+
+Every module reads env vars in place of prompts under `-y`:
+
+```bash
+ZFS_SCRUB_WEBHOOK='https://discord.com/api/webhooks/<id>/<token>' \
+ZFS_SCRUB_POOLS='rpool tank' \
+  pve-toolbox -y install zfs-scrub
+```
+
+The per-module pages list the variables each one accepts.
+
+## Development
+
+```bash
+make syntax  # bash -n everything
+make lint    # shellcheck everything
+make test    # syntax + launcher smoke test against throwaway dirs
+```
+
+CI runs all three on every push and pull request, plus the smoke test again
+inside a `debian:13` container to match the PVE 9 host.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,63 @@
+# pve-toolbox
+
+Custom Proxmox VE host scripts behind one interactive launcher.
+
+Each script is a *module*: a self-contained directory that knows how to
+install, update, report on, and remove itself. The launcher discovers modules
+at runtime, so adding a new script means dropping in a directory — there is no
+registry to edit.
+
+```
+pve-toolbox/
+├── pve-toolbox              # launcher
+├── lib/
+│   ├── common.sh            # output, prompts, releases, systemd, state, conf
+│   └── discord.sh           # webhook reporting
+├── modules/
+│   ├── _template/           # copy this to start a new module
+│   ├── scrutiny-collectors/
+│   ├── zfs-scrub/
+│   └── zfs-replication/
+└── Makefile                 # make syntax / lint / test
+```
+
+## Modules
+
+| Module | What it does |
+| --- | --- |
+| [zfs-scrub](modules/zfs-scrub.md) | Scrubs each pool on its own timer, reports start and result to Discord |
+| [zfs-replication](modules/zfs-replication.md) | Runs `syncoid` jobs on timers, reports duration and size to Discord |
+| [scrutiny-collectors](modules/scrutiny-collectors.md) | SMART / ZFS / MDADM collectors feeding a remote Scrutiny instance |
+
+## Design
+
+Three ideas hold the whole thing together.
+
+**Modules are discovered, not registered.** The launcher globs
+`modules/*/module.sh`, sources each one to read its metadata, and builds the
+menu from that. A directory starting with `_` is skipped.
+
+**Modules are isolated.** Every module function runs in a subshell, so module
+globals cannot leak into the launcher or into each other. Metadata is read in
+a separate subshell again, which is why a module file must stay side-effect
+free at source time.
+
+**State and config are different things.** What the module knows goes in
+`/var/lib/pve-toolbox/<module>.state` at `0644`. What the operator set — a
+token, a webhook URL — goes in `/etc/pve-toolbox/<module>.conf` at `0600`.
+See [Writing a module](writing-a-module.md#state-versus-config).
+
+!!! note "Where things land"
+
+    | Path | Contents | Mode |
+    | --- | --- | --- |
+    | `/usr/local/bin/` | launcher symlink and module helper scripts | `0755` |
+    | `/usr/local/lib/pve-toolbox/` | shared libs the helpers source | `0644` |
+    | `/etc/pve-toolbox/` | per-module config, secrets included | `0600` |
+    | `/var/lib/pve-toolbox/` | per-module state | `0644` |
+    | `/var/log/pve-toolbox/` | per-job logs | `0640` |
+    | `/etc/systemd/system/` | units and timers | `0644` |
+
+    Every one of these is overridable — `TOOLBOX_BIN_DIR`, `TOOLBOX_LIB_DIR`,
+    `TOOLBOX_CONF_DIR`, `TOOLBOX_STATE_DIR`, `TOOLBOX_SYSTEMD_DIR` — which is
+    what makes the modules testable off a real host.

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -1,0 +1,28 @@
+# Modules
+
+A module is a directory under `modules/` containing at least `module.sh`. The
+launcher discovers them at runtime; directories starting with `_` are skipped.
+
+| Module | Tags | Host only | Helper installed |
+| --- | --- | --- | --- |
+| [zfs-scrub](zfs-scrub.md) | `storage zfs monitoring notify` | yes | `pve-toolbox-zfs-scrub` |
+| [zfs-replication](zfs-replication.md) | `storage zfs backup replication notify` | yes | `pve-toolbox-zfs-sync` |
+| [scrutiny-collectors](scrutiny-collectors.md) | `storage monitoring smart zfs` | yes | four collector binaries |
+
+Filter by tag:
+
+```bash
+pve-toolbox list zfs
+```
+
+## What every module implements
+
+| Function | Called by | Purpose |
+| --- | --- | --- |
+| `module_install` | `install`, menu `i` | Interactive install or reconfigure |
+| `module_update` | `update`, `check`, menu `u`/`c` | Update in place; `--check` reports only |
+| `module_status` | menu, `list` | One short line; exits 1 when not installed |
+| `module_status_long` | `status`, menu `s` | Detailed status; optional, falls back to `module_status` |
+| `module_uninstall` | `uninstall`, menu `x` | Remove what install created |
+
+See [Writing a module](../writing-a-module.md) for the full contract.

--- a/docs/modules/scrutiny-collectors.md
+++ b/docs/modules/scrutiny-collectors.md
@@ -1,0 +1,63 @@
+# scrutiny-collectors
+
+Installs the [Starosdev/scrutiny](https://github.com/Starosdev/scrutiny)
+collector binaries plus systemd timers, reporting to a Scrutiny web instance
+running elsewhere — typically a Docker LXC.
+
+```
+Module      scrutiny-collectors
+Binaries    /usr/local/bin/scrutiny-collector-{metrics,zfs,mdadm,performance}
+Config      /opt/scrutiny/config/*.yaml   (0640)
+Units       scrutiny-collector-<kind>.{service,timer}
+```
+
+## Collectors
+
+| Collector | Default schedule | Notes |
+| --- | --- | --- |
+| `metrics` | `*-*-* 04:00:00` | SMART data, daily |
+| `zfs` | `*:0/15` | Pool state, every 15 minutes |
+| `mdadm` | `*:0/15` | Only offered when `/proc/mdstat` shows an array |
+| `performance` | `Sun *-*-* 02:00:00` | fio-based, adds real disk load, off by default |
+
+Install asks which ones you want, and skips the ZFS collector entirely when
+there is no `zpool` binary.
+
+## Updates are the interesting part
+
+`update` does more than swap binaries:
+
+1. Pauses the timers and waits for any in-flight collection to finish.
+2. Replaces each binary, keeping the old one as `.prev`.
+3. Smoke-tests each collector by running its unit once.
+4. Rolls back the ones that failed, and re-tests them on the previous build.
+5. Resumes the timers.
+
+The recorded version only advances if **every** collector passed. If any
+rolled back, state stays at the old version and the run says which ones.
+
+Release assets are checksum-verified when the release ships a checksum file.
+
+## Env vars for `-y`
+
+| Variable | Meaning |
+| --- | --- |
+| `SCRUTINY_API_ENDPOINT` | Base URL of the Scrutiny web instance |
+| `SCRUTINY_API_TOKEN` | Collector token, blank if auth is off |
+| `SCRUTINY_HOST_ID` | Host id shown in the dashboard |
+| `SCRUTINY_VERSION` | Release tag, or `latest` |
+| `SCRUTINY_SCHEDULE_METRICS` | `OnCalendar` per collector |
+| `SCRUTINY_SCHEDULE_ZFS` | |
+| `SCRUTINY_SCHEDULE_MDADM` | |
+| `SCRUTINY_SCHEDULE_PERFORMANCE` | |
+
+!!! note "ZED still beats polling"
+
+    ZFS pool events reach you faster through ZED than any collector interval.
+    Keep the ZED-to-Discord hook alongside this; the collectors are for trend
+    data, not for alerting.
+
+## Uninstall
+
+Removes the binaries and units, leaves `/opt/scrutiny/config` in place so a
+reinstall keeps the endpoint and token.

--- a/docs/modules/zfs-replication.md
+++ b/docs/modules/zfs-replication.md
@@ -1,0 +1,129 @@
+# zfs-replication
+
+Runs [`syncoid`](https://github.com/jimsalterjrs/sanoid) replication jobs on
+systemd timers and reports each run to a Discord webhook — green on success,
+red with the tail of the log on failure.
+
+```
+Module      zfs-replication
+Helper      /usr/local/bin/pve-toolbox-zfs-sync
+Config      /etc/pve-toolbox/zfs-replication.conf   (0600)
+Logs        /var/log/pve-toolbox/<job>.log          (0640)
+Units       pve-toolbox-zfs-sync@<job>.{service,timer}
+```
+
+Needs `sanoid` for `syncoid`; install pulls it in.
+
+## One timer per job
+
+An hourly `appdata` sync and a nightly `media` sync are separate units with
+separate schedules and separate messages:
+
+```
+pve-toolbox-zfs-sync@appdata.timer   *-*-* 02:30:00
+pve-toolbox-zfs-sync@media.timer     Sun *-*-* 04:00:00
+```
+
+## A job
+
+```ini title="/etc/pve-toolbox/zfs-replication.conf"
+DISCORD_WEBHOOK='https://discord.com/api/webhooks/<id>/<token>'
+JOBS='appdata'
+LOG_DIR='/var/log/pve-toolbox'
+NOTIFY_START='0'
+
+JOB_APPDATA_SRC='fast-data-pool/appdata'
+JOB_APPDATA_DST='data-pool/appdata-backup'
+JOB_APPDATA_OPTS='--recursive --compress=zstd-fast'
+JOB_APPDATA_CHOWN='102105:102105'   # optional
+JOB_APPDATA_CHMOD='775'             # optional
+JOB_APPDATA_PATH=''                 # blank = the target's own mountpoint
+```
+
+Job keys are the job name uppercased with anything non-alphanumeric turned
+into `_`. Job names must match `^[A-Za-z][A-Za-z0-9_.:-]*$`, because they
+become systemd instance names.
+
+## What the report says
+
+The success embed carries duration, how much the target grew, its total size,
+and the snapshot count before and after. The failure embed carries the exit
+code and the last 25 log lines in a code block.
+
+:material-circle:{ style="color:#2ecc71" } Green
+: syncoid succeeded and any requested ownership fixup landed
+
+:material-circle:{ style="color:#f1c40f" } Yellow
+: syncoid succeeded but a requested `chown`/`chmod` was skipped
+
+:material-circle:{ style="color:#e74c3c" } Red
+: syncoid exited non-zero
+
+## Behaviour worth knowing
+
+**`flock` per job.** A run that overruns its schedule will not have a second
+copy started on top of it — the next trigger sees the lock, logs, and exits 0.
+
+**Logs are not in `/tmp`.** Each run writes `/var/log/pve-toolbox/<job>.log`
+at `0640`, keeping the previous run as `.log.prev`.
+
+**Ownership fixups are reported, not assumed.** If `chown`/`chmod` was
+requested but the target has no mountpoint, or the path is not a directory,
+the run finishes **yellow** and says so, instead of reporting a clean success.
+
+**The target path is derived.** With `JOB_*_PATH` blank the fixup applies to
+the target dataset's own `mountpoint`, so there is no hardcoded `/mnt/...` to
+go stale.
+
+!!! tip "Why the payload is built with `jq`"
+
+    A syncoid failure often contains quotes, backticks or backslashes.
+    Hand-rolled JSON — `-d "{\"content\":\"$ERROR\"}"` — either breaks the
+    request or has to strip characters out of the error you actually wanted to
+    read. Fields are passed to `jq` as separate arguments, so the message
+    arrives intact.
+
+## Env vars for `-y`
+
+| Variable | Meaning |
+| --- | --- |
+| `ZFS_REPL_WEBHOOK` | Discord webhook URL. Required. |
+| `ZFS_REPL_JOBS` | Space-separated job names |
+| `ZFS_REPL_NOTIFY_START` | Also notify when a job starts |
+| `ZFS_REPL_<JOB>_SRC` | Source dataset |
+| `ZFS_REPL_<JOB>_DST` | Target dataset |
+| `ZFS_REPL_<JOB>_OPTS` | syncoid options |
+| `ZFS_REPL_<JOB>_CHOWN` | `uid:gid` for the post-run fixup |
+| `ZFS_REPL_<JOB>_CHMOD` | mode for the post-run fixup |
+| `ZFS_REPL_<JOB>_PATH` | fixup path, blank for the mountpoint |
+| `ZFS_REPL_<JOB>_SCHEDULE` | `OnCalendar` for that job |
+
+```bash
+ZFS_REPL_WEBHOOK='https://discord.com/api/webhooks/<id>/<token>' \
+ZFS_REPL_JOBS='appdata' \
+ZFS_REPL_APPDATA_SRC='fast-data-pool/appdata' \
+ZFS_REPL_APPDATA_DST='data-pool/appdata-backup' \
+ZFS_REPL_APPDATA_CHOWN='102105:102105' \
+ZFS_REPL_APPDATA_CHMOD='775' \
+  pve-toolbox -y install zfs-replication
+```
+
+## Operating it
+
+```bash
+pve-toolbox-zfs-sync --list             # configured jobs
+pve-toolbox-zfs-sync --test appdata     # send a test message, replicate nothing
+systemctl start pve-toolbox-zfs-sync@appdata.service
+journalctl -u 'pve-toolbox-zfs-sync@*' -f
+tail -f /var/log/pve-toolbox/appdata.log
+```
+
+`pve-toolbox status zfs-replication` shows each job's source, target,
+schedule, and the outcome of its last run.
+
+## Update semantics
+
+`update` re-syncs the installed runner and the unit files with the checkout,
+offers to remove timers for jobs no longer in `JOBS`, and prompts for the
+settings of jobs that are configured but have no timer. `check` reports that
+without changing anything.

--- a/docs/modules/zfs-scrub.md
+++ b/docs/modules/zfs-scrub.md
@@ -1,0 +1,111 @@
+# zfs-scrub
+
+Scrubs every ZFS pool on its own systemd timer and reports each run to a
+Discord webhook twice: once when the scrub starts, once when it ends.
+
+```
+Module      zfs-scrub
+Helper      /usr/local/bin/pve-toolbox-zfs-scrub
+Config      /etc/pve-toolbox/zfs-scrub.conf   (0600)
+Units       pve-toolbox-zfs-scrub@<pool>.{service,timer}
+```
+
+## Why a watcher instead of a plain timer
+
+`zpool scrub` returns the moment the scrub is *queued*, not when it finishes.
+A normal oneshot unit would exit immediately and the result would be lost.
+
+Instead the unit stays active for the whole run — `TimeoutStartSec=infinity` —
+and polls `zpool status` until the scan ends, then reports what zfs recorded.
+
+!!! warning "Stopping the unit does not stop the scrub"
+
+    The scrub runs in the kernel. Stopping the unit only stops the reporting,
+    and you get a message saying exactly that rather than silence. A reboot
+    mid-scrub is the same case: zfs resumes the scrub, the watcher does not,
+    and the warning may not make it out before the network goes down.
+
+    To actually stop a scrub: `zpool scrub -s <pool>`.
+
+## One timer per pool
+
+Defaults stagger the pools a week apart, because pools usually share spindles
+and scrubbing them on the same night is how a Sunday turns into a slow Sunday:
+
+```
+pve-toolbox-zfs-scrub@rpool.timer   Sun *-*-01..07 03:00:00
+pve-toolbox-zfs-scrub@tank.timer    Sun *-*-08..14 03:00:00
+pve-toolbox-zfs-scrub@backup.timer  Sun *-*-15..21 03:00:00
+```
+
+Every schedule is a plain systemd `OnCalendar` you are asked about at install
+time, so the stagger is a default, not a rule.
+
+## What the report says
+
+| Colour                                            | When                                                                                            |
+|---------------------------------------------------|-------------------------------------------------------------------------------------------------|
+| :material-circle:{ style="color:#3498db" } Blue   | Scrub started                                                                                   |
+| :material-circle:{ style="color:#2ecc71" } Green  | Finished, nothing repaired, no errors                                                           |
+| :material-circle:{ style="color:#f1c40f" } Yellow | Repaired something, pool not `ONLINE`, or scrub canceled or paused                              |
+| :material-circle:{ style="color:#e74c3c" } Red    | Scan reported errors, `zpool status -v` knows about damaged files, or the scrub failed to start |
+
+The result embed carries the raw `scan:` line as its description plus fields
+for health, repaired, errors, scrub time, watched time, and data errors.
+
+!!! tip "The sneaky case"
+
+    A scan line can say `0 errors` while zfs still knows about permanently
+    damaged files. The report reads `zpool status -v` separately and goes red
+    on that, which a naive `with 0 errors` check would miss.
+
+## Configuration
+
+```ini title="/etc/pve-toolbox/zfs-scrub.conf"
+DISCORD_WEBHOOK='https://discord.com/api/webhooks/<id>/<token>'
+POLL_INTERVAL=300
+NOTIFY_START=1
+```
+
+The webhook URL is the only credential Discord checks, so it goes through
+`conf_set` into a `0600` file rather than the world-readable state file.
+
+`POLL_INTERVAL` is clamped to a minimum of 10 seconds.
+
+## Env vars for `-y`
+
+| Variable                    | Default   | Meaning                           |
+|-----------------------------|-----------|-----------------------------------|
+| `ZFS_SCRUB_WEBHOOK`         | —         | Discord webhook URL. Required.    |
+| `ZFS_SCRUB_POOLS`           | all pools | Space-separated pools to schedule |
+| `ZFS_SCRUB_INTERVAL`        | `300`     | Seconds between completion checks |
+| `ZFS_SCRUB_NOTIFY_START`    | `y`       | Also notify when a scrub starts   |
+| `ZFS_SCRUB_SCHEDULE_<POOL>` | staggered | `OnCalendar` for that pool        |
+
+`<POOL>` is the pool name uppercased with anything non-alphanumeric turned
+into `_`, so `tank-ssd` reads `ZFS_SCRUB_SCHEDULE_TANK_SSD`.
+
+## Conflicting timers
+
+`zfsutils-linux` ships its own `zfs-scrub-monthly@<pool>.timer`. Install
+detects an enabled one and offers to disable it, so a pool is not scrubbed on
+two schedules. The package files are never deleted, only disabled.
+
+## Operating it
+
+```bash
+pve-toolbox-zfs-scrub --test tank      # send a test message, scrub nothing
+systemctl list-timers 'pve-toolbox-zfs-scrub@*'
+systemctl start pve-toolbox-zfs-scrub@tank.service   # scrub now
+journalctl -u 'pve-toolbox-zfs-scrub@*' -f
+```
+
+A second run while a scrub is already in progress leaves the running one
+alone and exits 0.
+
+## Update semantics
+
+There is no upstream release to track. `update` re-syncs the installed watcher
+and the unit files with the checkout, removes timers for pools that no longer
+exist, and offers to schedule pools created since the last run. `check`
+reports all of that without changing anything.

--- a/docs/reference/common.md
+++ b/docs/reference/common.md
@@ -1,0 +1,114 @@
+# lib/common.sh
+
+Sourced by the launcher and by every module. Defines no side effects beyond
+variables and functions, so it is safe to source when only module metadata is
+wanted.
+
+## Paths
+
+Every path is overridable, which is what makes modules testable off a real
+host:
+
+| Variable | Default |
+| --- | --- |
+| `TOOLBOX_BIN_DIR` | `/usr/local/bin` |
+| `TOOLBOX_LIB_DIR` | `/usr/local/lib/pve-toolbox` |
+| `TOOLBOX_CONF_DIR` | `/etc/pve-toolbox` |
+| `TOOLBOX_STATE_DIR` | `/var/lib/pve-toolbox` |
+| `TOOLBOX_SYSTEMD_DIR` | `/etc/systemd/system` |
+
+## Output
+
+`info` `ok` `warn` `die` `step` `dim`
+: Coloured when stdout is a tty, plain otherwise. `die` writes to stderr and
+  exits 1.
+
+## Prompts
+
+`ask <var> <prompt> <default>`
+: Reads into `<var>`. If `<var>` is already set its value becomes the default,
+  which is how env vars override prompts.
+
+`ask_yn <var> <prompt> <y|n>`
+: Loops until it gets a yes or no.
+
+`ask_secret <var> <prompt>`
+: No echo. Skipped entirely if `<var>` is already set.
+
+`confirm <prompt> [y|n]`
+: Exit status, for use in `if`.
+
+!!! note "`-y` mode"
+
+    With `ASSUME_YES=1` every prompt returns its default without reading. A
+    module that requires a value must check for it and `die` rather than
+    looping forever on an empty default.
+
+## Preflight
+
+`require_root`
+: Exits unless `EUID` is 0.
+
+`require_pve`
+: Reports the PVE version, warns and asks to continue if `pveversion` is
+  missing or if it detects an LXC.
+
+`in_lxc` · `have_zfs` · `have_mdadm`
+: Exit status only.
+
+`detect_arch`
+: Prints `amd64`, `arm64` or `arm-7`; dies on anything else.
+
+`pkg_ensure <command:package>...`
+: Installs only the packages whose command is missing.
+
+## State and config
+
+See [State versus config](../writing-a-module.md#state-versus-config).
+
+`state_get` `state_set` `state_clear` `state_exists`
+: `0644`, `KEY=value`.
+
+`conf_file` `conf_get` `conf_set` `conf_load` `conf_clear` `conf_exists`
+: `0600`, `KEY='value'`, sourceable. `conf_load` sources every key into the
+  caller.
+
+## GitHub releases
+
+`gh_release <repo> <tag|latest>`
+: Sets `GH_JSON` and `GH_TAG`.
+
+`gh_fetch_checksums`
+: Sets `CHECKSUM_FILE`, empty when the release ships none.
+
+`install_release_binary <asset-fragment> <arch-fragment> <target>`
+: Downloads, verifies the checksum when there is one, keeps the old build as
+  `<target>.prev`. Returns 1 when no asset matches.
+
+`rollback_binary <target>`
+: Restores `<target>.prev`.
+
+`is_newer <candidate> <current>`
+: Version sort, so a downgrade can be caught and confirmed.
+
+## systemd
+
+`systemd_oneshot <unit> <description> <exec> <OnCalendar>`
+: Writes a niced oneshot service plus timer and enables it.
+
+    !!! warning
+        Sets `TimeoutStartSec=900`. Work that can run longer — a scrub, a
+        replication — needs its own unit file.
+
+`systemd_remove <unit>` · `wait_for_idle <unit> [timeout]` · `run_unit <unit>`
+: `run_unit` dumps the last 20 journal lines on failure. It blocks, so do not
+  use it for long-running units — `systemctl start --no-block` instead.
+
+## Misc
+
+`backup_file <path>`
+: Copies to `<path>.bak.<timestamp>` before you overwrite it.
+
+`install_toolbox_lib <name>...`
+: Copies `lib/<name>` into `TOOLBOX_LIB_DIR` at `0644`, so an installed helper
+  script can source it.

--- a/docs/reference/discord.md
+++ b/docs/reference/discord.md
@@ -1,0 +1,106 @@
+# lib/discord.sh
+
+Webhook reporting, shared by modules and by the helper scripts they install.
+
+Deliberately standalone: it needs only `curl` and `jq`, and pulls in nothing
+else from the toolbox. That is what lets a runner in `/usr/local/bin` use it
+without the checkout still existing.
+
+## Sourcing it
+
+Modules get it through `lib/common.sh` automatically. A standalone runner
+sources it from the installed location:
+
+```bash
+TOOLBOX_LIB="${PVE_TOOLBOX_LIB:-/usr/local/lib/pve-toolbox}"
+# shellcheck source=../../lib/discord.sh
+source "$TOOLBOX_LIB/discord.sh" 2>/dev/null \
+    || { printf 'error: cannot source %s/discord.sh\n' "$TOOLBOX_LIB" >&2; exit 1; }
+```
+
+Install it from a module with `install_toolbox_lib discord.sh` and set
+`Environment=PVE_TOOLBOX_LIB=$TOOLBOX_LIB_DIR` in the unit. It is shared, so
+`module_uninstall` should leave it in place.
+
+## discord_notify
+
+```
+discord_notify <webhook> <color> <title> <description> [name value ...]
+```
+
+Returns non-zero when nothing was delivered — no webhook configured, or the
+POST failed. That split matters:
+
+```bash
+# a --test mode should fail loudly
+discord_notify "$WEBHOOK" "$DISCORD_INFO" "Test" "..." \
+    || fail "could not deliver the test notification"
+
+# a scheduled run should not abort because Discord was down
+discord_notify "$WEBHOOK" "$DISCORD_OK" "Done" "..." || true
+```
+
+!!! warning "`set -e` and the return value"
+
+    Under `set -euo pipefail` an unguarded `discord_notify` that fails will
+    abort the script. Append `|| true` anywhere the notification is not the
+    point of the run.
+
+## Colours
+
+| Constant | Value | Use |
+| --- | --- | --- |
+| `DISCORD_INFO` | `3447003` | blue — something started |
+| `DISCORD_OK` | `3066993` | green — finished clean |
+| `DISCORD_WARN` | `15844367` | yellow — finished, but not entirely |
+| `DISCORD_ERR` | `15158332` | red — failed |
+
+## Fields
+
+Pass fields as **alternating name/value arguments**, never as one pre-joined
+string:
+
+```bash
+discord_notify "$WEBHOOK" "$DISCORD_OK" "ZFS scrub finished - tank" "$scan" \
+    Host       "$(hostname -s)" \
+    Pool       tank \
+    Repaired   0B \
+    "Scrub time" 04:12:33
+```
+
+The payload is assembled by `jq` from `$ARGS.positional`, so a value holding
+quotes, backticks, backslashes or newlines survives intact. Nothing is escaped
+by hand and nothing is stripped.
+
+An empty value renders as `-` rather than producing an invalid embed.
+
+## Other helpers
+
+`discord_payload <color> <title> <desc> [name value ...]`
+: Prints the JSON without posting it. Useful in tests.
+
+`discord_fields [name value ...]`
+: Prints just the fields array.
+
+`discord_fence <text> [room]`
+: Wraps text in a code block, keeping the **last** `room` characters
+  (default 3000) so a long log tail truncates from the top and the closing
+  fence always survives.
+
+```bash
+desc=$(printf 'syncoid exited %s:\n%s' "$rc" "$(discord_fence "$tail")")
+```
+
+## Limits
+
+Discord's own caps are applied here, so an oversized message truncates instead
+of the whole POST being rejected:
+
+| Variable | Default | Applies to |
+| --- | --- | --- |
+| `DISCORD_MAX_TITLE` | 250 | embed title |
+| `DISCORD_MAX_DESC` | 3800 | embed description |
+| `DISCORD_MAX_FIELD` | 1000 | each field value |
+
+`DISCORD_FOOTER` defaults to `pve-toolbox on <short hostname>` and can be set
+before calling.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+mkdocs-material==9.5.44

--- a/docs/writing-a-module.md
+++ b/docs/writing-a-module.md
@@ -1,0 +1,140 @@
+# Writing a module
+
+```bash
+cp -r modules/_template modules/my-thing
+$EDITOR modules/my-thing/module.sh
+```
+
+Set the metadata and implement the four required functions. `MODULE_NAME` must
+match the directory name.
+
+## Metadata
+
+```bash
+MODULE_NAME="my-thing"       # must equal the directory name
+MODULE_TITLE="My thing"      # short name for the menu
+MODULE_DESC="one line"       # shown by `pve-toolbox list`
+MODULE_TAGS="storage notify" # space separated, filters `list <tag>`
+MODULE_HOST_ONLY=1           # 1 if it must run on the host, not an LXC
+```
+
+The launcher reads these through indirect expansion in `meta()`, which is why
+each module carries a `# shellcheck disable=SC2034` above the block.
+
+## Functions
+
+| Function | Contract |
+| --- | --- |
+| `module_install` | Interactive install or reconfigure |
+| `module_update` | `[--check]` update in place; honours `$FORCE` |
+| `module_status` | Print one short line; exit 1 when not installed |
+| `module_status_long` | Detailed status. Optional, falls back to `module_status` |
+| `module_uninstall` | Remove what install created |
+
+`module_status` is called for every module on every menu draw, so keep it
+cheap and make its first word meaningful — the menu shows only that word in
+the `STATUS` column.
+
+## Two rules
+
+!!! danger "Keep the file side-effect free at source time"
+
+    The launcher sources **every** module just to read its metadata for the
+    menu. Definitions only at top level: no work, no prompts, no `mkdir`.
+    Compute paths lazily inside a function instead:
+
+    ```bash
+    _my_dir() { printf '%s/modules/%s' "${TOOLBOX_ROOT:-/opt/pve-toolbox}" "$MODULE_NAME"; }
+    ```
+
+!!! danger "Persist through the helpers, not ad-hoc dotfiles"
+
+    `state_set`/`state_get` and `conf_set`/`conf_get` are what `status` and
+    `check` read back.
+
+## State versus config
+
+| | State | Config |
+| --- | --- | --- |
+| Path | `/var/lib/pve-toolbox/<module>.state` | `/etc/pve-toolbox/<module>.conf` |
+| Mode | `0644` | `0600` |
+| Holds | what the module knows | what the operator set |
+| Format | `KEY=value` | `KEY='value'`, sourceable |
+| API | `state_get` `state_set` `state_clear` `state_exists` | `conf_get` `conf_set` `conf_load` `conf_clear` `conf_exists` `conf_file` |
+
+Anything secret — a token, a webhook URL, a password — belongs in config.
+
+```bash
+conf_set  "$MODULE_NAME" API_TOKEN "$token"          # 0600
+state_set "$MODULE_NAME" INSTALLED_AT "$(date -Is)"  # 0644
+```
+
+Config values are single-quoted with `'\''` escaping, so any value round-trips
+and the file stays sourceable by a plain script:
+
+```bash
+source /etc/pve-toolbox/my-thing.conf
+echo "$API_TOKEN"
+```
+
+## Long-running work
+
+A module that installs a helper script should put it in the module directory
+and install it into `TOOLBOX_BIN_DIR`, so the systemd unit does not depend on
+the checkout staying where it is:
+
+```bash
+install -m 0755 "$(_my_dir)/my-runner.sh" "$TOOLBOX_BIN_DIR/my-runner"
+install_toolbox_lib discord.sh
+```
+
+Point the unit at both:
+
+```ini
+[Service]
+Type=oneshot
+Environment=MY_CONF=/etc/pve-toolbox/my-thing.conf
+Environment=PVE_TOOLBOX_LIB=/usr/local/lib/pve-toolbox
+ExecStart=/usr/local/bin/my-runner %i
+TimeoutStartSec=infinity
+```
+
+`systemd_oneshot` in `lib/common.sh` writes a service and timer pair for the
+simple case, but it sets `TimeoutStartSec=900`. Work that can outlast that —
+a scrub, a replication — needs its own unit file.
+
+!!! warning "`systemctl start` on a long oneshot blocks"
+
+    Use `systemctl start --no-block` from a module, or the launcher sits there
+    for hours.
+
+## Isolation
+
+Modules run in a subshell, so their globals cannot leak into the launcher or
+into each other. Prefix module-level variables and helpers anyway — `ZS_`,
+`_zs_` for `zfs-scrub` — because `lib/common.sh` and the launcher share the
+same shell.
+
+## What you get for free
+
+Everything in `lib/common.sh` is already sourced:
+
+`info` `ok` `warn` `die` `step` `dim` · `ask` `ask_yn` `ask_secret` `confirm` ·
+`require_root` `require_pve` `in_lxc` · `detect_arch` `pkg_ensure` `have_zfs`
+`have_mdadm` · `gh_release` `install_release_binary` `rollback_binary`
+`is_newer` · `state_*` `conf_*` · `systemd_oneshot` `systemd_remove`
+`wait_for_idle` `run_unit` · `backup_file` `install_toolbox_lib` ·
+[`discord_notify`](reference/discord.md)
+
+See the [`lib/common.sh` reference](reference/common.md).
+
+## Checks
+
+```bash
+make syntax
+make lint
+make test
+```
+
+`make lint` runs `shellcheck -x -S warning` over the launcher, `lib/*.sh` and
+every `modules/*/*.sh`, so a helper script is linted too.

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,0 +1,412 @@
+# shellcheck shell=bash
+#
+# lib/common.sh - shared helpers for pve-toolbox modules.
+#
+# Sourced by bin/pve-toolbox and by every module. Defines no side effects
+# beyond variable and function definitions, so it is safe to source when
+# only module metadata is wanted.
+#
+[[ -n ${_TOOLBOX_COMMON_LOADED:-} ]] && return 0
+_TOOLBOX_COMMON_LOADED=1
+
+TOOLBOX_BIN_DIR="${TOOLBOX_BIN_DIR:-/usr/local/bin}"
+TOOLBOX_STATE_DIR="${TOOLBOX_STATE_DIR:-/var/lib/pve-toolbox}"
+TOOLBOX_SYSTEMD_DIR="${TOOLBOX_SYSTEMD_DIR:-/etc/systemd/system}"
+TOOLBOX_CONF_DIR="${TOOLBOX_CONF_DIR:-/etc/pve-toolbox}"
+TOOLBOX_LIB_DIR="${TOOLBOX_LIB_DIR:-/usr/local/lib/pve-toolbox}"
+ASSUME_YES="${ASSUME_YES:-0}"
+
+# Reporting helpers, also installed into TOOLBOX_LIB_DIR for the standalone
+# runners that modules drop into TOOLBOX_BIN_DIR.
+# shellcheck source=lib/discord.sh
+source "${BASH_SOURCE[0]%/*}/discord.sh"
+
+# ---------------------------------------------------------------- output --
+
+if [[ -t 1 ]]; then
+    c_reset=$'\e[0m'; c_bold=$'\e[1m'; c_dim=$'\e[2m'
+    c_red=$'\e[31m'; c_green=$'\e[32m'; c_yellow=$'\e[33m'; c_blue=$'\e[34m'
+else
+    c_reset=""; c_bold=""; c_dim=""
+    c_red=""; c_green=""; c_yellow=""; c_blue=""
+fi
+
+info() { printf '%s==>%s %s\n' "$c_blue$c_bold" "$c_reset" "$*"; }
+ok()   { printf '%s  ok%s %s\n' "$c_green" "$c_reset" "$*"; }
+warn() { printf '%s  !!%s %s\n' "$c_yellow" "$c_reset" "$*"; }
+die()  { printf '%s error:%s %s\n' "$c_red$c_bold" "$c_reset" "$*" >&2; exit 1; }
+step() { printf '\n%s%s%s\n' "$c_bold" "$*" "$c_reset"; }
+dim()  { printf '%s%s%s\n' "$c_dim" "$*" "$c_reset"; }
+
+# ----------------------------------------------------------------- input --
+
+# ask <varname> <prompt> <default>
+ask() {
+    local __var=$1 __prompt=$2 __default=$3 __reply
+    if [[ -n ${!__var:-} ]]; then __default=${!__var}; fi
+    if [[ $ASSUME_YES -eq 1 ]]; then
+        printf -v "$__var" '%s' "$__default"
+        return 0
+    fi
+    read -r -p "$(printf '%s [%s]: ' "$__prompt" "$c_dim$__default$c_reset")" __reply || true
+    printf -v "$__var" '%s' "${__reply:-$__default}"
+}
+
+# ask_secret <varname> <prompt>
+ask_secret() {
+    local __var=$1 __prompt=$2 __reply
+    if [[ $ASSUME_YES -eq 1 || -n ${!__var:-} ]]; then return 0; fi
+    read -r -s -p "$(printf '%s: ' "$__prompt")" __reply || true
+    echo
+    printf -v "$__var" '%s' "$__reply"
+}
+
+# ask_yn <varname> <prompt> <y|n>
+ask_yn() {
+    local __var=$1 __prompt=$2 __default=$3 __reply
+    if [[ -n ${!__var:-} ]]; then __default=${!__var}; fi
+    if [[ $ASSUME_YES -eq 1 ]]; then
+        printf -v "$__var" '%s' "$__default"
+        return 0
+    fi
+    while true; do
+        read -r -p "$(printf '%s (y/n) [%s]: ' "$__prompt" "$c_dim$__default$c_reset")" __reply || true
+        __reply=${__reply:-$__default}
+        case ${__reply,,} in
+            y|yes) printf -v "$__var" 'y'; return 0 ;;
+            n|no)  printf -v "$__var" 'n'; return 0 ;;
+            *) warn "please answer y or n" ;;
+        esac
+    done
+}
+
+confirm() { # confirm <prompt> <default y|n> -> exit status
+    local __r=""
+    ask_yn __r "$1" "${2:-y}"
+    [[ $__r == y ]]
+}
+
+# ------------------------------------------------------------- preflight --
+
+require_root() { [[ $EUID -eq 0 ]] || die "must run as root"; }
+
+in_lxc() {
+    [[ -f /proc/1/environ ]] && grep -qa 'container=lxc' /proc/1/environ 2>/dev/null
+}
+
+require_pve() {
+    if command -v pveversion >/dev/null 2>&1; then
+        ok "Proxmox VE: $(pveversion | head -n1)"
+    else
+        warn "pveversion not found - this does not look like a PVE host"
+        confirm "continue anyway?" "n" || exit 1
+    fi
+    if in_lxc; then
+        warn "running inside an LXC container"
+        confirm "continue anyway?" "n" || exit 1
+    fi
+}
+
+detect_arch() {
+    case "$(uname -m)" in
+        x86_64)  ARCH=amd64 ;;
+        aarch64) ARCH=arm64 ;;
+        armv7l)  ARCH=arm-7 ;;
+        *) die "unsupported architecture: $(uname -m)" ;;
+    esac
+    printf '%s' "$ARCH"
+}
+
+# pkg_ensure <command:package> ...
+pkg_ensure() {
+    local missing=() spec cmd pkg
+    for spec in "$@"; do
+        cmd=${spec%%:*}; pkg=${spec##*:}
+        command -v "$cmd" >/dev/null 2>&1 || missing+=("$pkg")
+    done
+    [[ ${#missing[@]} -eq 0 ]] && return 0
+    info "installing packages: ${missing[*]}"
+    DEBIAN_FRONTEND=noninteractive apt-get update -qq
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "${missing[@]}"
+}
+
+have_zfs()   { command -v zpool >/dev/null 2>&1; }
+have_mdadm() { [[ -f /proc/mdstat ]] && grep -qE '^md[0-9]' /proc/mdstat 2>/dev/null; }
+
+# ------------------------------------------------------------ github api --
+
+# gh_release <repo> <tag|latest> -> sets GH_JSON, GH_TAG
+gh_release() {
+    local repo=$1 tag=${2:-latest} url
+    if [[ $tag == latest ]]; then
+        url="https://api.github.com/repos/$repo/releases/latest"
+    else
+        url="https://api.github.com/repos/$repo/releases/tags/$tag"
+    fi
+    GH_JSON=$(curl -fsSL -H 'Accept: application/vnd.github+json' "$url") \
+        || die "could not fetch release metadata from $url (rate limited, or bad tag?)"
+    GH_TAG=$(jq -r '.tag_name' <<<"$GH_JSON")
+    [[ -n $GH_TAG && $GH_TAG != null ]] || die "no tag_name in release metadata"
+}
+
+# gh_asset <name-fragment> <arch-fragment> -> prints download url
+gh_asset() {
+    jq -r --arg frag "$1" --arg arch "$2" '
+        .assets[]
+        | select(.name | test($frag))
+        | select(.name | test($arch))
+        | select(.name | test("\\.(sha256|txt|sig|asc|sbom|json)$") | not)
+        | .browser_download_url
+    ' <<<"$GH_JSON" | head -n1
+}
+
+# gh_checksums -> prints url of a checksum file, empty if none
+gh_checksums() {
+    jq -r '.assets[] | select(.name | test("(?i)sha256|checksums")) | .browser_download_url' \
+        <<<"$GH_JSON" | head -n1
+}
+
+# gh_fetch_checksums -> sets CHECKSUM_FILE (may be empty)
+gh_fetch_checksums() {
+    local url
+    CHECKSUM_FILE=""
+    url=$(gh_checksums)
+    [[ -z $url ]] && { warn "release has no checksum file"; return 0; }
+    CHECKSUM_FILE=$(mktemp)
+    curl -fsSL -o "$CHECKSUM_FILE" "$url" || CHECKSUM_FILE=""
+}
+
+verify_checksum() { # verify_checksum <file> <asset-name>
+    [[ -n ${CHECKSUM_FILE:-} && -s ${CHECKSUM_FILE:-} ]] || return 0
+    local expected actual
+    expected=$(awk -v n="$2" 'index($2, n) || index($2, "*"n) {print $1}' "$CHECKSUM_FILE" | head -n1)
+    [[ -z $expected ]] && { warn "no checksum entry for $2"; return 0; }
+    actual=$(sha256sum "$1" | awk '{print $1}')
+    [[ $expected == "$actual" ]] || return 1
+    ok "checksum verified"
+}
+
+# install_release_binary <asset-fragment> <arch-fragment> <target-name>
+# Keeps the previous build as <target>.prev for rollback. Returns 1 if no asset.
+install_release_binary() {
+    local frag=$1 arch=$2 target=$3 url tmp name
+    url=$(gh_asset "$frag" "$arch")
+    if [[ -z $url ]]; then
+        warn "no asset matching '$frag' for $arch in $GH_TAG"
+        return 1
+    fi
+    name=$(basename "$url")
+    tmp=$(mktemp)
+    info "downloading $name"
+    curl -fsSL --retry 3 -o "$tmp" "$url" || { rm -f "$tmp"; die "download failed: $url"; }
+    if ! verify_checksum "$tmp" "$name"; then
+        rm -f "$tmp"; die "checksum mismatch for $name"
+    fi
+    [[ -f "$TOOLBOX_BIN_DIR/$target" ]] && cp -a "$TOOLBOX_BIN_DIR/$target" "$TOOLBOX_BIN_DIR/$target.prev"
+    install -m 0755 "$tmp" "$TOOLBOX_BIN_DIR/$target"
+    rm -f "$tmp"
+    ok "installed $TOOLBOX_BIN_DIR/$target"
+}
+
+rollback_binary() { # rollback_binary <target-name>
+    local bin="$TOOLBOX_BIN_DIR/$1"
+    [[ -f "$bin.prev" ]] || { warn "no previous build for $1"; return 1; }
+    mv -f "$bin.prev" "$bin"
+    warn "rolled back $1"
+}
+
+# is_newer <candidate> <current> -> 0 if candidate sorts strictly above current
+is_newer() {
+    [[ $1 == "$2" ]] && return 1
+    [[ -z $2 || $2 == unknown ]] && return 0
+    local top
+    top=$(printf '%s\n%s\n' "${1#v}" "${2#v}" | sort -V | tail -n1)
+    [[ $top == "${1#v}" ]]
+}
+
+# ------------------------------------------------------------------ state --
+
+_state_file() { printf '%s/%s.state' "$TOOLBOX_STATE_DIR" "$1"; }
+
+state_set() { # state_set <module> <key> <value>
+    local f; f=$(_state_file "$1")
+    mkdir -p "$TOOLBOX_STATE_DIR"
+    touch "$f"; chmod 0644 "$f"
+    if grep -q "^$2=" "$f" 2>/dev/null; then
+        sed -i "s|^$2=.*|$2=$3|" "$f"
+    else
+        printf '%s=%s\n' "$2" "$3" >> "$f"
+    fi
+}
+
+state_get() { # state_get <module> <key>
+    local f; f=$(_state_file "$1")
+    [[ -f $f ]] || return 0
+    awk -F= -v k="$2" '$1 == k { sub(/^[^=]*=/, ""); print; exit }' "$f"
+}
+
+state_clear() { rm -f "$(_state_file "$1")"; }
+state_exists() { [[ -f $(_state_file "$1") ]]; }
+
+# ------------------------------------------------------------------- conf --
+#
+# State is what a module knows; conf is what an operator set. State lives in
+# TOOLBOX_STATE_DIR at 0644 and is safe to print; conf lives in
+# TOOLBOX_CONF_DIR at 0600 because it is where tokens, webhook URLs and
+# passwords go. Conf files are plain KEY='value' and stay sourceable, so a
+# helper script installed into TOOLBOX_BIN_DIR can read one directly without
+# pulling in this library.
+
+conf_file() { printf '%s/%s.conf' "$TOOLBOX_CONF_DIR" "$1"; }
+
+# Single-quote for the shell, turning any embedded quote into '\'' .
+_conf_quote() {
+    local v=$1
+    v=${v//\'/\'\\\'\'}
+    printf "'%s'" "$v"
+}
+
+conf_set() { # conf_set <module> <key> <value>
+    local f tmp q
+    f=$(conf_file "$1")
+    mkdir -p "$TOOLBOX_CONF_DIR"
+    chmod 0750 "$TOOLBOX_CONF_DIR"
+    if [[ ! -f $f ]]; then
+        ( umask 077; printf '# managed by pve-toolbox / %s\n' "$1" > "$f" )
+    fi
+    chmod 0600 "$f"
+    q=$(_conf_quote "$3")
+    tmp=$(mktemp)
+    # Via the environment, not -v: awk expands backslash escapes in -v values
+    # and would eat the quote escaping.
+    _CONF_V=$q awk -v k="$2" '
+        $0 ~ "^" k "=" { print k "=" ENVIRON["_CONF_V"]; found = 1; next }
+        { print }
+        END { if (!found) print k "=" ENVIRON["_CONF_V"] }
+    ' "$f" > "$tmp"
+    # Overwrite in place so the 0600 mode and the inode survive.
+    cat "$tmp" > "$f"
+    rm -f "$tmp"
+}
+
+# Read one key back by sourcing in a subshell, so the quoting round-trips.
+conf_get() { # conf_get <module> <key>
+    local f
+    f=$(conf_file "$1")
+    [[ -r $f ]] || return 0
+    (
+        set +u
+        # shellcheck source=/dev/null
+        source "$f"
+        printf '%s' "${!2}"
+    )
+}
+
+# Pull every key into the caller, for a module reconfiguring itself.
+conf_load() { # conf_load <module>
+    local f
+    f=$(conf_file "$1")
+    [[ -r $f ]] || return 1
+    # shellcheck source=/dev/null
+    source "$f"
+}
+
+conf_clear() { rm -f "$(conf_file "$1")"; }
+conf_exists() { [[ -f $(conf_file "$1") ]]; }
+
+# ---------------------------------------------------------------- systemd --
+
+# systemd_oneshot <unit> <description> <exec> <OnCalendar>
+# Writes a oneshot service plus a timer, both niced down, and enables the timer.
+systemd_oneshot() {
+    local unit=$1 desc=$2 exec=$3 schedule=$4
+
+    cat > "$TOOLBOX_SYSTEMD_DIR/$unit.service" <<EOF
+[Unit]
+Description=$desc
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=$exec
+Nice=10
+IOSchedulingClass=idle
+TimeoutStartSec=900
+StandardOutput=journal
+StandardError=journal
+EOF
+
+    cat > "$TOOLBOX_SYSTEMD_DIR/$unit.timer" <<EOF
+[Unit]
+Description=$desc (timer)
+
+[Timer]
+OnCalendar=$schedule
+RandomizedDelaySec=120
+Persistent=true
+Unit=$unit.service
+
+[Install]
+WantedBy=timers.target
+EOF
+
+    systemctl daemon-reload
+    systemctl enable --now "$unit.timer" >/dev/null 2>&1
+    ok "enabled $unit.timer  ($schedule)"
+}
+
+systemd_remove() { # systemd_remove <unit>
+    if systemctl list-unit-files 2>/dev/null | grep -q "^$1.timer"; then
+        systemctl disable --now "$1.timer" >/dev/null 2>&1 || true
+    fi
+    rm -f "$TOOLBOX_SYSTEMD_DIR/$1.service" "$TOOLBOX_SYSTEMD_DIR/$1.timer"
+    systemctl daemon-reload
+}
+
+wait_for_idle() { # wait_for_idle <unit> [timeout]
+    local unit=$1 limit=${2:-120} waited=0
+    while systemctl is-active --quiet "$unit.service"; do
+        [[ $waited -eq 0 ]] && info "$unit is running, waiting for it to finish..."
+        sleep 5; waited=$((waited + 5))
+        if [[ $waited -ge $limit ]]; then
+            warn "$unit still running after ${limit}s - stopping it"
+            systemctl stop "$unit.service" || true
+            break
+        fi
+    done
+}
+
+run_unit() { # run_unit <unit> -> 0 on success, dumps journal on failure
+    if systemctl start "$1.service"; then
+        ok "$1 completed"
+        return 0
+    fi
+    warn "$1 failed"
+    journalctl -u "$1.service" -n 20 --no-pager || true
+    return 1
+}
+
+# ------------------------------------------------------------------ misc --
+
+# install_toolbox_lib <name>... - put a lib/*.sh next to the installed helper
+# scripts, so a runner in TOOLBOX_BIN_DIR can source it without needing this
+# checkout to still be around.
+install_toolbox_lib() {
+    local src n
+    mkdir -p "$TOOLBOX_LIB_DIR"
+    for n in "$@"; do
+        src="${BASH_SOURCE[0]%/*}/$n"
+        [[ -f $src ]] || die "missing shared lib: $src"
+        install -m 0644 "$src" "$TOOLBOX_LIB_DIR/$n"
+        ok "installed $TOOLBOX_LIB_DIR/$n"
+    done
+}
+
+backup_file() {
+    [[ -f $1 ]] || return 0
+    local bak
+    bak="$1.bak.$(date +%Y%m%d%H%M%S)"
+    cp -a "$1" "$bak"
+    warn "backed up existing $(basename "$1") -> $(basename "$bak")"
+}

--- a/lib/discord.sh
+++ b/lib/discord.sh
@@ -1,0 +1,97 @@
+# shellcheck shell=bash
+#
+# lib/discord.sh - Discord webhook reporting, shared by modules and by the
+# helper scripts they install.
+#
+# Deliberately standalone: lib/common.sh sources it for modules, and a runner
+# dropped into TOOLBOX_BIN_DIR sources it straight from TOOLBOX_LIB_DIR
+# without pulling in the rest of the toolbox. Needs only curl and jq.
+#
+#   discord_notify <webhook> <color> <title> <description> [name value ...]
+#
+# Returns 1 if nothing was delivered, so a caller that cares (a --test mode)
+# can fail loudly while a caller that does not can ignore it.
+#
+[[ -n ${_TOOLBOX_DISCORD_LOADED:-} ]] && return 0
+_TOOLBOX_DISCORD_LOADED=1
+
+# Callers pick one of these; shellcheck cannot see across the source boundary.
+# shellcheck disable=SC2034
+{
+    DISCORD_INFO=3447003      # blue
+    DISCORD_OK=3066993        # green
+    DISCORD_WARN=15844367     # yellow
+    DISCORD_ERR=15158332      # red
+}
+
+# Shown under every embed. Override before calling if a module wants its own.
+DISCORD_FOOTER="${DISCORD_FOOTER:-pve-toolbox on $(hostname -s 2>/dev/null || hostname)}"
+
+# Discord's own limits, applied here so a long log tail truncates instead of
+# getting the whole POST rejected.
+DISCORD_MAX_TITLE=250
+DISCORD_MAX_DESC=3800
+DISCORD_MAX_FIELD=1000
+
+discord_log() { printf '%s\n' "$*"; }
+
+# discord_fields [name value ...] -> compact JSON array
+# Pairs are separate arguments, so a value may contain quotes, backticks,
+# backslashes or newlines without any escaping of our own.
+discord_fields() {
+    jq -n -c --argjson max "$DISCORD_MAX_FIELD" '
+        [ range(0; ($ARGS.positional | length); 2)
+          | { name:   ($ARGS.positional[.] // "-"),
+              value:  (($ARGS.positional[. + 1] // "") as $v
+                       | if $v == "" then "-" else $v[0:$max] end),
+              inline: true } ]' --args "$@"
+}
+
+# discord_payload <color> <title> <description> [name value ...] -> JSON
+discord_payload() {
+    local color=$1 title=$2 desc=$3
+    shift 3
+    local fields
+    fields=$(discord_fields "$@")
+    jq -n -c \
+        --arg title "$title" \
+        --arg desc "$desc" \
+        --arg footer "$DISCORD_FOOTER" \
+        --argjson color "$color" \
+        --argjson fields "$fields" \
+        --argjson maxt "$DISCORD_MAX_TITLE" \
+        --argjson maxd "$DISCORD_MAX_DESC" \
+        '{ embeds: [ { title:       $title[0:$maxt],
+                       description: $desc[0:$maxd],
+                       color:       $color,
+                       fields:      $fields,
+                       footer:      { text: $footer } } ] }'
+}
+
+# discord_notify <webhook> <color> <title> <description> [name value ...]
+discord_notify() {
+    local webhook=$1 color=$2 title=$3 desc=$4
+    shift 4
+    if [[ -z $webhook ]]; then
+        discord_log "no Discord webhook configured - not sending: $title"
+        return 1
+    fi
+    local payload
+    payload=$(discord_payload "$color" "$title" "$desc" "$@")
+    if curl -sS -f -m 20 --retry 3 --retry-connrefused \
+            -H 'Content-Type: application/json' \
+            -X POST -d "$payload" "$webhook" >/dev/null 2>&1; then
+        discord_log "notified: $title"
+        return 0
+    fi
+    discord_log "warning: POST to the Discord webhook failed ($title)"
+    return 1
+}
+
+# discord_fence <text> -> text wrapped in a code block, trimmed to fit a
+# description alongside whatever preamble the caller adds.
+discord_fence() {
+    local t=$1 room=${2:-3000}
+    [[ ${#t} -gt $room ]] && t=${t: -room}
+    printf '```\n%s\n```' "$t"
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,72 @@
+site_name: pve-toolbox
+site_description: Custom Proxmox VE host scripts behind one interactive launcher
+site_url: https://quwisky.github.io/pve-toolbox/
+repo_url: https://github.com/quwisky/pve-toolbox
+repo_name: quwisky/pve-toolbox
+edit_uri: edit/main/docs/
+copyright: MIT licensed
+
+theme:
+  name: material
+  icon:
+    repo: fontawesome/brands/github
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  features:
+    - navigation.tracking
+    - navigation.sections
+    - navigation.top
+    - navigation.footer
+    - content.code.copy
+    - content.action.edit
+    - search.suggest
+    - search.highlight
+    - toc.follow
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+
+plugins:
+  - search
+
+nav:
+  - Home: index.md
+  - Getting started: getting-started.md
+  - Modules:
+      - Overview: modules/index.md
+      - zfs-scrub: modules/zfs-scrub.md
+      - zfs-replication: modules/zfs-replication.md
+      - scrutiny-collectors: modules/scrutiny-collectors.md
+  - Writing a module: writing-a-module.md
+  - Reference:
+      - lib/common.sh: reference/common.md
+      - lib/discord.sh: reference/discord.md

--- a/modules/_template/module.sh
+++ b/modules/_template/module.sh
@@ -1,0 +1,75 @@
+# shellcheck shell=bash
+#
+# Template module. Copy the directory, rename it, edit the metadata, fill
+# in the four functions. Directories starting with _ are skipped by the
+# launcher, so this file is never offered in the menu.
+#
+# Contract
+# --------
+#   Metadata (evaluated at source time - keep this file side-effect free):
+#     MODULE_NAME       machine name, must equal the directory name
+#     MODULE_TITLE      short human name for the menu
+#     MODULE_DESC       one line describing what it does
+#     MODULE_TAGS       space separated, used by `pve-toolbox list <tag>`
+#     MODULE_HOST_ONLY  1 if it must run on the PVE host rather than an LXC
+#
+#   Functions:
+#     module_install      interactive install / reconfigure
+#     module_update       [--check] update in place; honours $FORCE
+#     module_status       one line for the menu; exit 1 if not installed
+#     module_status_long  detailed status (optional, falls back to status)
+#     module_uninstall    remove what install created
+#
+# Everything in lib/common.sh is already sourced: info/ok/warn/die/step,
+# ask/ask_yn/ask_secret/confirm, require_root/require_pve, detect_arch,
+# pkg_ensure, gh_release/install_release_binary/rollback_binary,
+# state_get/state_set, conf_get/conf_set, systemd_oneshot/systemd_remove,
+# run_unit, backup_file, discord_notify, install_toolbox_lib.
+#
+# Two places to persist things, and the difference matters:
+#   state_set  /var/lib/pve-toolbox/<module>.state  0644, what the module knows
+#   conf_set   /etc/pve-toolbox/<module>.conf       0600, what the operator set
+# Anything secret - a token, a webhook URL, a password - belongs in conf.
+# Conf files are KEY='value' and stay sourceable, so a helper script you drop
+# into TOOLBOX_BIN_DIR can read one without this library.
+#
+# The launcher reads this metadata indirectly, in meta().
+# shellcheck disable=SC2034
+MODULE_NAME="_template"
+MODULE_TITLE="Template"
+MODULE_DESC="copy this directory to start a new module"
+MODULE_TAGS="example"
+MODULE_HOST_ONLY=0
+
+module_install() {
+    require_root
+
+    local answer=""
+    ask answer "some setting" "default-value"
+
+    # ... do the work ...
+    dim "  you picked: $answer"
+
+    conf_set  "$MODULE_NAME" SOME_TOKEN "$answer"        # 0600, secrets
+    state_set "$MODULE_NAME" INSTALLED_AT "$(date -Is)"  # 0644, facts
+    ok "installed"
+}
+
+module_update() {
+    local check_only=0
+    [[ ${1:-} == --check ]] && check_only=1
+    [[ $check_only -eq 1 ]] && { ok "nothing to check"; return 0; }
+    ok "nothing to update"
+}
+
+module_status() {
+    state_exists "$MODULE_NAME" || { printf 'not installed'; return 1; }
+    printf 'installed'
+}
+
+module_uninstall() {
+    require_root
+    conf_clear "$MODULE_NAME"
+    state_clear "$MODULE_NAME"
+    ok "removed"
+}

--- a/modules/scrutiny-collectors/module.sh
+++ b/modules/scrutiny-collectors/module.sh
@@ -1,0 +1,327 @@
+# shellcheck shell=bash
+#
+# Scrutiny collector binaries + systemd timers on a Proxmox host.
+# The Scrutiny web UI and InfluxDB are expected to run elsewhere.
+#
+# The launcher reads this metadata indirectly, in meta().
+# shellcheck disable=SC2034
+MODULE_NAME="scrutiny-collectors"
+MODULE_TITLE="Scrutiny collectors"
+MODULE_DESC="SMART / ZFS / MDADM collectors reporting to a remote Scrutiny web instance"
+MODULE_TAGS="storage monitoring smart zfs"
+MODULE_HOST_ONLY=1        # must run on the PVE host, not in an LXC
+
+REPO="Starosdev/scrutiny"
+CONFIG_DIR="/opt/scrutiny/config"
+UNIT_PREFIX="scrutiny-collector"
+
+declare -A SC_BIN=(
+    [metrics]=scrutiny-collector-metrics
+    [zfs]=scrutiny-collector-zfs
+    [mdadm]=scrutiny-collector-mdadm
+    [performance]=scrutiny-collector-performance
+)
+declare -A SC_ASSET=(
+    [metrics]='collector-metrics'
+    [zfs]='collector-zfs'
+    [mdadm]='collector-mdadm'
+    [performance]='collector-performance'
+)
+declare -A SC_CONFIG=(
+    [metrics]=collector.yaml
+    [zfs]=collector-zfs.yaml
+    [mdadm]=collector-mdadm.yaml
+    [performance]=collector-performance.yaml
+)
+declare -A SC_DESC=(
+    [metrics]="Scrutiny SMART collector"
+    [zfs]="Scrutiny ZFS pool collector"
+    [mdadm]="Scrutiny MDADM collector"
+    [performance]="Scrutiny performance collector"
+)
+SC_ORDER=(metrics zfs mdadm performance)
+
+# ------------------------------------------------------------- internals --
+
+_sc_defaults() {
+    : "${SCRUTINY_API_ENDPOINT:=}"
+    : "${SCRUTINY_API_TOKEN:=}"
+    : "${SCRUTINY_HOST_ID:=$(hostname -s)}"
+    : "${SCRUTINY_VERSION:=latest}"
+    : "${SCRUTINY_SCHEDULE_METRICS:=*-*-* 04:00:00}"
+    : "${SCRUTINY_SCHEDULE_ZFS:=*:0/15}"
+    : "${SCRUTINY_SCHEDULE_MDADM:=*:0/15}"
+    : "${SCRUTINY_SCHEDULE_PERFORMANCE:=Sun *-*-* 02:00:00}"
+}
+
+_sc_installed() {
+    SC_PRESENT=()
+    local s
+    for s in "${SC_ORDER[@]}"; do
+        if [[ -x "$TOOLBOX_BIN_DIR/${SC_BIN[$s]}" ]]; then SC_PRESENT+=("$s"); fi
+    done
+    return 0
+}
+
+_sc_version() {
+    local v
+    v=$(state_get "$MODULE_NAME" VERSION)
+    if [[ -z $v ]]; then
+        local s bin
+        for s in "${SC_ORDER[@]}"; do
+            bin="$TOOLBOX_BIN_DIR/${SC_BIN[$s]}"
+            [[ -x $bin ]] || continue
+            v=$("$bin" --version 2>/dev/null | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -n1) || true
+            [[ -n $v ]] && break
+        done
+    fi
+    printf '%s' "${v:-unknown}"
+}
+
+_sc_write_config() { # _sc_write_config <suffix>
+    local file="$CONFIG_DIR/${SC_CONFIG[$1]}"
+    backup_file "$file"
+    {
+        echo "# managed by pve-toolbox / $MODULE_NAME"
+        echo "host:"
+        echo "  id: \"$SCRUTINY_HOST_ID\""
+        echo "api:"
+        echo "  endpoint: \"$SCRUTINY_API_ENDPOINT\""
+        echo "  timeout: 60"
+        [[ -n $SCRUTINY_API_TOKEN ]] && echo "  token: \"$SCRUTINY_API_TOKEN\""
+        echo "log:"
+        echo "  level: INFO"
+        if [[ $1 == performance ]]; then
+            echo "performance:"
+            echo "  enabled: true"
+            echo "  profile: quick"
+        fi
+    } > "$file"
+    chmod 0640 "$file"
+    ok "wrote $file"
+}
+
+_sc_schedule_for() {
+    local var="SCRUTINY_SCHEDULE_${1^^}"
+    printf '%s' "${!var}"
+}
+
+# --------------------------------------------------------------- install --
+
+module_install() {
+    require_root
+    require_pve
+    _sc_defaults
+
+    local arch; arch="linux-$(detect_arch)"
+    ok "architecture: $arch"
+    pkg_ensure curl:curl jq:jq smartctl:smartmontools
+
+    step "Scrutiny web instance"
+    while [[ -z $SCRUTINY_API_ENDPOINT ]]; do
+        ask SCRUTINY_API_ENDPOINT "API endpoint of the Scrutiny web container" "http://10.0.0.10:8080"
+    done
+    SCRUTINY_API_ENDPOINT=${SCRUTINY_API_ENDPOINT%/}
+    ask_secret SCRUTINY_API_TOKEN "collector API token (blank if auth is off)"
+    ask SCRUTINY_HOST_ID "host id shown in the dashboard" "$SCRUTINY_HOST_ID"
+
+    if curl -fsS --max-time 8 "$SCRUTINY_API_ENDPOINT/api/health" >/dev/null 2>&1; then
+        ok "web API reachable"
+    else
+        warn "could not reach $SCRUTINY_API_ENDPOINT/api/health"
+        confirm "continue anyway?" "y" || return 1
+    fi
+
+    step "Which collectors?"
+    local want=() pick
+    pick=y; ask_yn pick "SMART metrics collector" "y"; [[ $pick == y ]] && want+=(metrics)
+
+    if have_zfs; then
+        ok "pools: $(zpool list -H -o name 2>/dev/null | tr '\n' ' ')"
+        pick=y; ask_yn pick "ZFS pool collector" "y"; [[ $pick == y ]] && want+=(zfs)
+    else
+        warn "no zpool binary - skipping ZFS collector"
+    fi
+
+    if have_mdadm; then
+        pick=y; ask_yn pick "MDADM collector" "y"; [[ $pick == y ]] && want+=(mdadm)
+    fi
+
+    pick=n; ask_yn pick "fio performance collector (adds real disk load)" "n"
+    [[ $pick == y ]] && want+=(performance)
+
+    [[ ${#want[@]} -eq 0 ]] && { warn "nothing selected"; return 1; }
+
+    local s var
+    for s in "${want[@]}"; do
+        var="SCRUTINY_SCHEDULE_${s^^}"
+        ask "$var" "  $s schedule (systemd OnCalendar)" "${!var}"
+    done
+    ask SCRUTINY_VERSION "release tag" "$SCRUTINY_VERSION"
+
+    step "Download"
+    gh_release "$REPO" "$SCRUTINY_VERSION"
+    ok "release: $GH_TAG"
+    gh_fetch_checksums
+    mkdir -p "$CONFIG_DIR"
+
+    local got=()
+    for s in "${want[@]}"; do
+        install_release_binary "${SC_ASSET[$s]}" "$arch" "${SC_BIN[$s]}" && got+=("$s")
+    done
+    [[ -n ${CHECKSUM_FILE:-} ]] && rm -f "$CHECKSUM_FILE"
+    [[ ${#got[@]} -eq 0 ]] && die "no matching release assets found in $GH_TAG"
+
+    step "Config and systemd units"
+    for s in "${got[@]}"; do
+        _sc_write_config "$s"
+        systemd_oneshot "$UNIT_PREFIX-$s" "${SC_DESC[$s]}" \
+            "$TOOLBOX_BIN_DIR/${SC_BIN[$s]} run --config $CONFIG_DIR/${SC_CONFIG[$s]}" \
+            "$(_sc_schedule_for "$s")"
+    done
+
+    step "Verification"
+    local run=y
+    ask_yn run "run each collector once now?" "y"
+    if [[ $run == y ]]; then
+        for s in "${got[@]}"; do
+            [[ $s == performance ]] && { warn "skipping fio test run (heavy I/O)"; continue; }
+            run_unit "$UNIT_PREFIX-$s" || true
+        done
+    fi
+
+    state_set "$MODULE_NAME" VERSION "$GH_TAG"
+    state_set "$MODULE_NAME" ARCH "$arch"
+    state_set "$MODULE_NAME" COLLECTORS "${got[*]}"
+    state_set "$MODULE_NAME" ENDPOINT "$SCRUTINY_API_ENDPOINT"
+    state_set "$MODULE_NAME" INSTALLED_AT "$(date -Is)"
+
+    step "Done - $GH_TAG"
+    dim "  systemctl list-timers '$UNIT_PREFIX-*'"
+    dim "  ZED still beats any polling interval; keep your ZED -> Discord hook."
+}
+
+# ---------------------------------------------------------------- update --
+
+# module_update [--check]
+module_update() {
+    require_root
+    local check_only=0
+    [[ ${1:-} == --check ]] && check_only=1
+
+    pkg_ensure curl:curl jq:jq
+    local arch; arch="linux-$(detect_arch)"
+    _sc_installed
+    [[ ${#SC_PRESENT[@]} -eq 0 ]] && die "no collectors installed"
+
+    local current; current=$(_sc_version)
+    gh_release "$REPO" "${SCRUTINY_VERSION:-latest}"
+
+    printf '  installed  %s (%s)\n' "$current" "${SC_PRESENT[*]}"
+    printf '  available  %s\n' "$GH_TAG"
+
+    if [[ $current == "$GH_TAG" && ${FORCE:-0} -eq 0 ]]; then
+        ok "up to date"
+        return 0
+    fi
+    if [[ $check_only -eq 1 ]]; then
+        info "update available: $current -> $GH_TAG"
+        dim "  https://github.com/$REPO/releases/tag/$GH_TAG"
+        return 0
+    fi
+    if ! is_newer "$GH_TAG" "$current" && [[ ${FORCE:-0} -eq 0 ]]; then
+        warn "$GH_TAG is not newer than $current - this would be a downgrade"
+        confirm "proceed anyway?" "n" || return 0
+    fi
+    confirm "update ${#SC_PRESENT[@]} collector(s) to $GH_TAG?" "y" || return 0
+
+    gh_fetch_checksums
+
+    step "Pausing timers"
+    local s
+    for s in "${SC_PRESENT[@]}"; do
+        systemctl stop "$UNIT_PREFIX-$s.timer" 2>/dev/null || true
+        wait_for_idle "$UNIT_PREFIX-$s"
+    done
+
+    step "Replacing binaries"
+    local updated=()
+    for s in "${SC_PRESENT[@]}"; do
+        install_release_binary "${SC_ASSET[$s]}" "$arch" "${SC_BIN[$s]}" && updated+=("$s")
+    done
+    [[ -n ${CHECKSUM_FILE:-} ]] && rm -f "$CHECKSUM_FILE"
+
+    if [[ ${#updated[@]} -eq 0 ]]; then
+        for s in "${SC_PRESENT[@]}"; do systemctl start "$UNIT_PREFIX-$s.timer" 2>/dev/null || true; done
+        die "no binaries replaced - no matching assets in $GH_TAG"
+    fi
+
+    step "Smoke test"
+    local broken=()
+    for s in "${updated[@]}"; do
+        [[ $s == performance ]] && { warn "skipping fio test run"; continue; }
+        run_unit "$UNIT_PREFIX-$s" || broken+=("$s")
+    done
+
+    if [[ ${#broken[@]} -gt 0 ]]; then
+        step "Rollback"
+        for s in "${broken[@]}"; do
+            if rollback_binary "${SC_BIN[$s]}"; then
+                run_unit "$UNIT_PREFIX-$s" >/dev/null 2>&1 \
+                    && ok "$s healthy again on the previous build" \
+                    || warn "$s still failing after rollback - check its config"
+            fi
+        done
+    fi
+
+    step "Resuming timers"
+    for s in "${SC_PRESENT[@]}"; do systemctl start "$UNIT_PREFIX-$s.timer" 2>/dev/null || true; done
+
+    if [[ ${#broken[@]} -eq 0 ]]; then
+        state_set "$MODULE_NAME" VERSION "$GH_TAG"
+        state_set "$MODULE_NAME" UPDATED_AT "$(date -Is)"
+        for s in "${updated[@]}"; do rm -f "$TOOLBOX_BIN_DIR/${SC_BIN[$s]}.prev"; done
+        step "Updated to $GH_TAG"
+    else
+        warn "state kept at $current because these rolled back: ${broken[*]}"
+    fi
+}
+
+# ---------------------------------------------------------------- status --
+
+module_status() {
+    _sc_installed
+    if [[ ${#SC_PRESENT[@]} -eq 0 ]]; then
+        printf 'not installed'
+        return 1
+    fi
+    printf '%s  [%s]' "$(_sc_version)" "${SC_PRESENT[*]}"
+}
+
+module_status_long() {
+    _sc_installed
+    if [[ ${#SC_PRESENT[@]} -eq 0 ]]; then
+        warn "not installed"
+        return 1
+    fi
+    printf '  version    %s\n' "$(_sc_version)"
+    printf '  endpoint   %s\n' "$(state_get "$MODULE_NAME" ENDPOINT)"
+    printf '  collectors %s\n' "${SC_PRESENT[*]}"
+    echo
+    systemctl list-timers "$UNIT_PREFIX-*" --no-pager 2>/dev/null || true
+}
+
+# ------------------------------------------------------------- uninstall --
+
+module_uninstall() {
+    require_root
+    _sc_installed
+    local s
+    for s in "${SC_ORDER[@]}"; do
+        systemd_remove "$UNIT_PREFIX-$s"
+        rm -f "$TOOLBOX_BIN_DIR/${SC_BIN[$s]}" "$TOOLBOX_BIN_DIR/${SC_BIN[$s]}.prev"
+    done
+    state_clear "$MODULE_NAME"
+    ok "binaries and units removed"
+    warn "config left in place: $CONFIG_DIR"
+}

--- a/modules/zfs-replication/module.sh
+++ b/modules/zfs-replication/module.sh
@@ -1,0 +1,462 @@
+# shellcheck shell=bash
+#
+# syncoid replication jobs with Discord reporting.
+#
+# One systemd timer per job, so an hourly appdata sync and a nightly media
+# sync are separate units with separate schedules and separate messages.
+#
+# The work is in pve-toolbox-zfs-sync.sh, installed as
+# $TOOLBOX_BIN_DIR/pve-toolbox-zfs-sync so the units do not depend on this
+# checkout staying where it is.
+#
+# The launcher reads this metadata indirectly, in meta().
+# shellcheck disable=SC2034
+MODULE_NAME="zfs-replication"
+MODULE_TITLE="ZFS replication + Discord"
+MODULE_DESC="syncoid jobs on a timer, Discord message with duration and size on each run"
+MODULE_TAGS="storage zfs backup replication notify"
+MODULE_HOST_ONLY=1        # needs the host's zfs, not an LXC view of it
+
+ZR_BIN="pve-toolbox-zfs-sync"
+ZR_UNIT="pve-toolbox-zfs-sync"
+ZR_LOG_DIR="/var/log/pve-toolbox"
+
+# ------------------------------------------------------------- internals --
+
+_zr_dir() { printf '%s/modules/%s' "${TOOLBOX_ROOT:-/opt/pve-toolbox}" "$MODULE_NAME"; }
+_zr_src() { printf '%s/%s.sh' "$(_zr_dir)" "$ZR_BIN"; }
+
+_zr_defaults() {
+    : "${ZFS_REPL_WEBHOOK:=}"
+    : "${ZFS_REPL_JOBS:=}"
+    : "${ZFS_REPL_NOTIFY_START:=n}"
+    : "${ZFS_REPL_OPTS:=--recursive --compress=zstd-fast}"
+    : "${ZFS_REPL_SCHEDULE:=*-*-* 02:30:00}"
+}
+
+# Job settings are stored as JOB_<NAME>_<KEY>, name uppercased with anything
+# non-alphanumeric turned into an underscore. Same rule as the runner uses.
+_zr_key() { # _zr_key <job> <KEY>
+    local n=${1//[^A-Za-z0-9]/_}
+    printf 'JOB_%s_%s' "${n^^}" "$2"
+}
+
+# Unit names carry the job name; refuse anything systemd would mangle.
+_zr_valid_job() { [[ $1 =~ ^[A-Za-z][A-Za-z0-9_.:-]*$ ]]; }
+
+_zr_configured() { # -> ZR_JOBS from conf
+    ZR_JOBS=()
+    local raw
+    raw=$(conf_get "$MODULE_NAME" JOBS)
+    [[ -n $raw ]] || return 0
+    read -r -a ZR_JOBS <<<"$raw"
+    return 0
+}
+
+_zr_scheduled() { # -> ZR_SCHEDULED from the timers on disk
+    ZR_SCHEDULED=()
+    local f b
+    for f in "$TOOLBOX_SYSTEMD_DIR/$ZR_UNIT@"*.timer; do
+        [[ -f $f ]] || continue
+        b=$(basename "$f" .timer)
+        ZR_SCHEDULED+=("${b#*@}")
+    done
+    return 0
+}
+
+_zr_schedule_of() {
+    local f="$TOOLBOX_SYSTEMD_DIR/$ZR_UNIT@$1.timer"
+    [[ -f $f ]] || { printf 'no timer'; return 0; }
+    sed -n 's/^OnCalendar=//p' "$f" | head -n1
+}
+
+_zr_sum() {
+    [[ -f $1 ]] || { printf 'none'; return 0; }
+    sha256sum "$1" | awk '{print $1}'
+}
+
+_zr_last_run() { # _zr_last_run <job> -> "ok 2026-08-21T02:41:03+0000 in 00:11:02"
+    local f="$ZR_LOG_DIR/$1.last" status when took
+    [[ -r $f ]] || { printf 'never run'; return 0; }
+    IFS='|' read -r status when took < "$f" || true
+    printf '%s at %s, took %s' "${status:-?}" "${when:-?}" "${took:-?}"
+}
+
+_zr_webhook_shown() {
+    local f url
+    f=$(conf_file "$MODULE_NAME")
+    [[ -f $f ]] || { printf 'not configured'; return 0; }
+    [[ -r $f ]] || { printf 'configured (root only)'; return 0; }
+    url=$(conf_get "$MODULE_NAME" DISCORD_WEBHOOK)
+    [[ -n $url ]] || { printf 'not configured'; return 0; }
+    printf '%s/****%s' "${url%/*}" "${url: -4}"
+}
+
+# One template service for every job; %i is the job name.
+_zr_write_service() {
+    cat > "$TOOLBOX_SYSTEMD_DIR/$ZR_UNIT@.service" <<EOF
+[Unit]
+Description=pve-toolbox ZFS replication job %i
+Documentation=man:syncoid(8)
+After=zfs.target network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+Environment=SYNC_CONF=$(conf_file "$MODULE_NAME")
+Environment=PVE_TOOLBOX_LIB=$TOOLBOX_LIB_DIR
+ExecStart=$TOOLBOX_BIN_DIR/$ZR_BIN %i
+# Replicating a large delta takes as long as it takes.
+TimeoutStartSec=infinity
+Nice=10
+IOSchedulingClass=idle
+StandardOutput=journal
+StandardError=journal
+EOF
+    ok "wrote $ZR_UNIT@.service"
+}
+
+_zr_write_timer() { # _zr_write_timer <job> <OnCalendar>
+    cat > "$TOOLBOX_SYSTEMD_DIR/$ZR_UNIT@$1.timer" <<EOF
+[Unit]
+Description=pve-toolbox ZFS replication job $1 (timer)
+
+[Timer]
+OnCalendar=$2
+RandomizedDelaySec=300
+Persistent=true
+Unit=$ZR_UNIT@$1.service
+
+[Install]
+WantedBy=timers.target
+EOF
+}
+
+_zr_enable() {
+    if systemctl enable --now "$ZR_UNIT@$1.timer" >/dev/null 2>&1; then
+        ok "enabled $ZR_UNIT@$1.timer  ($(_zr_schedule_of "$1"))"
+    else
+        warn "could not enable $ZR_UNIT@$1.timer"
+    fi
+}
+
+_zr_remove_timer() {
+    systemctl disable --now "$ZR_UNIT@$1.timer" >/dev/null 2>&1 || true
+    rm -f "$TOOLBOX_SYSTEMD_DIR/$ZR_UNIT@$1.timer"
+}
+
+# Ask for one job's settings and persist them. Returns 1 if the user backs out.
+_zr_ask_job() { # _zr_ask_job <job>
+    local job=$1 src="" dst="" opts="" own="" mode="" path="" sched=""
+    local k
+
+    k=$(_zr_key "$job" SRC);   src=$(conf_get "$MODULE_NAME" "$k")
+    k=$(_zr_key "$job" DST);   dst=$(conf_get "$MODULE_NAME" "$k")
+    k=$(_zr_key "$job" OPTS);  opts=$(conf_get "$MODULE_NAME" "$k")
+    k=$(_zr_key "$job" CHOWN); own=$(conf_get "$MODULE_NAME" "$k")
+    k=$(_zr_key "$job" CHMOD); mode=$(conf_get "$MODULE_NAME" "$k")
+    k=$(_zr_key "$job" PATH);  path=$(conf_get "$MODULE_NAME" "$k")
+
+    # Env overrides let -y drive this: ZFS_REPL_<JOB>_SRC and friends.
+    local env_prefix="ZFS_REPL_${job//[^A-Za-z0-9]/_}"
+    env_prefix=${env_prefix^^}
+    local v
+    v="${env_prefix}_SRC";   [[ -n ${!v:-} ]] && src=${!v}
+    v="${env_prefix}_DST";   [[ -n ${!v:-} ]] && dst=${!v}
+    v="${env_prefix}_OPTS";  [[ -n ${!v:-} ]] && opts=${!v}
+    v="${env_prefix}_CHOWN"; [[ -n ${!v:-} ]] && own=${!v}
+    v="${env_prefix}_CHMOD"; [[ -n ${!v:-} ]] && mode=${!v}
+    v="${env_prefix}_PATH";  [[ -n ${!v:-} ]] && path=${!v}
+    v="${env_prefix}_SCHEDULE"; sched=${!v:-$ZFS_REPL_SCHEDULE}
+
+    ask src  "  source dataset" "$src"
+    ask dst  "  target dataset" "$dst"
+    if [[ -z $src || -z $dst ]]; then
+        warn "job $job needs both a source and a target - skipped"
+        return 1
+    fi
+    ask opts "  syncoid options" "${opts:-$ZFS_REPL_OPTS}"
+
+    if have_zfs; then
+        zfs list -H -o name "$src" >/dev/null 2>&1 \
+            || warn "source $src does not exist yet"
+        zfs list -H -o name "${dst%/*}" >/dev/null 2>&1 \
+            || warn "target parent ${dst%/*} does not exist yet"
+    fi
+
+    local fix=n
+    [[ -n $own || -n $mode ]] && fix=y
+    ask_yn fix "  fix ownership on the target after each run" "$fix"
+    if [[ $fix == y ]]; then
+        ask own  "    chown (uid:gid, blank to skip)" "$own"
+        ask mode "    chmod (blank to skip)" "$mode"
+        ask path "    path (blank = the target's own mountpoint)" "$path"
+    else
+        own=""; mode=""; path=""
+    fi
+    ask sched "  schedule (systemd OnCalendar)" "$sched"
+
+    conf_set "$MODULE_NAME" "$(_zr_key "$job" SRC)"   "$src"
+    conf_set "$MODULE_NAME" "$(_zr_key "$job" DST)"   "$dst"
+    conf_set "$MODULE_NAME" "$(_zr_key "$job" OPTS)"  "$opts"
+    conf_set "$MODULE_NAME" "$(_zr_key "$job" CHOWN)" "$own"
+    conf_set "$MODULE_NAME" "$(_zr_key "$job" CHMOD)" "$mode"
+    conf_set "$MODULE_NAME" "$(_zr_key "$job" PATH)"  "$path"
+    _zr_write_timer "$job" "$sched"
+    ok "job $job: $src -> $dst  ($sched)"
+}
+
+# --------------------------------------------------------------- install --
+
+module_install() {
+    require_root
+    require_pve
+    have_zfs || die "no zfs binary - this module needs ZFS on the host"
+    _zr_defaults
+    pkg_ensure curl:curl jq:jq syncoid:sanoid
+
+    step "Discord webhook"
+    if [[ -z $ZFS_REPL_WEBHOOK && $ASSUME_YES -eq 1 ]]; then
+        die "set ZFS_REPL_WEBHOOK for a non-interactive install"
+    fi
+    if [[ -z $ZFS_REPL_WEBHOOK ]]; then
+        ZFS_REPL_WEBHOOK=$(conf_get "$MODULE_NAME" DISCORD_WEBHOOK)
+    fi
+    while [[ -z $ZFS_REPL_WEBHOOK ]]; do
+        ask ZFS_REPL_WEBHOOK "Discord webhook URL" ""
+    done
+    if [[ ! $ZFS_REPL_WEBHOOK =~ ^https://[A-Za-z0-9._~/-]+$ ]]; then
+        die "that does not look like a URL (Server Settings -> Integrations -> Webhooks)"
+    fi
+
+    step "Jobs"
+    dim "  one timer per job, so each pair syncs on its own schedule"
+    local want=() job
+    if [[ -n $ZFS_REPL_JOBS ]]; then
+        read -r -a want <<<"$ZFS_REPL_JOBS"
+    else
+        _zr_configured
+        want=("${ZR_JOBS[@]}")
+        while true; do
+            job=""
+            ask job "job name (blank when done)" ""
+            [[ -z $job ]] && break
+            if ! _zr_valid_job "$job"; then
+                warn "job names must start with a letter and hold only [A-Za-z0-9_.:-]"
+                continue
+            fi
+            [[ " ${want[*]:-} " == *" $job "* ]] || want+=("$job")
+        done
+    fi
+    [[ ${#want[@]} -eq 0 ]] && { warn "no jobs defined"; return 1; }
+
+    for job in "${want[@]}"; do
+        _zr_valid_job "$job" || die "job name '$job' cannot be used in a systemd unit name"
+    done
+
+    conf_set "$MODULE_NAME" DISCORD_WEBHOOK "$ZFS_REPL_WEBHOOK"
+    conf_set "$MODULE_NAME" LOG_DIR "$ZR_LOG_DIR"
+
+    local kept=()
+    for job in "${want[@]}"; do
+        step "Job: $job"
+        if _zr_ask_job "$job"; then kept+=("$job"); fi
+    done
+    [[ ${#kept[@]} -eq 0 ]] && { warn "no usable jobs"; return 1; }
+
+    ask_yn ZFS_REPL_NOTIFY_START "also notify when a job starts" "$ZFS_REPL_NOTIFY_START"
+    local notify_start=0
+    [[ $ZFS_REPL_NOTIFY_START == y ]] && notify_start=1
+    conf_set "$MODULE_NAME" NOTIFY_START "$notify_start"
+    conf_set "$MODULE_NAME" JOBS "${kept[*]}"
+
+    step "Install"
+    install_toolbox_lib discord.sh
+    install -m 0755 "$(_zr_src)" "$TOOLBOX_BIN_DIR/$ZR_BIN"
+    ok "installed $TOOLBOX_BIN_DIR/$ZR_BIN"
+    mkdir -p "$ZR_LOG_DIR"
+    chmod 0750 "$ZR_LOG_DIR"
+    _zr_write_service
+    systemctl daemon-reload
+    for job in "${kept[@]}"; do _zr_enable "$job"; done
+
+    step "Verification"
+    local t=y
+    ask_yn t "send a test notification to Discord now" "y"
+    if [[ $t == y ]]; then
+        if SYNC_CONF="$(conf_file "$MODULE_NAME")" PVE_TOOLBOX_LIB="$TOOLBOX_LIB_DIR" \
+           "$TOOLBOX_BIN_DIR/$ZR_BIN" --test "${kept[0]}"; then
+            ok "sent - check the channel"
+        else
+            warn "failed - fix DISCORD_WEBHOOK in $(conf_file "$MODULE_NAME") and retry"
+        fi
+    fi
+
+    local now=n
+    ask_yn now "run the jobs once right now" "n"
+    if [[ $now == y ]]; then
+        for job in "${kept[@]}"; do
+            systemctl start --no-block "$ZR_UNIT@$job.service"
+            ok "started $ZR_UNIT@$job.service (runs in the background)"
+        done
+    fi
+
+    state_set "$MODULE_NAME" JOBS "${kept[*]}"
+    state_set "$MODULE_NAME" SCRIPT_SUM "$(_zr_sum "$(_zr_src)")"
+    state_set "$MODULE_NAME" INSTALLED_AT "$(date -Is)"
+
+    step "Done - ${#kept[@]} job(s) scheduled"
+    dim "  systemctl list-timers '$ZR_UNIT@*'"
+    dim "  logs in $ZR_LOG_DIR/<job>.log, previous run kept as .log.prev"
+}
+
+# ---------------------------------------------------------------- update --
+
+# No upstream release here: an update re-syncs the installed runner and the
+# unit files with this checkout, and reports jobs whose timer went missing.
+module_update() {
+    require_root
+    local check_only=0
+    [[ ${1:-} == --check ]] && check_only=1
+
+    _zr_configured
+    _zr_scheduled
+    [[ ${#ZR_JOBS[@]} -eq 0 && ${#ZR_SCHEDULED[@]} -eq 0 ]] && die "not installed"
+
+    local src dst new cur
+    src=$(_zr_src); dst="$TOOLBOX_BIN_DIR/$ZR_BIN"
+    new=$(_zr_sum "$src"); cur=$(_zr_sum "$dst")
+
+    local missing=() stale=() j
+    for j in "${ZR_JOBS[@]}"; do
+        [[ " ${ZR_SCHEDULED[*]} " == *" $j "* ]] || missing+=("$j")
+    done
+    for j in "${ZR_SCHEDULED[@]}"; do
+        [[ " ${ZR_JOBS[*]} " == *" $j "* ]] || stale+=("$j")
+    done
+
+    local drift=0
+    [[ $new != "$cur" ]] && drift=1
+    printf '  runner     %s\n' \
+        "$([[ $drift -eq 1 ]] && printf 'differs from this checkout' || printf 'up to date')"
+    printf '  jobs       %s\n' "${ZR_JOBS[*]:-none}"
+    if [[ ${#missing[@]} -gt 0 ]]; then warn "configured but no timer: ${missing[*]}"; fi
+    if [[ ${#stale[@]} -gt 0 ]];   then warn "timer but not configured: ${stale[*]}"; fi
+
+    if [[ $drift -eq 0 && ${#missing[@]} -eq 0 && ${#stale[@]} -eq 0 && ${FORCE:-0} -eq 0 ]]; then
+        ok "up to date"
+        return 0
+    fi
+    if [[ $check_only -eq 1 ]]; then
+        info "update available: runner or job timers are out of sync"
+        return 0
+    fi
+
+    step "Runner and units"
+    install_toolbox_lib discord.sh
+    install -m 0755 "$src" "$dst"
+    ok "installed $dst"
+    _zr_write_service
+
+    if [[ ${#stale[@]} -gt 0 ]]; then
+        step "Timers with no job"
+        for j in "${stale[@]}"; do
+            local drop=y
+            ask_yn drop "  remove the timer for $j" "y"
+            if [[ $drop == y ]]; then
+                _zr_remove_timer "$j"
+                ok "removed $ZR_UNIT@$j.timer"
+            fi
+        done
+    fi
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        step "Jobs with no timer"
+        for j in "${missing[@]}"; do
+            _zr_ask_job "$j" || continue
+        done
+    fi
+
+    systemctl daemon-reload
+    _zr_scheduled
+    for j in "${ZR_SCHEDULED[@]}"; do _zr_enable "$j"; done
+
+    state_set "$MODULE_NAME" JOBS "${ZR_SCHEDULED[*]}"
+    state_set "$MODULE_NAME" SCRIPT_SUM "$new"
+    state_set "$MODULE_NAME" UPDATED_AT "$(date -Is)"
+    step "In sync - ${#ZR_SCHEDULED[@]} job(s) scheduled"
+}
+
+# ---------------------------------------------------------------- status --
+
+module_status() {
+    _zr_scheduled
+    if [[ ${#ZR_SCHEDULED[@]} -eq 0 ]]; then
+        printf 'not installed'
+        return 1
+    fi
+    local running=() j
+    for j in "${ZR_SCHEDULED[@]}"; do
+        if systemctl is-active --quiet "$ZR_UNIT@$j.service" 2>/dev/null; then
+            running+=("$j")
+        fi
+    done
+    if [[ ${#running[@]} -gt 0 ]]; then
+        printf 'syncing  [%s]' "${running[*]}"
+    else
+        printf 'jobs:%d  [%s]' "${#ZR_SCHEDULED[@]}" "${ZR_SCHEDULED[*]}"
+    fi
+}
+
+module_status_long() {
+    _zr_scheduled
+    if [[ ${#ZR_SCHEDULED[@]} -eq 0 ]]; then
+        warn "not installed"
+        return 1
+    fi
+    printf '  runner     %s\n' "$TOOLBOX_BIN_DIR/$ZR_BIN"
+    printf '  config     %s\n' "$(conf_file "$MODULE_NAME")"
+    printf '  webhook    %s\n' "$(_zr_webhook_shown)"
+    printf '  logs       %s\n' "$ZR_LOG_DIR"
+    echo
+    local j src dst
+    for j in "${ZR_SCHEDULED[@]}"; do
+        src=$(conf_get "$MODULE_NAME" "$(_zr_key "$j" SRC)")
+        dst=$(conf_get "$MODULE_NAME" "$(_zr_key "$j" DST)")
+        printf '  %-14s %s -> %s\n' "$j" "${src:-?}" "${dst:-?}"
+        printf '    %-12s %s\n' "schedule" "$(_zr_schedule_of "$j")"
+        printf '    %-12s %s\n' "last run" "$(_zr_last_run "$j")"
+    done
+    echo
+    systemctl list-timers "$ZR_UNIT@*" --no-pager 2>/dev/null || true
+}
+
+# ------------------------------------------------------------- uninstall --
+
+module_uninstall() {
+    require_root
+    _zr_scheduled
+    local j
+    for j in "${ZR_SCHEDULED[@]}"; do
+        _zr_remove_timer "$j"
+        ok "removed $ZR_UNIT@$j.timer"
+    done
+    rm -f "$TOOLBOX_SYSTEMD_DIR/$ZR_UNIT@.service"
+    systemctl daemon-reload
+    rm -f "$TOOLBOX_BIN_DIR/$ZR_BIN"
+    state_clear "$MODULE_NAME"
+    ok "runner, units and state removed"
+
+    if conf_exists "$MODULE_NAME"; then
+        local conf drop=y
+        conf=$(conf_file "$MODULE_NAME")
+        ask_yn drop "also remove $conf (holds the webhook URL and job definitions)" "y"
+        if [[ $drop == y ]]; then
+            conf_clear "$MODULE_NAME"
+            ok "removed $conf"
+        else
+            warn "config left in place: $conf"
+        fi
+    fi
+    dim "  $TOOLBOX_LIB_DIR/discord.sh is shared with other modules and stays"
+    warn "replicated data and logs are left alone: $ZR_LOG_DIR"
+}

--- a/modules/zfs-replication/pve-toolbox-zfs-sync.sh
+++ b/modules/zfs-replication/pve-toolbox-zfs-sync.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+#
+# pve-toolbox-zfs-sync - run one syncoid replication job and report to Discord.
+#
+# Installed by the pve-toolbox 'zfs-replication' module as
+# /usr/local/bin/pve-toolbox-zfs-sync and driven by one systemd timer per job:
+#
+#   pve-toolbox-zfs-sync <job>         replicate, then report success or failure
+#   pve-toolbox-zfs-sync --test <job>  send a test notification, replicate nothing
+#   pve-toolbox-zfs-sync --list        list configured jobs
+#
+# Config, written by the module, root-only because the webhook URL is the only
+# credential Discord checks. Job keys are the job name uppercased, with
+# anything non-alphanumeric turned into an underscore:
+#
+#   /etc/pve-toolbox/zfs-replication.conf
+#     DISCORD_WEBHOOK='https://discord.com/api/webhooks/<id>/<token>'
+#     JOBS='appdata'
+#     JOB_APPDATA_SRC='fast-data-pool/appdata'
+#     JOB_APPDATA_DST='data-pool/appdata-backup'
+#     JOB_APPDATA_OPTS='--recursive --compress=zstd-fast'
+#     JOB_APPDATA_CHOWN='102105:102105'   # optional, applied to the target
+#     JOB_APPDATA_CHMOD='775'             # optional
+#     JOB_APPDATA_PATH=''                 # optional, defaults to the mountpoint
+#
+set -euo pipefail
+
+CONF="${SYNC_CONF:-/etc/pve-toolbox/zfs-replication.conf}"
+
+DISCORD_WEBHOOK=""
+JOBS=""
+LOG_DIR="/var/log/pve-toolbox"
+NOTIFY_START=0
+LOG_TAIL=25
+
+# Reporting comes from the shared lib installed alongside this script.
+TOOLBOX_LIB="${PVE_TOOLBOX_LIB:-/usr/local/lib/pve-toolbox}"
+# shellcheck source=../../lib/discord.sh
+source "$TOOLBOX_LIB/discord.sh" 2>/dev/null \
+    || { printf 'error: cannot source %s/discord.sh\n' "$TOOLBOX_LIB" >&2; exit 1; }
+
+JOB=""
+HOST_SHORT=$(hostname -s 2>/dev/null || hostname)
+
+log()  { printf '%s\n' "$*"; }
+fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+usage() { sed -n '3,10p' "$0" | sed 's/^# \{0,1\}//'; }
+
+
+# ------------------------------------------------------------------- zfs --
+
+_ds_exists() { zfs list -H -o name "$1" >/dev/null 2>&1; }
+
+# Bytes used, so the report can state how much the run actually moved.
+_used_bytes() { zfs get -Hp -o value used "$1" 2>/dev/null || printf '0'; }
+_snap_count() { zfs list -H -t snapshot -r -o name "$1" 2>/dev/null | grep -c . || printf '0'; }
+
+_human() { # bytes -> 1.2G
+    numfmt --to=iec --suffix=B "${1:-0}" 2>/dev/null || printf '%sB' "${1:-0}"
+}
+
+_hms() { printf '%02d:%02d:%02d' $(($1 / 3600)) $((($1 % 3600) / 60)) $(($1 % 60)); }
+
+# ------------------------------------------------------------------ jobs --
+
+# Job settings live under JOB_<NAME>_*; resolve them into JOB_SRC, JOB_DST, ...
+_job_key() {
+    local n=${1//[^A-Za-z0-9]/_}
+    printf 'JOB_%s_%s' "${n^^}" "$2"
+}
+
+_load_job() {
+    local var
+    var=$(_job_key "$JOB" SRC);   JOB_SRC=${!var:-}
+    var=$(_job_key "$JOB" DST);   JOB_DST=${!var:-}
+    var=$(_job_key "$JOB" OPTS);  JOB_OPTS=${!var:-"--recursive"}
+    var=$(_job_key "$JOB" CHOWN); JOB_CHOWN=${!var:-}
+    var=$(_job_key "$JOB" CHMOD); JOB_CHMOD=${!var:-}
+    var=$(_job_key "$JOB" PATH);  JOB_PATH=${!var:-}
+
+    [[ -n $JOB_SRC ]] || fail "job '$JOB' has no source - is it in JOBS= in $CONF?"
+    [[ -n $JOB_DST ]] || fail "job '$JOB' has no target"
+}
+
+# Fall back to the target's own mountpoint rather than a hardcoded /mnt path.
+_target_path() {
+    if [[ -n $JOB_PATH ]]; then
+        printf '%s' "$JOB_PATH"
+        return 0
+    fi
+    local mp
+    mp=$(zfs get -H -o value mountpoint "$JOB_DST" 2>/dev/null || true)
+    [[ -n $mp && $mp != none && $mp != legacy && $mp != - ]] && printf '%s' "$mp"
+}
+
+# --------------------------------------------------------------- reports --
+
+_notify_start() {
+    discord_notify "$DISCORD_WEBHOOK" "$DISCORD_INFO" "ZFS replication started - $JOB" \
+        "Replicating *$JOB_SRC* to *$JOB_DST*." \
+        Job    "$JOB" \
+        Host   "$HOST_SHORT" \
+        Source "$JOB_SRC" \
+        Target "$JOB_DST"
+}
+
+_record() { # _record <status> <elapsed>
+    printf '%s|%s|%s\n' "$1" "$(date -Is)" "$(_hms "$2")" > "$LOG_DIR/$JOB.last"
+}
+
+# ------------------------------------------------------------------ main --
+
+main() {
+    local mode=sync
+    case ${1:-} in
+        -h|--help) usage; exit 0 ;;
+        --list)    mode=list ;;
+        --test)    mode=selftest; shift ;;
+    esac
+
+    command -v jq   >/dev/null 2>&1 || fail "jq not found"
+    command -v curl >/dev/null 2>&1 || fail "curl not found"
+
+    if [[ -r $CONF ]]; then
+        # shellcheck source=/dev/null
+        source "$CONF"
+    else
+        fail "cannot read $CONF"
+    fi
+
+    if [[ $mode == list ]]; then
+        printf '%s\n' $JOBS
+        exit 0
+    fi
+
+    JOB=${1:-}
+    [[ -n $JOB ]] || { usage >&2; exit 2; }
+    [[ " $JOBS " == *" $JOB "* ]] || fail "unknown job: $JOB (JOBS='$JOBS')"
+    _load_job
+
+    if [[ $mode == selftest ]]; then
+        discord_notify "$DISCORD_WEBHOOK" "$DISCORD_INFO" "pve-toolbox test notification" \
+            "Replication reports for *$JOB* on *$HOST_SHORT* will arrive in this channel." \
+            Job    "$JOB" \
+            Host   "$HOST_SHORT" \
+            Source "$JOB_SRC" \
+            Target "$JOB_DST" \
+            || fail "could not deliver the test notification - check DISCORD_WEBHOOK in $CONF"
+        exit 0
+    fi
+
+    command -v syncoid >/dev/null 2>&1 || fail "syncoid not found - apt install sanoid"
+    command -v zfs     >/dev/null 2>&1 || fail "zfs not found"
+
+    # A slow run must not have a second copy started on top of it.
+    local lock="/run/lock/pve-toolbox-zfs-sync-$JOB.lock"
+    exec 9>"$lock"
+    if ! flock -n 9; then
+        log "job $JOB is already running - leaving it alone"
+        exit 0
+    fi
+
+    _ds_exists "$JOB_SRC" || fail "source dataset does not exist: $JOB_SRC"
+
+    mkdir -p "$LOG_DIR"
+    chmod 0750 "$LOG_DIR"
+    local logfile="$LOG_DIR/$JOB.log"
+    [[ -f $logfile ]] && mv -f "$logfile" "$logfile.prev"
+    {
+        printf 'pve-toolbox zfs-replication job %s\n' "$JOB"
+        printf 'started  %s\n' "$(date -Is)"
+        printf 'source   %s\n' "$JOB_SRC"
+        printf 'target   %s\n' "$JOB_DST"
+        printf 'options  %s\n\n' "$JOB_OPTS"
+    } > "$logfile"
+    chmod 0640 "$logfile"
+
+    if [[ $NOTIFY_START == 1 ]]; then _notify_start || true; fi
+
+    local before_used before_snaps started rc=0
+    before_used=$(_used_bytes "$JOB_DST")
+    before_snaps=$(_snap_count "$JOB_DST")
+    started=$SECONDS
+
+    log "replicating $JOB_SRC -> $JOB_DST"
+    # shellcheck disable=SC2086
+    syncoid $JOB_OPTS "$JOB_SRC" "$JOB_DST" >> "$logfile" 2>&1 || rc=$?
+    local elapsed=$((SECONDS - started))
+
+    if [[ $rc -ne 0 ]]; then
+        local tail_out desc
+        tail_out=$(tail -n "$LOG_TAIL" "$logfile")
+        desc=$(printf 'syncoid exited %s. Last %s lines of %s:\n%s' \
+                      "$rc" "$LOG_TAIL" "$logfile" "$(discord_fence "$tail_out")")
+        _record failed "$elapsed"
+        discord_notify "$DISCORD_WEBHOOK" "$DISCORD_ERR" "ZFS replication failed - $JOB" "$desc" \
+            Job         "$JOB" \
+            Host        "$HOST_SHORT" \
+            Source      "$JOB_SRC" \
+            Target      "$JOB_DST" \
+            "Exit code" "$rc" \
+            Duration    "$(_hms "$elapsed")" || true
+        fail "syncoid exited $rc - see $logfile"
+    fi
+
+    # Ownership fixups, only where they were actually asked for.
+    local path perms="not requested"
+    path=$(_target_path)
+    if [[ -n $JOB_CHOWN || -n $JOB_CHMOD ]]; then
+        if [[ -z $path ]]; then
+            perms="skipped, $JOB_DST has no mountpoint"
+            log "warning: $perms"
+        elif [[ ! -d $path ]]; then
+            perms="skipped, $path is not a directory"
+            log "warning: $perms"
+        else
+            perms=""
+            if [[ -n $JOB_CHOWN ]]; then
+                chown -R "$JOB_CHOWN" "$path" && perms="owner $JOB_CHOWN"
+            fi
+            if [[ -n $JOB_CHMOD ]]; then
+                chmod -R "$JOB_CHMOD" "$path" && perms="${perms:+$perms, }mode $JOB_CHMOD"
+            fi
+            perms="${perms:-none} on $path"
+            log "applied $perms"
+        fi
+    fi
+
+    local after_used after_snaps delta
+    after_used=$(_used_bytes "$JOB_DST")
+    after_snaps=$(_snap_count "$JOB_DST")
+    delta=$((after_used - before_used))
+    [[ $delta -lt 0 ]] && delta=0
+
+    # syncoid succeeded but a requested chown/chmod did not land: the original
+    # script reported that as a clean success. Flag it instead.
+    local color=$DISCORD_OK verdict="finished"
+    if [[ $perms == skipped* ]]; then
+        color=$DISCORD_WARN
+        verdict="finished, permissions not applied"
+    fi
+
+    _record ok "$elapsed"
+    printf '\nfinished %s after %s\n' "$(date -Is)" "$(_hms "$elapsed")" >> "$logfile"
+
+    discord_notify "$DISCORD_WEBHOOK" "$color" "ZFS replication $verdict - $JOB" \
+        "Replicated *$JOB_SRC* to *$JOB_DST*." \
+        Job          "$JOB" \
+        Host         "$HOST_SHORT" \
+        Source       "$JOB_SRC" \
+        Target       "$JOB_DST" \
+        Duration     "$(_hms "$elapsed")" \
+        Grew         "$(_human "$delta")" \
+        "Target size" "$(_human "$after_used")" \
+        Snapshots    "$before_snaps to $after_snaps" \
+        Permissions  "$perms" || true
+    log "done in $(_hms "$elapsed")"
+}
+
+main "$@"

--- a/modules/zfs-scrub/module.sh
+++ b/modules/zfs-scrub/module.sh
@@ -1,0 +1,466 @@
+# shellcheck shell=bash
+#
+# Scheduled ZFS scrubs with Discord reporting.
+#
+# One systemd timer per pool, each on its own schedule, each firing a watcher
+# that posts to Discord twice: once when the scrub starts and once when it
+# ends, with the repaired/errors/duration summary zfs reports.
+#
+# The heavy lifting is in pve-toolbox-zfs-scrub.sh, installed as
+# $TOOLBOX_BIN_DIR/pve-toolbox-zfs-scrub so the units do not depend on this
+# checkout staying where it is.
+#
+# The launcher reads this metadata indirectly, in meta().
+# shellcheck disable=SC2034
+MODULE_NAME="zfs-scrub"
+MODULE_TITLE="ZFS scrub + Discord"
+MODULE_DESC="scheduled scrub per pool, Discord message on start and on result"
+MODULE_TAGS="storage zfs monitoring notify"
+MODULE_HOST_ONLY=1        # needs the host's zpool, not an LXC view of it
+
+ZS_BIN="pve-toolbox-zfs-scrub"
+
+# Namespaced away from zfs-scrub@.service, which zfsutils-linux ships.
+ZS_UNIT="pve-toolbox-zfs-scrub"
+
+# ------------------------------------------------------------- internals --
+
+_zs_dir() { printf '%s/modules/%s' "${TOOLBOX_ROOT:-/opt/pve-toolbox}" "$MODULE_NAME"; }
+_zs_src() { printf '%s/%s.sh' "$(_zs_dir)" "$ZS_BIN"; }
+
+_zs_defaults() {
+    : "${ZFS_SCRUB_WEBHOOK:=}"
+    : "${ZFS_SCRUB_POOLS:=}"
+    : "${ZFS_SCRUB_INTERVAL:=300}"
+    : "${ZFS_SCRUB_NOTIFY_START:=y}"
+}
+
+_zs_pools() { zpool list -H -o name 2>/dev/null; }
+
+# Pool names may contain . - : which are not legal in a variable name.
+_zs_var() { # _zs_var <pool> -> ZFS_SCRUB_SCHEDULE_<POOL>
+    local p=${1//[^A-Za-z0-9]/_}
+    printf 'ZFS_SCRUB_SCHEDULE_%s' "${p^^}"
+}
+
+# Pools share spindles, so stagger them a week apart rather than scrubbing
+# everything on the same night.
+_zs_default_schedule() { # _zs_default_schedule <index>
+    case $(( ${1:-0} % 4 )) in
+        0) printf 'Sun *-*-01..07 03:00:00' ;;
+        1) printf 'Sun *-*-08..14 03:00:00' ;;
+        2) printf 'Sun *-*-15..21 03:00:00' ;;
+        *) printf 'Sun *-*-22..28 03:00:00' ;;
+    esac
+}
+
+# Unit names carry the pool name; refuse anything systemd would mangle.
+_zs_valid_pool() {
+    [[ $1 =~ ^[A-Za-z][A-Za-z0-9_.:-]*$ ]]
+}
+
+# Which pools currently have a timer on disk - the timers are the truth here,
+# not the state file.
+_zs_scheduled() {
+    ZS_SCHEDULED=()
+    local f b
+    for f in "$TOOLBOX_SYSTEMD_DIR/$ZS_UNIT@"*.timer; do
+        [[ -f $f ]] || continue
+        b=$(basename "$f" .timer)
+        ZS_SCHEDULED+=("${b#*@}")
+    done
+    return 0
+}
+
+_zs_schedule_of() { # _zs_schedule_of <pool>
+    local f="$TOOLBOX_SYSTEMD_DIR/$ZS_UNIT@$1.timer"
+    [[ -f $f ]] || { printf 'no timer'; return 0; }
+    sed -n 's/^OnCalendar=//p' "$f" | head -n1
+}
+
+_zs_sum() { # _zs_sum <file>
+    [[ -f $1 ]] || { printf 'none'; return 0; }
+    sha256sum "$1" | awk '{print $1}'
+}
+
+_zs_write_conf() {
+    local notify_start=0
+    [[ $ZFS_SCRUB_NOTIFY_START == y ]] && notify_start=1
+    conf_set "$MODULE_NAME" DISCORD_WEBHOOK "$ZFS_SCRUB_WEBHOOK"
+    conf_set "$MODULE_NAME" POLL_INTERVAL   "$ZFS_SCRUB_INTERVAL"
+    conf_set "$MODULE_NAME" NOTIFY_START    "$notify_start"
+    ok "wrote $(conf_file "$MODULE_NAME") (0600)"
+}
+
+# One template service for every pool; %i is the pool name.
+_zs_write_service() {
+    cat > "$TOOLBOX_SYSTEMD_DIR/$ZS_UNIT@.service" <<EOF
+[Unit]
+Description=pve-toolbox ZFS scrub of %i
+Documentation=man:zpool-scrub(8)
+After=zfs.target network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+Environment=SCRUB_CONF=$(conf_file "$MODULE_NAME")
+Environment=PVE_TOOLBOX_LIB=$TOOLBOX_LIB_DIR
+ExecStart=$TOOLBOX_BIN_DIR/$ZS_BIN %i
+# The unit stays active for the whole scrub so it can report the result;
+# on a large pool that is hours, not minutes.
+TimeoutStartSec=infinity
+Nice=19
+StandardOutput=journal
+StandardError=journal
+EOF
+    ok "wrote $ZS_UNIT@.service"
+}
+
+_zs_write_timer() { # _zs_write_timer <pool> <OnCalendar>
+    cat > "$TOOLBOX_SYSTEMD_DIR/$ZS_UNIT@$1.timer" <<EOF
+[Unit]
+Description=pve-toolbox ZFS scrub of $1 (timer)
+
+[Timer]
+OnCalendar=$2
+RandomizedDelaySec=1800
+Persistent=true
+Unit=$ZS_UNIT@$1.service
+
+[Install]
+WantedBy=timers.target
+EOF
+}
+
+_zs_enable() { # _zs_enable <pool>
+    if systemctl enable --now "$ZS_UNIT@$1.timer" >/dev/null 2>&1; then
+        ok "enabled $ZS_UNIT@$1.timer  ($(_zs_schedule_of "$1"))"
+    else
+        warn "could not enable $ZS_UNIT@$1.timer"
+    fi
+}
+
+_zs_remove_timer() { # _zs_remove_timer <pool>
+    systemctl disable --now "$ZS_UNIT@$1.timer" >/dev/null 2>&1 || true
+    rm -f "$TOOLBOX_SYSTEMD_DIR/$ZS_UNIT@$1.timer"
+}
+
+# zfsutils-linux ships its own scrub timers; two schedules on one pool is
+# just wasted I/O.
+_zs_distro_timers() { # _zs_distro_timers <pool>...
+    ZS_CONFLICT=()
+    local p u
+    for p in "$@"; do
+        for u in "zfs-scrub-monthly@$p.timer" "zfs-scrub-weekly@$p.timer"; do
+            systemctl is-enabled --quiet "$u" 2>/dev/null && ZS_CONFLICT+=("$u")
+        done
+    done
+    return 0
+}
+
+_zs_webhook_shown() {
+    local f url
+    f=$(conf_file "$MODULE_NAME")
+    [[ -f $f ]] || { printf 'not configured'; return 0; }
+    [[ -r $f ]] || { printf 'configured (root only)'; return 0; }
+    url=$(conf_get "$MODULE_NAME" DISCORD_WEBHOOK)
+    [[ -n $url ]] || { printf 'not configured'; return 0; }
+    printf '%s/****%s' "${url%/*}" "${url: -4}"
+}
+
+# --------------------------------------------------------------- install --
+
+module_install() {
+    require_root
+    require_pve
+    have_zfs || die "no zpool binary - this module needs ZFS on the host"
+    _zs_defaults
+    pkg_ensure curl:curl jq:jq
+
+    step "Discord webhook"
+    if [[ -z $ZFS_SCRUB_WEBHOOK && $ASSUME_YES -eq 1 ]]; then
+        die "set ZFS_SCRUB_WEBHOOK for a non-interactive install"
+    fi
+    while [[ -z $ZFS_SCRUB_WEBHOOK ]]; do
+        ask ZFS_SCRUB_WEBHOOK "Discord webhook URL" ""
+    done
+    if [[ ! $ZFS_SCRUB_WEBHOOK =~ ^https://[A-Za-z0-9._~/-]+$ ]]; then
+        die "that does not look like a URL (Server Settings -> Integrations -> Webhooks)"
+    fi
+    case $ZFS_SCRUB_WEBHOOK in
+        https://discord.com/api/webhooks/*|https://discordapp.com/api/webhooks/*|https://ptb.discord.com/api/webhooks/*) ;;
+        *) warn "not a discord.com/api/webhooks URL - continuing, it just has to accept the same JSON" ;;
+    esac
+
+    step "Pools"
+    local all=() p
+    mapfile -t all < <(_zs_pools)
+    [[ ${#all[@]} -eq 0 ]] && die "no ZFS pools on this host"
+
+    local want=()
+    if [[ -n $ZFS_SCRUB_POOLS ]]; then
+        for p in $ZFS_SCRUB_POOLS; do
+            zpool list -H -o name "$p" >/dev/null 2>&1 || die "no such pool: $p"
+            want+=("$p")
+        done
+    else
+        local pick size health
+        for p in "${all[@]}"; do
+            size=$(zpool list -H -o size "$p" 2>/dev/null || printf '?')
+            health=$(zpool list -H -o health "$p" 2>/dev/null || printf '?')
+            pick=y; ask_yn pick "  scrub $p ($size, $health)" "y"
+            [[ $pick == y ]] && want+=("$p")
+        done
+    fi
+    [[ ${#want[@]} -eq 0 ]] && { warn "no pools selected"; return 1; }
+
+    for p in "${want[@]}"; do
+        _zs_valid_pool "$p" || die "pool name '$p' cannot be used in a systemd unit name"
+    done
+
+    step "Schedules"
+    dim "  staggered a week apart so the pools do not all scrub on the same night"
+    local i=0 var
+    for p in "${want[@]}"; do
+        var=$(_zs_var "$p")
+        [[ -z ${!var:-} ]] && printf -v "$var" '%s' "$(_zs_default_schedule "$i")"
+        ask "$var" "  $p (systemd OnCalendar)" "${!var}"
+        i=$((i + 1))
+    done
+    ask ZFS_SCRUB_INTERVAL "how often to check whether a scrub finished (seconds)" \
+        "$ZFS_SCRUB_INTERVAL"
+    ask_yn ZFS_SCRUB_NOTIFY_START "also notify when a scrub starts" \
+        "$ZFS_SCRUB_NOTIFY_START"
+
+    _zs_distro_timers "${want[@]}"
+    if [[ ${#ZS_CONFLICT[@]} -gt 0 ]]; then
+        step "Timers already scrubbing these pools"
+        warn "from zfsutils-linux: ${ZS_CONFLICT[*]}"
+        local dis=y u
+        ask_yn dis "disable them so each pool is scrubbed once, by us" "y"
+        if [[ $dis == y ]]; then
+            for u in "${ZS_CONFLICT[@]}"; do
+                systemctl disable --now "$u" >/dev/null 2>&1 || true
+                ok "disabled $u"
+            done
+        fi
+    fi
+
+    step "Install"
+    install_toolbox_lib discord.sh
+    install -m 0755 "$(_zs_src)" "$TOOLBOX_BIN_DIR/$ZS_BIN"
+    ok "installed $TOOLBOX_BIN_DIR/$ZS_BIN"
+    _zs_write_conf
+    _zs_write_service
+    for p in "${want[@]}"; do
+        var=$(_zs_var "$p")
+        _zs_write_timer "$p" "${!var}"
+    done
+    systemctl daemon-reload
+    for p in "${want[@]}"; do _zs_enable "$p"; done
+
+    step "Verification"
+    local t=y
+    ask_yn t "send a test notification to Discord now" "y"
+    if [[ $t == y ]]; then
+        if SCRUB_CONF="$(conf_file "$MODULE_NAME")" PVE_TOOLBOX_LIB="$TOOLBOX_LIB_DIR" \
+           "$TOOLBOX_BIN_DIR/$ZS_BIN" --test "${want[0]}"; then
+            ok "sent - check the channel"
+        else
+            warn "failed - fix DISCORD_WEBHOOK in $(conf_file "$MODULE_NAME") and retry"
+        fi
+    fi
+
+    local now=n
+    ask_yn now "start a scrub on the selected pools right now" "n"
+    if [[ $now == y ]]; then
+        for p in "${want[@]}"; do
+            systemctl start --no-block "$ZS_UNIT@$p.service"
+            ok "started $ZS_UNIT@$p.service (runs in the background)"
+        done
+    fi
+
+    state_set "$MODULE_NAME" POOLS "${want[*]}"
+    state_set "$MODULE_NAME" INTERVAL "$ZFS_SCRUB_INTERVAL"
+    state_set "$MODULE_NAME" NOTIFY_START "$ZFS_SCRUB_NOTIFY_START"
+    state_set "$MODULE_NAME" SCRIPT_SUM "$(_zs_sum "$(_zs_src)")"
+    state_set "$MODULE_NAME" INSTALLED_AT "$(date -Is)"
+
+    step "Done - ${#want[@]} pool(s) scheduled"
+    dim "  systemctl list-timers '$ZS_UNIT@*'"
+    dim "  journalctl -u '$ZS_UNIT@*' -f   follow a running scrub"
+    dim "  stopping the unit stops the reporting, not the scrub"
+}
+
+# ---------------------------------------------------------------- update --
+
+# There is no upstream release here: an update re-syncs the installed watcher
+# and the per-pool timers with this checkout, and picks up new pools.
+module_update() {
+    require_root
+    local check_only=0
+    [[ ${1:-} == --check ]] && check_only=1
+
+    _zs_scheduled
+    [[ ${#ZS_SCHEDULED[@]} -eq 0 ]] && die "not installed"
+
+    local src dst new cur
+    src=$(_zs_src); dst="$TOOLBOX_BIN_DIR/$ZS_BIN"
+    new=$(_zs_sum "$src"); cur=$(_zs_sum "$dst")
+
+    local missing=() stale=() p
+    if have_zfs; then
+        while read -r p; do
+            [[ -n $p ]] || continue
+            [[ " ${ZS_SCHEDULED[*]} " == *" $p "* ]] || missing+=("$p")
+        done < <(_zs_pools)
+        for p in "${ZS_SCHEDULED[@]}"; do
+            zpool list -H -o name "$p" >/dev/null 2>&1 || stale+=("$p")
+        done
+    fi
+
+    local drift=0
+    [[ $new != "$cur" ]] && drift=1
+    printf '  watcher    %s\n' \
+        "$([[ $drift -eq 1 ]] && printf 'differs from this checkout' || printf 'up to date')"
+    printf '  scheduled  %s\n' "${ZS_SCHEDULED[*]}"
+    if [[ ${#missing[@]} -gt 0 ]]; then warn "pools with no scrub timer: ${missing[*]}"; fi
+    if [[ ${#stale[@]} -gt 0 ]];   then warn "timers for pools that are gone: ${stale[*]}"; fi
+
+    if [[ $drift -eq 0 && ${#missing[@]} -eq 0 && ${#stale[@]} -eq 0 && ${FORCE:-0} -eq 0 ]]; then
+        ok "up to date"
+        return 0
+    fi
+    if [[ $check_only -eq 1 ]]; then
+        info "update available: watcher or pool timers are out of sync"
+        return 0
+    fi
+
+    step "Watcher and units"
+    install_toolbox_lib discord.sh
+    install -m 0755 "$src" "$dst"
+    ok "installed $dst"
+    _zs_write_service
+
+    if [[ ${#stale[@]} -gt 0 ]]; then
+        step "Pools that no longer exist"
+        for p in "${stale[@]}"; do
+            local drop=y
+            ask_yn drop "  remove the timer for $p" "y"
+            if [[ $drop == y ]]; then
+                _zs_remove_timer "$p"
+                ok "removed $ZS_UNIT@$p.timer"
+            fi
+        done
+    fi
+
+    local added=()
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        step "New pools"
+        local i=${#ZS_SCHEDULED[@]}
+        for p in "${missing[@]}"; do
+            if ! _zs_valid_pool "$p"; then
+                warn "skipping $p - not usable in a systemd unit name"
+                continue
+            fi
+            local add=y sched
+            ask_yn add "  schedule scrubs for $p" "y"
+            [[ $add == y ]] || continue
+            sched=$(_zs_default_schedule "$i")
+            ask sched "  $p (systemd OnCalendar)" "$sched"
+            _zs_write_timer "$p" "$sched"
+            added+=("$p")
+            i=$((i + 1))
+        done
+    fi
+
+    systemctl daemon-reload
+    for p in "${added[@]:-}"; do
+        [[ -n $p ]] && _zs_enable "$p"
+    done
+
+    _zs_scheduled
+    state_set "$MODULE_NAME" POOLS "${ZS_SCHEDULED[*]}"
+    state_set "$MODULE_NAME" SCRIPT_SUM "$new"
+    state_set "$MODULE_NAME" UPDATED_AT "$(date -Is)"
+    step "In sync - ${#ZS_SCHEDULED[@]} pool(s) scheduled"
+}
+
+# ---------------------------------------------------------------- status --
+
+module_status() {
+    _zs_scheduled
+    if [[ ${#ZS_SCHEDULED[@]} -eq 0 ]]; then
+        printf 'not installed'
+        return 1
+    fi
+    local running=() p
+    if have_zfs; then
+        for p in "${ZS_SCHEDULED[@]}"; do
+            if zpool status "$p" 2>/dev/null | grep -q 'scrub in progress'; then
+                running+=("$p")
+            fi
+        done
+    fi
+    if [[ ${#running[@]} -gt 0 ]]; then
+        printf 'scrubbing  [%s]' "${running[*]}"
+    else
+        printf 'pools:%d  [%s]' "${#ZS_SCHEDULED[@]}" "${ZS_SCHEDULED[*]}"
+    fi
+}
+
+module_status_long() {
+    _zs_scheduled
+    if [[ ${#ZS_SCHEDULED[@]} -eq 0 ]]; then
+        warn "not installed"
+        return 1
+    fi
+    printf '  watcher    %s\n' "$TOOLBOX_BIN_DIR/$ZS_BIN"
+    printf '  config     %s\n' "$(conf_file "$MODULE_NAME")"
+    printf '  webhook    %s\n' "$(_zs_webhook_shown)"
+    printf '  notify     start=%s, poll every %ss\n' \
+        "$(state_get "$MODULE_NAME" NOTIFY_START)" \
+        "$(state_get "$MODULE_NAME" INTERVAL)"
+    echo
+    local p health scan
+    for p in "${ZS_SCHEDULED[@]}"; do
+        health=$(zpool list -H -o health "$p" 2>/dev/null || printf '?')
+        scan=$(zpool status "$p" 2>/dev/null \
+            | sed -n 's/^[[:space:]]*scan:[[:space:]]*//p' | head -n1)
+        printf '  %-16s %-9s %s\n' "$p" "$health" "$(_zs_schedule_of "$p")"
+        printf '    %s\n' "${scan:-no scrub recorded}"
+    done
+    echo
+    systemctl list-timers "$ZS_UNIT@*" --no-pager 2>/dev/null || true
+}
+
+# ------------------------------------------------------------- uninstall --
+
+module_uninstall() {
+    require_root
+    _zs_scheduled
+    local p
+    for p in "${ZS_SCHEDULED[@]}"; do
+        _zs_remove_timer "$p"
+        ok "removed $ZS_UNIT@$p.timer"
+    done
+    rm -f "$TOOLBOX_SYSTEMD_DIR/$ZS_UNIT@.service"
+    systemctl daemon-reload
+    rm -f "$TOOLBOX_BIN_DIR/$ZS_BIN"
+    state_clear "$MODULE_NAME"
+    ok "watcher, units and state removed"
+
+    if conf_exists "$MODULE_NAME"; then
+        local conf drop=y
+        conf=$(conf_file "$MODULE_NAME")
+        ask_yn drop "also remove $conf (holds the webhook URL)" "y"
+        if [[ $drop == y ]]; then
+            conf_clear "$MODULE_NAME"
+            ok "removed $conf"
+        else
+            warn "config left in place: $conf"
+        fi
+    fi
+    dim "  $TOOLBOX_LIB_DIR/discord.sh is shared with other modules and stays"
+    warn "a scrub already running in the kernel is not stopped - 'zpool scrub -s <pool>' does that"
+}

--- a/modules/zfs-scrub/pve-toolbox-zfs-scrub.sh
+++ b/modules/zfs-scrub/pve-toolbox-zfs-scrub.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+#
+# pve-toolbox-zfs-scrub - scrub one ZFS pool and report to a Discord webhook.
+#
+# Installed by the pve-toolbox 'zfs-scrub' module as
+# /usr/local/bin/pve-toolbox-zfs-scrub and driven by one systemd timer per pool:
+#
+#   pve-toolbox-zfs-scrub <pool>         start a scrub, wait for it, report start + result
+#   pve-toolbox-zfs-scrub --test <pool>  send a test notification, scrub nothing
+#
+# One pool per invocation on purpose: every pool gets its own timer, its own
+# schedule and its own pair of Discord messages.
+#
+# Config, written by the module. Root-only, because the webhook URL is the
+# only credential Discord checks:
+#
+#   /etc/pve-toolbox/zfs-scrub.conf
+#     DISCORD_WEBHOOK='https://discord.com/api/webhooks/<id>/<token>'
+#     POLL_INTERVAL=300
+#     NOTIFY_START=1
+#
+set -euo pipefail
+
+CONF="${SCRUB_CONF:-/etc/pve-toolbox/zfs-scrub.conf}"
+
+DISCORD_WEBHOOK=""
+POLL_INTERVAL=300
+NOTIFY_START=1
+
+# Reporting comes from the shared lib installed alongside this script.
+TOOLBOX_LIB="${PVE_TOOLBOX_LIB:-/usr/local/lib/pve-toolbox}"
+# shellcheck source=../../lib/discord.sh
+source "$TOOLBOX_LIB/discord.sh" 2>/dev/null \
+    || { printf 'error: cannot source %s/discord.sh\n' "$TOOLBOX_LIB" >&2; exit 1; }
+
+POOL=""
+HOST_SHORT=$(hostname -s 2>/dev/null || hostname)
+
+log()  { printf '%s\n' "$*"; }
+fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+usage() { sed -n '3,12p' "$0" | sed 's/^# \{0,1\}//'; }
+
+# ------------------------------------------------------------------- zfs --
+
+_pool_exists() { zpool list -H -o name "$1" >/dev/null 2>&1; }
+_health()      { zpool list -H -o health "$1" 2>/dev/null || printf 'UNKNOWN'; }
+_scrubbing()   { zpool status "$1" 2>/dev/null | grep -q 'scrub in progress'; }
+
+# The scan: line is the one summary zfs keeps across reboots.
+_scan_line() {
+    zpool status "$1" 2>/dev/null \
+        | sed -n 's/^[[:space:]]*scan:[[:space:]]*//p' | head -n1
+}
+
+_errors_line() {
+    zpool status -v "$1" 2>/dev/null \
+        | sed -n 's/^errors:[[:space:]]*//p' | head -n1
+}
+
+_capacity() {
+    local size alloc cap
+    IFS=$'\t' read -r size alloc cap \
+        < <(zpool list -H -o size,alloc,cap "$1" 2>/dev/null) || true
+    printf '%s of %s used, cap %s' "${alloc:--}" "${size:--}" "${cap:--}"
+}
+
+_hms() { printf '%02d:%02d:%02d' $(($1 / 3600)) $((($1 % 3600) / 60)) $(($1 % 60)); }
+
+# _result <scan-line> -> sets R_STATE R_REPAIRED R_DURATION R_ERRORS
+_result() {
+    local line=$1
+    R_STATE=unknown; R_REPAIRED="-"; R_DURATION="-"; R_ERRORS="-"
+    case $line in
+        *"scrub in progress"*) R_STATE=running ;;
+        *"scrub canceled"*)    R_STATE=canceled ;;
+        *"scrub paused"*)      R_STATE=paused ;;
+        *"scrub repaired"*)    R_STATE=finished ;;
+        *resilver*)            R_STATE=resilver ;;
+    esac
+    [[ $R_STATE == finished ]] || return 0
+    R_REPAIRED=$(sed -n 's/.*scrub repaired \([^ ]*\) in .*/\1/p' <<<"$line")
+    R_DURATION=$(sed -n 's/.* in \(.*\) with [0-9][0-9]* errors.*/\1/p' <<<"$line")
+    R_ERRORS=$(sed -n 's/.* with \([0-9][0-9]*\) errors.*/\1/p' <<<"$line")
+    : "${R_REPAIRED:=-}" "${R_DURATION:=-}" "${R_ERRORS:=-}"
+}
+
+# ---------------------------------------------------------------- report --
+
+_notify_start() {
+    discord_notify "$DISCORD_WEBHOOK" "$DISCORD_INFO" "ZFS scrub started - $POOL" \
+        "Scrub of *$POOL* is now running. The result lands here when it finishes." \
+        Host     "$HOST_SHORT" \
+        Pool     "$POOL" \
+        Health   "$(_health "$POOL")" \
+        Capacity "$(_capacity "$POOL")"
+}
+
+_notify_result() {
+    local elapsed=$1 scan health errors color verdict
+    scan=$(_scan_line "$POOL")
+    health=$(_health "$POOL")
+    errors=$(_errors_line "$POOL")
+    _result "$scan"
+
+    case $R_STATE in
+        finished)
+            if [[ $R_ERRORS =~ ^[0-9]+$ ]] && [[ $R_ERRORS -gt 0 ]]; then
+                color=$DISCORD_ERR;  verdict="finished with $R_ERRORS errors"
+            elif [[ $health != ONLINE ]]; then
+                color=$DISCORD_WARN; verdict="finished, pool is $health"
+            elif [[ $R_REPAIRED != 0B && $R_REPAIRED != 0 && $R_REPAIRED != "-" ]]; then
+                color=$DISCORD_WARN; verdict="finished, repaired $R_REPAIRED"
+            else
+                color=$DISCORD_OK;   verdict="finished clean"
+            fi ;;
+        canceled) color=$DISCORD_WARN; verdict="canceled" ;;
+        paused)   color=$DISCORD_WARN; verdict="paused" ;;
+        *)        color=$DISCORD_WARN; verdict="finished, status not recognised" ;;
+    esac
+
+    # A scan line can report 0 errors while zfs still knows about damaged files.
+    if [[ -n $errors && $errors != "No known data errors" ]]; then
+        color=$DISCORD_ERR
+        verdict="finished, data errors on the pool"
+    fi
+
+    discord_notify "$DISCORD_WEBHOOK" "$color" "ZFS scrub $verdict - $POOL" "$scan" \
+        Host          "$HOST_SHORT" \
+        Pool          "$POOL" \
+        Health        "$health" \
+        Repaired      "$R_REPAIRED" \
+        Errors        "$R_ERRORS" \
+        "Scrub time"  "$R_DURATION" \
+        "Watched for" "$(_hms "$elapsed")" \
+        "Data errors" "${errors:--}"
+}
+
+# Stopping the unit does not stop the scrub - say so rather than going quiet.
+_on_signal() {
+    trap - TERM INT
+    discord_notify "$DISCORD_WEBHOOK" "$DISCORD_WARN" "ZFS scrub no longer watched - $POOL" \
+        "The watcher unit was stopped, so no result will be reported for this run. The scrub itself keeps running in the kernel; follow it with 'zpool status $POOL'." \
+        Host "$HOST_SHORT" \
+        Pool "$POOL"
+    exit 143
+}
+
+# ------------------------------------------------------------------ main --
+
+main() {
+    local mode=scrub
+    case ${1:-} in
+        -h|--help) usage; exit 0 ;;
+        --test)    mode=selftest; shift ;;
+    esac
+
+    POOL=${1:-}
+    [[ -n $POOL ]] || { usage >&2; exit 2; }
+
+    command -v zpool >/dev/null 2>&1 || fail "zpool not found - is this a ZFS host?"
+    command -v jq    >/dev/null 2>&1 || fail "jq not found"
+    command -v curl  >/dev/null 2>&1 || fail "curl not found"
+
+    if [[ -r $CONF ]]; then
+        # shellcheck source=/dev/null
+        source "$CONF"
+    else
+        log "warning: cannot read $CONF - falling back to defaults"
+    fi
+    [[ $POLL_INTERVAL =~ ^[0-9]+$ ]] || POLL_INTERVAL=300
+    if [[ $POLL_INTERVAL -lt 10 ]]; then POLL_INTERVAL=10; fi
+
+    _pool_exists "$POOL" || fail "no such ZFS pool: $POOL"
+
+    if [[ $mode == selftest ]]; then
+        discord_notify "$DISCORD_WEBHOOK" "$DISCORD_INFO" "pve-toolbox test notification" \
+            "Scrub reports for *$POOL* on *$HOST_SHORT* will arrive in this channel." \
+            Host        "$HOST_SHORT" \
+            Pool        "$POOL" \
+            Health      "$(_health "$POOL")" \
+            "Last scan" "$(_scan_line "$POOL")" \
+            || fail "could not deliver the test notification - check DISCORD_WEBHOOK in $CONF"
+        exit 0
+    fi
+
+    if _scrubbing "$POOL"; then
+        log "a scrub is already running on $POOL - leaving it alone"
+        exit 0
+    fi
+
+    trap _on_signal TERM INT
+
+    if [[ $NOTIFY_START == 1 ]]; then _notify_start || true; fi
+
+    if ! zpool scrub "$POOL"; then
+        discord_notify "$DISCORD_WEBHOOK" "$DISCORD_ERR" "ZFS scrub failed to start - $POOL" \
+            "'zpool scrub $POOL' returned an error, so nothing is running." \
+            Host   "$HOST_SHORT" \
+            Pool   "$POOL" \
+            Health "$(_health "$POOL")" || true
+        fail "zpool scrub $POOL failed"
+    fi
+    log "scrub of $POOL started, polling every ${POLL_INTERVAL}s"
+
+    local started=$SECONDS
+    sleep 5
+    while _scrubbing "$POOL"; do
+        sleep "$POLL_INTERVAL"
+    done
+
+    trap - TERM INT
+    _notify_result "$((SECONDS - started))" || true
+}
+
+main "$@"

--- a/pve-toolbox
+++ b/pve-toolbox
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+#
+# pve-toolbox - interactive launcher for custom Proxmox scripts.
+#
+#   pve-toolbox                    interactive menu
+#   pve-toolbox list [tag]         list modules
+#   pve-toolbox install <mod>...   install specific modules
+#   pve-toolbox update [mod]...    update (all installed if none given)
+#   pve-toolbox check [mod]...     report available updates, change nothing
+#   pve-toolbox status [mod]       detailed status
+#   pve-toolbox uninstall <mod>...
+#   pve-toolbox link               symlink into /usr/local/bin
+#   pve-toolbox self-update        git pull this checkout
+#
+# Flags: -y/--yes non-interactive, -f/--force, -h/--help
+#
+set -euo pipefail
+
+TOOLBOX_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_DIR="$TOOLBOX_ROOT/modules"
+
+# shellcheck source=lib/common.sh
+source "$TOOLBOX_ROOT/lib/common.sh"
+
+FORCE=0
+
+# --------------------------------------------------------------- discovery --
+
+discover() {
+    MODULES=()
+    local d
+    for d in "$MODULE_DIR"/*/; do
+        [[ -f "$d/module.sh" ]] || continue
+        local name; name=$(basename "$d")
+        [[ $name == _* ]] && continue
+        MODULES+=("$name")
+    done
+    if [[ ${#MODULES[@]} -eq 0 ]]; then
+        die "no modules found in $MODULE_DIR"
+    fi
+}
+
+# Read metadata without polluting the current shell.
+meta() { # meta <module> <VAR>
+    (
+        set +u
+        # shellcheck source=/dev/null
+        source "$MODULE_DIR/$1/module.sh"
+        printf '%s' "${!2}"
+    )
+}
+
+# Run a module function in a subshell so module globals stay isolated.
+run_module() { # run_module <module> <function> [args...]
+    local mod=$1 fn=$2; shift 2
+    [[ -f "$MODULE_DIR/$mod/module.sh" ]] || die "unknown module: $mod"
+    (
+        # shellcheck source=/dev/null
+        source "$MODULE_DIR/$mod/module.sh"
+        if ! declare -F "$fn" >/dev/null; then
+            if [[ $fn == module_status_long ]] && declare -F module_status >/dev/null; then
+                local rc=0
+                module_status || rc=$?
+                echo
+                exit "$rc"
+            fi
+            die "module $mod does not implement $fn"
+        fi
+        "$fn" "$@"
+    )
+}
+
+status_line() { # status_line <module> -> prints short status
+    run_module "$1" module_status 2>/dev/null || true
+}
+
+# ------------------------------------------------------------------- menu --
+
+print_table() {
+    local i=1 m title desc st
+    printf '\n%s  #  %-24s %-11s %s%s\n' "$c_bold" "MODULE" "STATUS" "DESCRIPTION" "$c_reset"
+    for m in "${MODULES[@]}"; do
+        title=$(meta "$m" MODULE_TITLE)
+        desc=$(meta "$m" MODULE_DESC)
+        st=$(status_line "$m")
+        local mark="   "
+        [[ " ${SELECTED[*]:-} " == *" $m "* ]] && mark=" ${c_green}*${c_reset} "
+        if [[ $st == "not installed" || -z $st ]]; then
+            printf '%s%2d) %-24s %s%-11s%s %s\n' "$mark" "$i" "$title" "$c_dim" "-" "$c_reset" "$desc"
+        else
+            printf '%s%2d) %-24s %s%-11s%s %s\n' "$mark" "$i" "$title" "$c_green" "${st%% *}" "$c_reset" "$desc"
+        fi
+        i=$((i + 1))
+    done
+    echo
+}
+
+menu() {
+    discover
+    SELECTED=()
+    while true; do
+        printf '\n%s pve-toolbox %s%s\n' "$c_bold$c_blue" "$(hostname -s)" "$c_reset"
+        print_table
+        dim "  numbers toggle selection (e.g. '1 3'), then:"
+        printf '  %si%s install/reconfigure selected   %su%s update all installed\n' \
+            "$c_bold" "$c_reset" "$c_bold" "$c_reset"
+        printf '  %sc%s check for updates              %ss%s status of selected\n' \
+            "$c_bold" "$c_reset" "$c_bold" "$c_reset"
+        printf '  %sx%s uninstall selected             %sq%s quit\n\n' \
+            "$c_bold" "$c_reset" "$c_bold" "$c_reset"
+
+        local reply
+        read -r -p "> " reply || { echo; return 0; }
+        [[ -z $reply ]] && continue
+
+        case ${reply,,} in
+            q|quit|exit) return 0 ;;
+            i|install)
+                [[ ${#SELECTED[@]} -eq 0 ]] && { warn "nothing selected"; continue; }
+                local m; for m in "${SELECTED[@]}"; do
+                    step "Installing $(meta "$m" MODULE_TITLE)"
+                    run_module "$m" module_install || warn "$m did not complete"
+                done
+                SELECTED=() ;;
+            u|update)
+                local m; for m in "${MODULES[@]}"; do
+                    status_line "$m" | grep -q 'not installed' && continue
+                    step "Updating $(meta "$m" MODULE_TITLE)"
+                    run_module "$m" module_update || warn "$m update failed"
+                done ;;
+            c|check)
+                local m; for m in "${MODULES[@]}"; do
+                    status_line "$m" | grep -q 'not installed' && continue
+                    step "$(meta "$m" MODULE_TITLE)"
+                    run_module "$m" module_update --check || true
+                done ;;
+            s|status)
+                local list=() m
+                if [[ ${#SELECTED[@]} -gt 0 ]]; then list=("${SELECTED[@]}"); else list=("${MODULES[@]}"); fi
+                for m in "${list[@]}"; do
+                    step "$(meta "$m" MODULE_TITLE)"
+                    run_module "$m" module_status_long || true
+                done ;;
+            x|uninstall)
+                [[ ${#SELECTED[@]} -eq 0 ]] && { warn "nothing selected"; continue; }
+                warn "about to uninstall: ${SELECTED[*]}"
+                if confirm "are you sure?" "n"; then
+                    local m; for m in "${SELECTED[@]}"; do
+                        step "Removing $(meta "$m" MODULE_TITLE)"
+                        run_module "$m" module_uninstall || warn "$m removal failed"
+                    done
+                    SELECTED=()
+                fi ;;
+            *)
+                local tok idx m
+                for tok in $reply; do
+                    [[ $tok =~ ^[0-9]+$ ]] || { warn "not a number: $tok"; continue; }
+                    idx=$((tok - 1))
+                    [[ $idx -lt 0 || $idx -ge ${#MODULES[@]} ]] && { warn "out of range: $tok"; continue; }
+                    m=${MODULES[$idx]}
+                    if [[ " ${SELECTED[*]:-} " == *" $m "* ]]; then
+                        local keep=() k
+                        for k in "${SELECTED[@]}"; do [[ $k != "$m" ]] && keep+=("$k"); done
+                        SELECTED=("${keep[@]:-}")
+                        [[ -z ${SELECTED[0]:-} ]] && SELECTED=()
+                    else
+                        SELECTED+=("$m")
+                    fi
+                done ;;
+        esac
+    done
+}
+
+# --------------------------------------------------------------- commands --
+
+cmd_list() {
+    discover
+    local tag=${1:-} m
+    for m in "${MODULES[@]}"; do
+        [[ -n $tag && " $(meta "$m" MODULE_TAGS) " != *" $tag "* ]] && continue
+        printf '%s%-24s%s %s\n' "$c_bold" "$m" "$c_reset" "$(meta "$m" MODULE_DESC)"
+        printf '  %sstatus: %s | tags: %s%s\n' \
+            "$c_dim" "$(status_line "$m")" "$(meta "$m" MODULE_TAGS)" "$c_reset"
+    done
+}
+
+cmd_each() { # cmd_each <function> [--check] <modules...>
+    local fn=$1; shift
+    local extra=""
+    [[ ${1:-} == --check ]] && { extra=--check; shift; }
+    discover
+    local list=("$@") m
+    if [[ ${#list[@]} -eq 0 ]]; then
+        for m in "${MODULES[@]}"; do
+            status_line "$m" | grep -q 'not installed' && continue
+            list+=("$m")
+        done
+    fi
+    [[ ${#list[@]} -eq 0 ]] && { warn "no installed modules"; return 0; }
+    for m in "${list[@]}"; do
+        step "$(meta "$m" MODULE_TITLE)"
+        if [[ -n $extra ]]; then
+            run_module "$m" "$fn" "$extra" || warn "$m failed"
+        else
+            run_module "$m" "$fn" || warn "$m failed"
+        fi
+    done
+}
+
+cmd_link() {
+    require_root
+    ln -sfn "$TOOLBOX_ROOT/pve-toolbox" "$TOOLBOX_BIN_DIR/pve-toolbox"
+    ok "linked $TOOLBOX_BIN_DIR/pve-toolbox -> $TOOLBOX_ROOT/pve-toolbox"
+}
+
+cmd_self_update() {
+    [[ -d "$TOOLBOX_ROOT/.git" ]] || die "$TOOLBOX_ROOT is not a git checkout"
+    command -v git >/dev/null 2>&1 || die "git not installed"
+    info "pulling $TOOLBOX_ROOT"
+    git -C "$TOOLBOX_ROOT" pull --ff-only
+    ok "now at $(git -C "$TOOLBOX_ROOT" describe --always --dirty)"
+}
+
+usage() { sed -n '3,20p' "$0" | sed 's/^# \{0,1\}//'; }
+
+# ------------------------------------------------------------------- main --
+
+ARGS=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -y|--yes)   ASSUME_YES=1 ;;
+        -f|--force) FORCE=1 ;;
+        -h|--help)  usage; exit 0 ;;
+        --)         shift; ARGS+=("$@"); break ;;
+        -*)         die "unknown flag: $1" ;;
+        *)          ARGS+=("$1") ;;
+    esac
+    shift
+done
+export ASSUME_YES FORCE TOOLBOX_ROOT
+
+case "${ARGS[0]:-menu}" in
+    menu)        menu ;;
+    list)        cmd_list "${ARGS[@]:1}" ;;
+    install)     [[ ${#ARGS[@]} -lt 2 ]] && die "install needs a module name"
+                 cmd_each module_install "${ARGS[@]:1}" ;;
+    update)      cmd_each module_update "${ARGS[@]:1}" ;;
+    check)       cmd_each module_update --check "${ARGS[@]:1}" ;;
+    status)      cmd_each module_status_long "${ARGS[@]:1}" ;;
+    uninstall)   [[ ${#ARGS[@]} -lt 2 ]] && die "uninstall needs a module name"
+                 cmd_each module_uninstall "${ARGS[@]:1}" ;;
+    link)        cmd_link ;;
+    self-update) cmd_self_update ;;
+    *)           die "unknown command: ${ARGS[0]} (try --help)" ;;
+esac


### PR DESCRIPTION
Brings the toolbox up from the initial commit: the launcher and shared libs, two new ZFS modules, CI, and a documentation site.

## Modules

**`zfs-scrub`** — one timer per pool, staggered a week apart by default. `zpool scrub` returns as soon as the scrub is queued, so a plain oneshot would exit before there was anything to report; the unit stays active for the whole run and polls until the scan ends. Green on a clean scan, yellow on repairs or a non-`ONLINE` pool, red on errors. A scan line can say `0 errors` while zfs still knows about damaged files, so `zpool status -v` is read separately and escalates. Units are namespaced away from the `zfs-scrub@` that `zfsutils-linux` owns, and install offers to disable a conflicting `zfs-scrub-monthly@` timer.

**`zfs-replication`** — syncoid jobs on timers. Success reports duration, growth, target size and snapshot delta; failure reports the exit code and last 25 log lines. `flock` per job so a slow run does not get a second copy stacked on it. Ownership fixups are optional and reported rather than assumed — a requested `chown` that could not be applied finishes yellow instead of claiming success.

## Libraries

`conf_*` sits alongside `state_*`: state is `0644` for what a module knows, conf is `0600` for what an operator set. Conf files stay sourceable, so an installed helper reads one without `lib/common.sh`.

`lib/discord.sh` holds the reporting. Fields are passed as alternating name/value arguments and assembled by `jq`, so a syncoid error full of quotes and backticks arrives intact instead of breaking the request or being stripped.

## CI and docs

`make lint` did not pass before this — a declare-and-assign masking a return value, plus `MODULE_*` metadata that shellcheck cannot see used through `meta()`'s indirect expansion. Both fixed, so the new workflow is green rather than red on arrival. A second job repeats the smoke test in `debian:13`, matching PVE 9.

Nine mkdocs-material pages, built with `--strict` so a broken link fails.

Also fixes a real bug in the launcher: the `module_status_long` fallback ran `module_status; echo; exit $?`, where `$?` was `echo`'s status — it always reported success.

## Testing

Verified in `debian:13` containers with mocked `zpool`, `zfs`, `syncoid` and `systemctl`, and a local webhook receiver:

- both modules install, update through drift (pool/job added and removed), and uninstall leaving nothing behind
- scrub run end-to-end: start and result messages, green/yellow/red paths, the clean-scan-with-damaged-files case, skip when already scrubbing
- replication run end-to-end: success and failure reports, error text with quotes/backticks/backslashes intact
- both runners execute standalone against only the installed `discord.sh`; a missing lib exits 1 with a clear message
- conf round-trip through quotes, `$VAR`, backticks, backslashes, pipes and empty values at mode 600
- scan-line parsing against 10 real `zpool status` formats
- `make lint`, `make test` and `mkdocs build --strict` all pass

## Before merging

The Pages deploy job needs **Settings → Pages → Source: GitHub Actions**. The docs build job passes either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
