### PR TITLE
feat(ui): add full-screen whiptail interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      # TUI_TEST_REQUIRED turns a missing whiptail or expect into a failure
+      # rather than a skip. This is the job that has them, so the ui test has
+      # to run here; make test picks it up without a second pass.
       - run: make test
-
-      # Only here: this job has the whiptail the ui actually runs on.
-      - run: make test-tui
+        env:
+          TUI_TEST_REQUIRED: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,12 @@ jobs:
       - name: Install build deps
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends make git ca-certificates
+          apt-get install -y --no-install-recommends \
+            make git ca-certificates whiptail expect
 
       - uses: actions/checkout@v4
 
       - run: make test
+
+      # Only here: this job has the whiptail the ui actually runs on.
+      - run: make test-tui

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 SHELL := /bin/bash
-# Bash only. completions/_pve-toolbox is zsh, which neither bash -n nor
-# shellcheck can read.
+# Bash only. completions/_pve-toolbox is zsh and tests/tui.exp is Tcl;
+# neither bash -n nor shellcheck can read either.
 FILES := pve-toolbox $(sort $(wildcard lib/*.sh)) $(sort $(wildcard modules/*/*.sh)) \
-         completions/pve-toolbox.bash tests/smoke.sh
+         completions/pve-toolbox.bash $(sort $(wildcard tests/*.sh))
 
-.PHONY: lint syntax test
+.PHONY: lint syntax test test-tui
 
 lint: syntax
 	@command -v shellcheck >/dev/null || { echo "shellcheck not installed: apt install shellcheck"; exit 1; }
@@ -15,3 +15,9 @@ syntax:
 
 test: syntax
 	@./tests/smoke.sh
+	@./tests/tui.sh
+
+# Split out so it can be demanded explicitly; `test` skips it when expect
+# or whiptail is missing.
+test-tui:
+	@TUI_TEST_REQUIRED=1 ./tests/tui.sh

--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ make test-tui  # drive `ui` through a pty, needs whiptail + expect
 ```
 
 CI runs these on every push and pull request, plus the tests again inside a
-`debian:13` container to match the PVE 9 host. The ui test only runs there,
-since that container is the one with whiptail. The docs build with
+`debian:13` container to match the PVE 9 host. The ui test skips wherever
+whiptail is missing, so in practice it runs in that container, where CI marks
+it required rather than skippable. The docs build with
 `mkdocs build --strict`, so a broken internal link fails the build.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -16,14 +16,15 @@ pve-toolbox/
 ├── pve-toolbox              # launcher
 ├── lib/
 │   ├── common.sh            # output, prompts, releases, systemd, state, conf
-│   └── discord.sh           # webhook reporting, also installed for helper scripts
+│   ├── discord.sh           # webhook reporting, also installed for helper scripts
+│   └── tui.sh               # whiptail/dialog widgets for `pve-toolbox ui`
 ├── modules/
 │   ├── _template/           # copy this to start a new module (underscore = hidden)
 │   ├── scrutiny-collectors/ # SMART/ZFS/MDADM collectors for a remote Scrutiny
 │   ├── zfs-scrub/           # scheduled scrub per pool, reported to Discord
 │   └── zfs-replication/     # syncoid jobs on a timer, reported to Discord
 ├── completions/             # bash + zsh completion, installed by `link`
-├── tests/smoke.sh           # what `make test` runs
+├── tests/                   # what `make test` runs, incl. a driven ui test
 ├── docs/                    # mkdocs-material sources
 └── Makefile                 # make syntax / lint / test
 ```
@@ -44,6 +45,7 @@ declare `MODULE_HOST_ONLY=1` and warn if they detect an LXC.
 
 ```
 pve-toolbox                    interactive menu
+pve-toolbox ui                 full-screen menu (needs whiptail)
 pve-toolbox list [tag]         list modules and their status
 pve-toolbox install <mod>...   install specific modules
 pve-toolbox update [mod]...    update (all installed if none given)
@@ -94,13 +96,15 @@ Full contract, helper reference and the Discord reporting API:
 ## Development
 
 ```bash
-make syntax  # bash -n everything
-make lint    # shellcheck everything
-make test    # syntax + tests/smoke.sh against throwaway dirs
+make syntax    # bash -n everything
+make lint      # shellcheck everything
+make test      # syntax + tests/ against throwaway dirs
+make test-tui  # drive `ui` through a pty, needs whiptail + expect
 ```
 
-CI runs all three on every push and pull request, plus the smoke test again
-inside a `debian:13` container to match the PVE 9 host. The docs build with
+CI runs these on every push and pull request, plus the tests again inside a
+`debian:13` container to match the PVE 9 host. The ui test only runs there,
+since that container is the one with whiptail. The docs build with
 `mkdocs build --strict`, so a broken internal link fails the build.
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,9 +58,11 @@ installed, so that TAB can pause for a moment; the others only read metadata.
 
 ## The full-screen ui
 
-`pve-toolbox ui` is the same set of actions behind whiptail, which ships with
-Debian through debconf and so is already on a PVE host. Arrow keys move,
-space toggles a module, Enter confirms, Esc goes back a level.
+`pve-toolbox ui` is the same set of actions behind whiptail, which a PVE host
+already has - it is what debconf draws its prompts with. On a stripped-down
+Debian it may not be there, and `ui` says so rather than guessing; `apt install
+whiptail` is the fix. Arrow keys move, space toggles a module, Enter confirms,
+Esc goes back a level.
 
 ```
                  pve-toolbox
@@ -86,9 +88,11 @@ cannot happen inside a whiptail box, so once something is picked the screen is
 handed back and the module runs exactly as it does from the command line. It
 pauses for a keypress afterwards so the output stays readable.
 
-Set `TUI_BIN=dialog` to use dialog instead. On a terminal neither can draw on
-(`TERM=dumb`, which is what most CI containers set) `ui` refuses with a message
-rather than appearing to quit the moment it starts.
+Set `TUI_BIN=dialog` to use dialog instead; an override that is not installed
+is reported rather than ignored. On a terminal neither can draw on (`TERM=dumb`,
+which is what most CI containers set) `ui` refuses with a message rather than
+appearing to quit the moment it starts - whiptail exits 1 in that case, the same
+code it uses for Cancel, so it has to be caught before the first box.
 
 The numeric menu at `pve-toolbox` with no arguments is unchanged.
 
@@ -142,5 +146,6 @@ make test-tui  # drive `ui` through a pty, needs whiptail + expect
 ```
 
 CI runs these on every push and pull request, plus the tests again inside a
-`debian:13` container to match the PVE 9 host. The ui test only runs there,
-since that container is the one with whiptail.
+`debian:13` container to match the PVE 9 host. The ui test skips wherever
+whiptail is missing, so in practice it runs in that container, where CI marks
+it required rather than skippable.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,6 +16,7 @@ declare `MODULE_HOST_ONLY=1` and warn if they detect an LXC.
 
 ```
 pve-toolbox                    interactive menu
+pve-toolbox ui                 full-screen menu (needs whiptail)
 pve-toolbox list [tag]         list modules and their status
 pve-toolbox install <mod>...   install specific modules
 pve-toolbox update [mod]...    update (all installed if none given)
@@ -54,6 +55,42 @@ second time.
 
 `uninstall` is the one target that has to ask every module whether it is
 installed, so that TAB can pause for a moment; the others only read metadata.
+
+## The full-screen ui
+
+`pve-toolbox ui` is the same set of actions behind whiptail, which ships with
+Debian through debconf and so is already on a PVE host. Arrow keys move,
+space toggles a module, Enter confirms, Esc goes back a level.
+
+```
+                 pve-toolbox
+    Arrows move, Enter chooses, Esc quits.
+
+      install   Install or reconfigure modules
+      update    Update installed modules
+      check     Check for updates, change nothing
+      status    Show detailed status
+      uninstall Remove installed modules
+      quit      Exit
+
+              <Ok>            <Cancel>
+```
+
+Picking an action opens a checklist of the modules it applies to, each with
+its current status. `update`, `check` and `uninstall` only list what is
+actually installed, and say so plainly instead of showing an empty box.
+`uninstall` asks once more before it removes anything.
+
+The widgets only ever *choose*. Modules prompt and print as they work, which
+cannot happen inside a whiptail box, so once something is picked the screen is
+handed back and the module runs exactly as it does from the command line. It
+pauses for a keypress afterwards so the output stays readable.
+
+Set `TUI_BIN=dialog` to use dialog instead. On a terminal neither can draw on
+(`TERM=dumb`, which is what most CI containers set) `ui` refuses with a message
+rather than appearing to quit the moment it starts.
+
+The numeric menu at `pve-toolbox` with no arguments is unchanged.
 
 ## The menu
 
@@ -98,10 +135,12 @@ The per-module pages list the variables each one accepts.
 ## Development
 
 ```bash
-make syntax  # bash -n everything
-make lint    # shellcheck everything
-make test    # syntax + tests/smoke.sh against throwaway dirs
+make syntax    # bash -n everything
+make lint      # shellcheck everything
+make test      # syntax + tests/ against throwaway dirs
+make test-tui  # drive `ui` through a pty, needs whiptail + expect
 ```
 
-CI runs all three on every push and pull request, plus the smoke test again
-inside a `debian:13` container to match the PVE 9 host.
+CI runs these on every push and pull request, plus the tests again inside a
+`debian:13` container to match the PVE 9 host. The ui test only runs there,
+since that container is the one with whiptail.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,12 +12,15 @@ pve-toolbox/
 ├── pve-toolbox              # launcher
 ├── lib/
 │   ├── common.sh            # output, prompts, releases, systemd, state, conf
-│   └── discord.sh           # webhook reporting
+│   ├── discord.sh           # webhook reporting
+│   └── tui.sh               # whiptail widgets behind `pve-toolbox ui`
 ├── modules/
 │   ├── _template/           # copy this to start a new module
 │   ├── scrutiny-collectors/
 │   ├── zfs-scrub/
 │   └── zfs-replication/
+├── completions/             # bash + zsh, installed by `link`
+├── tests/                   # smoke tests, and a pty-driven test for the ui
 └── Makefile                 # make syntax / lint / test
 ```
 
@@ -57,7 +60,15 @@ See [Writing a module](writing-a-module.md#state-versus-config).
     | `/var/lib/pve-toolbox/` | per-module state | `0644` |
     | `/var/log/pve-toolbox/` | per-job logs | `0640` |
     | `/etc/systemd/system/` | units and timers | `0644` |
+    | `/usr/share/bash-completion/completions/` | bash completion symlink | `0644` |
+    | `/usr/share/zsh/vendor-completions/` | zsh completion symlink | `0644` |
 
     Every one of these is overridable — `TOOLBOX_BIN_DIR`, `TOOLBOX_LIB_DIR`,
-    `TOOLBOX_CONF_DIR`, `TOOLBOX_STATE_DIR`, `TOOLBOX_SYSTEMD_DIR` — which is
-    what makes the modules testable off a real host.
+    `TOOLBOX_CONF_DIR`, `TOOLBOX_STATE_DIR`, `TOOLBOX_SYSTEMD_DIR`,
+    `TOOLBOX_BASH_COMPLETION_DIR`, `TOOLBOX_ZSH_COMPLETION_DIR` — which is what
+    makes the modules testable off a real host.
+
+    The two completion paths are the exception to the table: `link` symlinks
+    into them rather than copying, so `self-update` refreshes them, and it
+    skips either directory that is not already there rather than creating a
+    tree for a shell that is not installed.

--- a/docs/reference/common.md
+++ b/docs/reference/common.md
@@ -16,6 +16,8 @@ host:
 | `TOOLBOX_CONF_DIR` | `/etc/pve-toolbox` |
 | `TOOLBOX_STATE_DIR` | `/var/lib/pve-toolbox` |
 | `TOOLBOX_SYSTEMD_DIR` | `/etc/systemd/system` |
+| `TOOLBOX_BASH_COMPLETION_DIR` | `/usr/share/bash-completion/completions` |
+| `TOOLBOX_ZSH_COMPLETION_DIR` | `/usr/share/zsh/vendor-completions` |
 
 ## Output
 

--- a/docs/reference/tui.md
+++ b/docs/reference/tui.md
@@ -1,0 +1,84 @@
+# lib/tui.sh
+
+The whiptail/dialog widgets behind [`pve-toolbox ui`](../getting-started.md#the-full-screen-ui).
+
+Sourced by the launcher on demand rather than at startup — nothing else needs
+it, and completion candidates should not pay for it. Like `lib/common.sh` it
+defines no side effects beyond variables and functions.
+
+Modules never source this. The widgets only ever *choose*; by the time a module
+function runs, the screen has already been handed back.
+
+## Backend
+
+| Variable | Default |
+| --- | --- |
+| `TUI_BIN` | first of `whiptail`, `dialog` found on `PATH` |
+| `TUI_BACKTITLE` | `pve-toolbox` |
+
+`tui_detect`
+: Exit status. Picks a backend and sets `TUI_BIN`. An explicit `TUI_BIN` is
+  checked rather than trusted — see the exit-code note below for why a name
+  that is not installed cannot be diagnosed after the fact.
+
+whiptail is what debconf draws its prompts with, so a PVE host already has it.
+dialog is accepted because for these four widgets the command lines are the
+same.
+
+## Widgets
+
+`tui_menu <title> <text> <tag> <item>...`
+: Prints the chosen tag. Non-zero on Cancel or Esc.
+
+`tui_checklist <title> <text> <tag> <desc> <on|off>...`
+: Prints the checked tags, one per line. Non-zero on Cancel or Esc.
+
+`tui_yesno <title> <text>`
+: Exit status, for use in `if`. Defaults to No.
+
+`tui_msg <title> <text>` · `tui_info <text>`
+: A box to acknowledge, and one that draws and returns immediately.
+
+`tui_clear`
+: Falls back to the escape sequence, because ncurses-bin is not guaranteed
+  just by having libnewt.
+
+## Geometry
+
+`tui_size <rows>`
+: Sets `TUI_H`, `TUI_W` and `TUI_LIST`.
+
+Sized to the terminal, not to the list: a host with forty pools still has to be
+usable in an 80x24 console. Width is capped at 100 and floored at 60, the list
+gets whatever is left after the border, prompt and buttons, and the box height
+is floored at 7 so an implausibly short terminal cannot ask for a negative one.
+
+## Two things whiptail does
+
+!!! warning "It draws on stdout and writes the selection to stderr"
+
+    Capturing a choice means swapping the two, which `tui_capture` does through
+    fd 3. A widget called inside a `$( )` *without* that swap draws into the
+    capture instead of onto the terminal — the box is then invisible and still
+    waiting for a keypress.
+
+    `tui_plain` exists for the widgets with nothing to capture, and sends their
+    screen to stderr so the mistake cannot be made twice. The launcher keeps
+    only `tui_checklist` inside a capture and answers through a global.
+
+!!! warning "It exits 1 on a terminal it cannot draw on"
+
+    Which is also its exit code for Cancel. The two are indistinguishable once
+    a widget has run, so the ui would look like it quit the instant it started.
+
+    Both causes are therefore ruled out before the first box: `TERM` is checked
+    against `dumb`, `unknown` and unset, and an explicit `TUI_BIN` is checked
+    for existence — a missing one exits 127, which is no easier to tell apart.
+
+## Tests
+
+`tests/tui.exp` drives the real launcher through a pty and asserts on what
+reaches the screen, including both cases above. It needs `expect` and
+`whiptail`, and skips without them so `make test` still works anywhere. CI sets
+`TUI_TEST_REQUIRED=1` in the Debian job, where a missing dependency is a
+failure rather than a skip.

--- a/docs/writing-a-module.md
+++ b/docs/writing-a-module.md
@@ -27,13 +27,33 @@ each module carries a `# shellcheck disable=SC2034` above the block.
 | --- | --- |
 | `module_install` | Interactive install or reconfigure |
 | `module_update` | `[--check]` update in place; honours `$FORCE` |
-| `module_status` | Print one short line; exit 1 when not installed |
+| `module_status` | Print one short line; print exactly `not installed` and exit 1 when it is not |
 | `module_status_long` | Detailed status. Optional, falls back to `module_status` |
 | `module_uninstall` | Remove what install created |
 
-`module_status` is called for every module on every menu draw, so keep it
-cheap and make its first word meaningful — the menu shows only that word in
-the `STATUS` column.
+`module_status` is called for every module on every menu draw, on every
+`ui` action, and by `uninstall` completion, so keep it cheap and make its first
+word meaningful — the menu shows only that word in the `STATUS` column.
+
+!!! warning "`not installed` is compared exactly"
+
+    `update` and `check` given no module names, every list the `ui` builds,
+    and `uninstall` completion all decide what to operate on by asking whether
+    the status is the string `not installed`. Printing nothing and exiting
+    non-zero means the same thing, and is the safe default if there is nothing
+    useful to say.
+
+    Anything else counts as installed, including a longer line that happens to
+    contain the words — `1 of 3 pools not installed` reads as *installed*.
+    Report a partial state through the wording of an installed status instead:
+
+    ```bash
+    module_status() {
+        _my_scheduled
+        [[ ${#MY_SCHEDULED[@]} -eq 0 ]] && { printf 'not installed'; return 1; }
+        printf 'pools:%d' "${#MY_SCHEDULED[@]}"
+    }
+    ```
 
 ## Two rules
 
@@ -136,5 +156,14 @@ make lint
 make test
 ```
 
-`make lint` runs `shellcheck -x -S warning` over the launcher, `lib/*.sh` and
-every `modules/*/*.sh`, so a helper script is linted too.
+`make lint` runs `shellcheck -x -S warning` over the launcher, `lib/*.sh`,
+every `modules/*/*.sh`, the bash completion and `tests/*.sh`, so a helper
+script you add is linted too. The zsh completion and `tests/tui.exp` are left
+out — neither is bash.
+
+`make test` runs `tests/smoke.sh`, which drives the launcher in place and
+through a symlink against throwaway directories, then `tests/tui.sh`, which
+drives `ui` through a pty. The ui test skips where `expect` or `whiptail` is
+missing; `make test-tui` demands them instead. CI gets the same effect by
+setting `TUI_TEST_REQUIRED=1` on `make test` in the Debian job, which is the
+one that has them.

--- a/lib/tui.sh
+++ b/lib/tui.sh
@@ -16,7 +16,13 @@ TUI_BACKTITLE="${TUI_BACKTITLE:-pve-toolbox}"
 # dialog is accepted too: for the four widgets used here the command lines are
 # the same, and some people have it instead.
 tui_detect() {
-    [[ -n $TUI_BIN ]] && return 0
+    # An override that is not installed exits 127, and once a widget has run
+    # that is as indistinguishable from Cancel as anything else, so check it
+    # here rather than finding out silently later.
+    if [[ -n $TUI_BIN ]]; then
+        command -v "$TUI_BIN" >/dev/null 2>&1
+        return
+    fi
     local c
     for c in whiptail dialog; do
         if command -v "$c" >/dev/null 2>&1; then
@@ -48,6 +54,7 @@ tui_size() { # tui_size <rows> -> sets TUI_H TUI_W TUI_LIST
 
     TUI_H=$(( TUI_LIST + 9 ))
     (( TUI_H > lines - 2 )) && TUI_H=$(( lines - 2 ))
+    (( TUI_H < 7 )) && TUI_H=7
 }
 
 # ---------------------------------------------------------------- widgets --

--- a/lib/tui.sh
+++ b/lib/tui.sh
@@ -1,0 +1,97 @@
+# shellcheck shell=bash
+#
+# lib/tui.sh - whiptail/dialog front end for `pve-toolbox ui`.
+#
+# Sourced by the launcher on demand, not at startup: nothing else needs it,
+# and `_complete` should not pay for it. Defines no side effects beyond
+# variable and function definitions.
+#
+[[ -n ${_TOOLBOX_TUI_LOADED:-} ]] && return 0
+_TOOLBOX_TUI_LOADED=1
+
+TUI_BIN="${TUI_BIN:-}"
+TUI_BACKTITLE="${TUI_BACKTITLE:-pve-toolbox}"
+
+# whiptail arrives with debconf, so it is on every Debian and every PVE host.
+# dialog is accepted too: for the four widgets used here the command lines are
+# the same, and some people have it instead.
+tui_detect() {
+    [[ -n $TUI_BIN ]] && return 0
+    local c
+    for c in whiptail dialog; do
+        if command -v "$c" >/dev/null 2>&1; then
+            TUI_BIN=$c
+            return 0
+        fi
+    done
+    return 1
+}
+
+# --------------------------------------------------------------- geometry --
+
+# Fit the box to the terminal rather than to the list: a host with 40 pools
+# still has to be usable in an 80x24 console.
+tui_size() { # tui_size <rows> -> sets TUI_H TUI_W TUI_LIST
+    local rows=$1 lines cols max
+    lines=$(tput lines 2>/dev/null) || lines=24
+    cols=$(tput cols 2>/dev/null) || cols=80
+
+    TUI_W=$(( cols - 8 ))
+    (( TUI_W > 100 )) && TUI_W=100
+    (( TUI_W < 60 )) && TUI_W=60
+
+    # 9 lines go to the border, the prompt text and the buttons.
+    max=$(( lines - 12 ))
+    (( max < 3 )) && max=3
+    TUI_LIST=$rows
+    (( TUI_LIST > max )) && TUI_LIST=$max
+
+    TUI_H=$(( TUI_LIST + 9 ))
+    (( TUI_H > lines - 2 )) && TUI_H=$(( lines - 2 ))
+}
+
+# ---------------------------------------------------------------- widgets --
+
+# The widgets draw on stdout and put the selection on stderr, so the two are
+# swapped through fd 3 to capture what was chosen without eating the screen.
+tui_capture() { "$TUI_BIN" --backtitle "$TUI_BACKTITLE" "$@" 3>&1 1>&2 2>&3; }
+
+# Exit status only, so nothing to capture - but the screen still goes to
+# stderr rather than stdout. Called inside a $( ) an unredirected widget draws
+# into the capture instead of onto the terminal, which leaves an invisible box
+# sitting there waiting for a keypress.
+tui_plain() { "$TUI_BIN" --backtitle "$TUI_BACKTITLE" "$@" 1>&2; }
+
+tui_menu() { # tui_menu <title> <text> <tag> <item>... -> prints the tag
+    local title=$1 text=$2; shift 2
+    tui_size $(( $# / 2 ))
+    tui_capture --title "$title" --menu "$text" \
+        "$TUI_H" "$TUI_W" "$TUI_LIST" "$@"
+}
+
+tui_checklist() { # tui_checklist <title> <text> <tag> <desc> <on|off>... -> tags, one per line
+    local title=$1 text=$2; shift 2
+    tui_size $(( $# / 3 ))
+    tui_capture --title "$title" --separate-output --checklist "$text" \
+        "$TUI_H" "$TUI_W" "$TUI_LIST" "$@"
+}
+
+tui_yesno() { # tui_yesno <title> <text> - defaults to No
+    tui_size 0
+    tui_plain --title "$1" --defaultno --yesno "$2" "$TUI_H" "$TUI_W"
+}
+
+tui_msg() { # tui_msg <title> <text>
+    tui_size 0
+    tui_plain --title "$1" --msgbox "$2" "$TUI_H" "$TUI_W"
+}
+
+# Draws and returns immediately, for the pause while module_status runs.
+tui_info() { # tui_info <text>
+    tui_size 0
+    tui_plain --infobox "$1" 7 "$TUI_W"
+}
+
+# ncurses-bin is not guaranteed just because libnewt is, so fall back to the
+# escape sequence rather than leaving the widget's screen on the terminal.
+tui_clear() { command clear 2>/dev/null || printf '\033[H\033[2J'; }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,3 +70,4 @@ nav:
   - Reference:
       - lib/common.sh: reference/common.md
       - lib/discord.sh: reference/discord.md
+      - lib/tui.sh: reference/tui.md

--- a/modules/_template/module.sh
+++ b/modules/_template/module.sh
@@ -16,7 +16,11 @@
 #   Functions:
 #     module_install      interactive install / reconfigure
 #     module_update       [--check] update in place; honours $FORCE
-#     module_status       one line for the menu; exit 1 if not installed
+#     module_status       one line for the menu; print exactly 'not installed'
+#                         and exit 1 if it is not. That string is compared
+#                         exactly to decide what update/uninstall/ui act on,
+#                         so a longer line merely containing the words counts
+#                         as installed.
 #     module_status_long  detailed status (optional, falls back to status)
 #     module_uninstall    remove what install created
 #

--- a/pve-toolbox
+++ b/pve-toolbox
@@ -80,8 +80,17 @@ run_module() { # run_module <module> <function> [args...]
     )
 }
 
-status_line() { # status_line <module> -> prints short status
-    run_module "$1" module_status 2>/dev/null || true
+status_line() { # status_line <module> -> short status, "not installed" if it is not
+    local st
+    st=$(run_module "$1" module_status 2>/dev/null) || true
+    printf '%s' "${st:-not installed}"
+}
+
+# The one reading of "installed", for the menu, the ui, completion and the
+# command line. module_status is contracted to exit 1 when a module is not
+# installed, and a module that prints nothing at all is not installed either.
+is_installed() { # is_installed <module>
+    [[ $(status_line "$1") != "not installed" ]]
 }
 
 # ------------------------------------------------------------------- menu --
@@ -95,7 +104,7 @@ print_table() {
         st=$(status_line "$m")
         local mark="   "
         [[ " ${SELECTED[*]:-} " == *" $m "* ]] && mark=" ${c_green}*${c_reset} "
-        if [[ $st == "not installed" || -z $st ]]; then
+        if [[ $st == "not installed" ]]; then
             printf '%s%2d) %-24s %s%-11s%s %s\n' "$mark" "$i" "$title" "$c_dim" "-" "$c_reset" "$desc"
         else
             printf '%s%2d) %-24s %s%-11s%s %s\n' "$mark" "$i" "$title" "$c_green" "${st%% *}" "$c_reset" "$desc"
@@ -134,13 +143,13 @@ menu() {
                 SELECTED=() ;;
             u|update)
                 local m; for m in "${MODULES[@]}"; do
-                    status_line "$m" | grep -q 'not installed' && continue
+                    is_installed "$m" || continue
                     step "Updating $(meta "$m" MODULE_TITLE)"
                     run_module "$m" module_update || warn "$m update failed"
                 done ;;
             c|check)
                 local m; for m in "${MODULES[@]}"; do
-                    status_line "$m" | grep -q 'not installed' && continue
+                    is_installed "$m" || continue
                     step "$(meta "$m" MODULE_TITLE)"
                     run_module "$m" module_update --check || true
                 done ;;
@@ -202,7 +211,7 @@ cmd_each() { # cmd_each <function> [--check] <modules...>
     local list=("$@") m
     if [[ ${#list[@]} -eq 0 ]]; then
         for m in "${MODULES[@]}"; do
-            status_line "$m" | grep -q 'not installed' && continue
+            is_installed "$m" || continue
             list+=("$m")
         done
     fi
@@ -239,7 +248,6 @@ ui_pick() { # ui_pick <title> <all|installed> <on|off> -> sets UI_PICKED
     tui_info "Reading module status..."
     for m in "${MODULES[@]}"; do
         st=$(status_line "$m")
-        [[ -z $st ]] && st="not installed"
         [[ $pool == installed && $st == "not installed" ]] && continue
         items+=("$m" "$(meta "$m" MODULE_TITLE) - $st" "$default")
     done
@@ -258,7 +266,11 @@ ui_run() { # ui_run <fn> <modules> [extra-arg]
     while IFS= read -r m; do
         [[ -z $m ]] && continue
         step "$(meta "$m" MODULE_TITLE)"
-        if [[ -n $extra ]]; then
+        if [[ $fn == module_status_long ]]; then
+            # module_status exits 1 to mean "not installed". That is what the
+            # status action is there to report, not a failure to announce.
+            run_module "$m" "$fn" || true
+        elif [[ -n $extra ]]; then
             run_module "$m" "$fn" "$extra" || warn "$m failed"
         else
             run_module "$m" "$fn" || warn "$m failed"
@@ -293,7 +305,9 @@ cmd_ui() {
     source "$TOOLBOX_ROOT/lib/tui.sh"
     tui_detect || die "ui needs whiptail or dialog (apt install whiptail)"
     discover
-    TUI_BACKTITLE="pve-toolbox @ $(hostname -s)"
+    local host
+    host=$(hostname -s 2>/dev/null) || host=""
+    TUI_BACKTITLE="pve-toolbox${host:+ @ $host}"
 
     local choice
     while true; do
@@ -345,7 +359,7 @@ link_completions() {
 # Candidates for the completion scripts. Separate from `list` because that
 # prints a status per module, and a TAB press should not shell out to zpool.
 cmd_complete() { # cmd_complete <commands|modules|installed|tags>
-    local m st
+    local m
     local -a tags
     case ${1:-} in
         commands)
@@ -355,9 +369,10 @@ cmd_complete() { # cmd_complete <commands|modules|installed|tags>
             discover; printf '%s\n' "${MODULES[@]}" ;;
         installed)
             discover
+            # An if, not an &&: with nothing installed the last iteration
+            # would otherwise decide the exit status.
             for m in "${MODULES[@]}"; do
-                st=$(status_line "$m")
-                [[ -n $st && $st != "not installed" ]] && printf '%s\n' "$m"
+                if is_installed "$m"; then printf '%s\n' "$m"; fi
             done ;;
         tags)
             discover

--- a/pve-toolbox
+++ b/pve-toolbox
@@ -3,6 +3,7 @@
 # pve-toolbox - interactive launcher for custom Proxmox scripts.
 #
 #   pve-toolbox                    interactive menu
+#   pve-toolbox ui                 full-screen menu (needs whiptail)
 #   pve-toolbox list [tag]         list modules
 #   pve-toolbox install <mod>...   install specific modules
 #   pve-toolbox update [mod]...    update (all installed if none given)
@@ -216,6 +217,104 @@ cmd_each() { # cmd_each <function> [--check] <modules...>
     done
 }
 
+# ------------------------------------------------------------------- ui --
+
+# Modules prompt and print while they work, which cannot happen inside a
+# whiptail box, so the widgets only ever choose. Once something is chosen the
+# screen is handed back and the module runs exactly as it does from the
+# command line.
+
+# Answers through UI_PICKED instead of stdout, so only the checklist is ever
+# inside a $( ). A widget called in a capture draws into the pipe rather than
+# onto the screen, and the box is then invisible but still waiting.
+UI_PICKED=""
+
+ui_pick() { # ui_pick <title> <all|installed> <on|off> -> sets UI_PICKED
+    local title=$1 pool=$2 default=$3
+    local -a items=()
+    local m st
+    UI_PICKED=""
+
+    # One module_status per module, and some of them shell out to zpool.
+    tui_info "Reading module status..."
+    for m in "${MODULES[@]}"; do
+        st=$(status_line "$m")
+        [[ -z $st ]] && st="not installed"
+        [[ $pool == installed && $st == "not installed" ]] && continue
+        items+=("$m" "$(meta "$m" MODULE_TITLE) - $st" "$default")
+    done
+
+    if [[ ${#items[@]} -eq 0 ]]; then
+        tui_msg "$title" "No modules are installed."
+        return 1
+    fi
+    UI_PICKED=$(tui_checklist "$title" \
+        "Space toggles, Enter confirms, Esc goes back." "${items[@]}")
+}
+
+ui_run() { # ui_run <fn> <modules> [extra-arg]
+    local fn=$1 picked=$2 extra=${3:-} m
+    tui_clear
+    while IFS= read -r m; do
+        [[ -z $m ]] && continue
+        step "$(meta "$m" MODULE_TITLE)"
+        if [[ -n $extra ]]; then
+            run_module "$m" "$fn" "$extra" || warn "$m failed"
+        else
+            run_module "$m" "$fn" || warn "$m failed"
+        fi
+    done <<<"$picked"
+    echo
+    read -rsn1 -p "press any key to go back to the menu " _ || true
+    echo
+}
+
+ui_action() { # ui_action <title> <fn> <pool> <default> [extra-arg]
+    local title=$1 fn=$2 pool=$3 default=$4 extra=${5:-}
+    ui_pick "$title" "$pool" "$default" || return 0
+    [[ -z $UI_PICKED ]] && return 0
+    if [[ $fn == module_uninstall ]]; then
+        tui_yesno "Uninstall" \
+            "About to remove:"$'\n\n'"$UI_PICKED"$'\n\n'"Continue?" || return 0
+    fi
+    ui_run "$fn" "$UI_PICKED" "$extra"
+}
+
+cmd_ui() {
+    [[ -t 0 && -t 1 ]] || die "ui needs a terminal, try 'pve-toolbox list'"
+    # whiptail exits 1 on a terminal it cannot draw on, which is also its exit
+    # code for Cancel. There is no telling the two apart once a widget has run,
+    # and the ui would look like it quit the instant it started, so rule the
+    # case out up front.
+    case ${TERM:-} in
+        ""|dumb|unknown) die "ui needs a capable terminal, TERM is '${TERM:-unset}'" ;;
+    esac
+    # shellcheck source=lib/tui.sh
+    source "$TOOLBOX_ROOT/lib/tui.sh"
+    tui_detect || die "ui needs whiptail or dialog (apt install whiptail)"
+    discover
+    TUI_BACKTITLE="pve-toolbox @ $(hostname -s)"
+
+    local choice
+    while true; do
+        choice=$(tui_menu "pve-toolbox" "Arrows move, Enter chooses, Esc quits." \
+            install   "Install or reconfigure modules" \
+            update    "Update installed modules" \
+            check     "Check for updates, change nothing" \
+            status    "Show detailed status" \
+            uninstall "Remove installed modules" \
+            quit      "Exit") || { tui_clear; return 0; }
+        case $choice in
+            install)   ui_action "Install / reconfigure" module_install     all       off ;;
+            update)    ui_action "Update"                module_update      installed on  ;;
+            check)     ui_action "Check for updates"     module_update      installed on --check ;;
+            status)    ui_action "Status"                module_status_long all       on  ;;
+            uninstall) ui_action "Uninstall"             module_uninstall   installed off ;;
+            quit)      tui_clear; return 0 ;;
+        esac
+    done
+}
+
 cmd_link() {
     require_root
     ln -sfn "$TOOLBOX_ROOT/pve-toolbox" "$TOOLBOX_BIN_DIR/pve-toolbox"
@@ -250,7 +349,7 @@ cmd_complete() { # cmd_complete <commands|modules|installed|tags>
     local -a tags
     case ${1:-} in
         commands)
-            printf '%s\n' menu list install update check status uninstall \
+            printf '%s\n' menu ui list install update check status uninstall \
                 link self-update ;;
         modules)
             discover; printf '%s\n' "${MODULES[@]}" ;;
@@ -310,6 +409,7 @@ case "${ARGS[0]:-menu}" in
     status)      cmd_each module_status_long "${ARGS[@]:1}" ;;
     uninstall)   [[ ${#ARGS[@]} -lt 2 ]] && die "uninstall needs a module name"
                  cmd_each module_uninstall "${ARGS[@]:1}" ;;
+    ui)          cmd_ui ;;
     link)        cmd_link ;;
     _complete)   cmd_complete "${ARGS[@]:1}" ;;
     self-update) cmd_self_update ;;

--- a/tests/tui.exp
+++ b/tests/tui.exp
@@ -8,9 +8,15 @@ set timeout 25
 log_user 0
 spawn ./pve-toolbox ui
 
+# expect_out is set in the calling scope, so a match made inside a proc is not
+# visible outside it. Hand the matched span out through a global for the
+# assertions that need to look at what was on the screen.
+set seen ""
+
 proc need {pat what} {
+    global seen
     expect {
-        -re $pat { puts "ok  $what" }
+        -re $pat { puts "ok  $what"; set seen $expect_out(buffer) }
         timeout  { puts "FAIL timeout: $what"; exit 1 }
         eof      { puts "FAIL eof: $what"; exit 1 }
     }
@@ -42,19 +48,25 @@ need {Space toggles} "status checklist"
 send -- "\r"
 need {not installed}                  "module output on the terminal"
 need {press any key to go back}       "pause after running"
+
+# module_status exits 1 for "not installed", which is the answer the status
+# action exists to give. Announcing it as a failure is the bug this guards.
+if {[string match {*failed*} $seen]} {
+    puts "FAIL status announced a not-installed module as failed"; exit 1
+}
+puts "ok  status does not call not-installed a failure"
 send -- " "
 need {Install or reconfigure modules} "keypress returns to the menu"
 
-# unchecking everything is not an action
-send -- "\033\[B"
-send -- "\033\[B"
-send -- "\033\[B"
+# Confirming an empty selection is not an action. Driven through 'install',
+# where every box starts off, so this does not depend on how many modules the
+# repo happens to ship.
 send -- "\r"
-need {Space toggles} "status checklist again"
-send -- " \033\[B \033\[B \r"
+need {Space toggles} "install checklist"
+send -- "\r"
 need {Install or reconfigure modules} "empty selection returns to the menu"
 
-# quit entry
+# quit entry, five rows down from install
 send -- "\033\[B"
 send -- "\033\[B"
 send -- "\033\[B"
@@ -65,6 +77,18 @@ expect eof
 catch wait result
 set code [lindex $result 3]
 if {$code == 0} { puts "ok  quit exits 0" } else { puts "FAIL exit $code"; exit 1 }
+
+# An override that is not installed exits 127, which after a widget has run
+# is as indistinguishable from Cancel as anything else. It has to be caught
+# before the first widget, or the ui just clears the screen and exits 0.
+set env(TUI_BIN) definitely-not-installed
+spawn ./pve-toolbox ui
+need {whiptail or dialog} "rejects a TUI_BIN that is not installed"
+expect eof
+catch wait result
+set code [lindex $result 3]
+if {$code == 1} { puts "ok  bad TUI_BIN exits 1" } else { puts "FAIL exit $code"; exit 1 }
+unset env(TUI_BIN)
 
 # A terminal whiptail cannot draw on has to say so. It exits 1 there, the same
 # code it uses for Cancel, so without the guard the ui would look like it quit

--- a/tests/tui.exp
+++ b/tests/tui.exp
@@ -1,0 +1,78 @@
+# Keystroke-level drive of `pve-toolbox ui`. Run through tests/tui.sh, which
+# handles the dependency check and TERM.
+#
+# Menu entries are chosen by counting Down presses, so reordering the menu in
+# cmd_ui means reordering the sends here.
+#
+set timeout 25
+log_user 0
+spawn ./pve-toolbox ui
+
+proc need {pat what} {
+    expect {
+        -re $pat { puts "ok  $what" }
+        timeout  { puts "FAIL timeout: $what"; exit 1 }
+        eof      { puts "FAIL eof: $what"; exit 1 }
+    }
+}
+
+need {Install or reconfigure modules} "menu renders"
+need {Remove installed modules}       "menu lists uninstall"
+
+# 'update' with nothing installed -> the empty-pool message, not a checklist
+send -- "\033\[B"
+send -- "\r"
+need {No modules are installed} "empty pool message"
+send -- "\r"
+need {Install or reconfigure modules} "back at the menu"
+
+# 'install' -> checklist of every module, Esc backs out without running
+send -- "\r"
+need {Space toggles}  "checklist prompt"
+need {zfs-scrub}      "checklist lists a module"
+send -- "\033"
+need {Install or reconfigure modules} "Esc returns to the menu"
+
+# 'status' -> all pre-checked -> runs on the real terminal, then pauses
+send -- "\033\[B"
+send -- "\033\[B"
+send -- "\033\[B"
+send -- "\r"
+need {Space toggles} "status checklist"
+send -- "\r"
+need {not installed}                  "module output on the terminal"
+need {press any key to go back}       "pause after running"
+send -- " "
+need {Install or reconfigure modules} "keypress returns to the menu"
+
+# unchecking everything is not an action
+send -- "\033\[B"
+send -- "\033\[B"
+send -- "\033\[B"
+send -- "\r"
+need {Space toggles} "status checklist again"
+send -- " \033\[B \033\[B \r"
+need {Install or reconfigure modules} "empty selection returns to the menu"
+
+# quit entry
+send -- "\033\[B"
+send -- "\033\[B"
+send -- "\033\[B"
+send -- "\033\[B"
+send -- "\033\[B"
+send -- "\r"
+expect eof
+catch wait result
+set code [lindex $result 3]
+if {$code == 0} { puts "ok  quit exits 0" } else { puts "FAIL exit $code"; exit 1 }
+
+# A terminal whiptail cannot draw on has to say so. It exits 1 there, the same
+# code it uses for Cancel, so without the guard the ui would look like it quit
+# the moment it started.
+set env(TERM) dumb
+spawn ./pve-toolbox ui
+need {ui needs a capable terminal} "refuses TERM=dumb"
+expect eof
+catch wait result
+set code [lindex $result 3]
+if {$code == 1} { puts "ok  TERM=dumb exits 1" } else { puts "FAIL exit $code"; exit 1 }

--- a/tests/tui.sh
+++ b/tests/tui.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Drives `pve-toolbox ui` through a pty and checks what it draws.
+#
+# Needs expect and whiptail. Missing either, this skips: `make test` has to
+# keep working on a machine with neither. CI sets TUI_TEST_REQUIRED=1 so a
+# missing dependency there is a failure rather than a quiet pass.
+#
+set -euo pipefail
+
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
+
+for cmd in expect whiptail; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        if [[ ${TUI_TEST_REQUIRED:-0} -eq 1 ]]; then
+            printf 'FAIL tui test required but %s is not installed\n' "$cmd" >&2
+            exit 1
+        fi
+        printf 'skip tui test, no %s\n' "$cmd"
+        exit 0
+    fi
+done
+
+# A container - CI included - normally sets TERM=dumb, which whiptail refuses
+# to draw on, so an unset TERM is not the only case to cover here.
+case ${TERM:-} in
+    ""|dumb|unknown) export TERM=xterm ;;
+esac
+
+exec expect tests/tui.exp


### PR DESCRIPTION
Adds `pve-toolbox ui`, a full-screen interface over the actions that already exist. The numeric menu and every subcommand are untouched.

## What it does

whiptail menu → checklist of the modules that action applies to, each with its current status → the module runs. Arrows move, space toggles, Enter confirms, Esc goes back a level.

- `update`, `check` and `uninstall` list only what is installed, and say so plainly rather than showing an empty box
- `uninstall` confirms before removing anything
- `TUI_BIN=dialog` switches backends; whiptail arrives with debconf so it is already on a PVE host

The widgets only ever *choose*. Modules prompt and print while they work, which cannot happen inside a whiptail box, so once something is picked the screen is handed back and the module runs exactly as it does from the command line, then pauses for a keypress.

## Two whiptail behaviours worth knowing

Both were found by driving the UI, and both are covered by tests.

**It draws on stdout and writes the selection to stderr**, so capturing a choice means swapping the two. A widget called inside a `$( )` that does not swap draws into the capture instead of onto the terminal — an invisible box, still waiting for a keypress. `ui_pick` therefore answers through a global with only the checklist captured, and `tui_plain` sends its screen to stderr so the same mistake cannot be made twice.

**It exits 1 on a terminal it cannot draw on**, which is also its exit code for Cancel. The two are indistinguishable afterwards, so the UI looked like it quit the instant it started. `TERM` is checked up front instead. Not hypothetical: containers, CI included, normally set `TERM=dumb`.

## Tests

`tests/tui.exp` drives the whole thing through a pty and checks what lands on the screen: the menu, the empty-pool message, the checklist, Esc at both levels, a module actually running, the pause, an empty selection, quit, and the `TERM=dumb` refusal. 16 checks.

It skips when expect or whiptail is missing, so `make test` still works anywhere. CI sets `TUI_TEST_REQUIRED=1` in the debian job — the one that has whiptail — so a missing dependency there fails rather than passing quietly.

```
make lint      # clean
make test      # skips the ui test locally
make test-tui  # 16/16 in a debian:13 container
```