### PR TITLE
fix(core): compare versions with the leading v stripped

### DIFF
--- a/docs/modules/scrutiny-collectors.md
+++ b/docs/modules/scrutiny-collectors.md
@@ -38,6 +38,26 @@ rolled back, state stays at the old version and the run says which ones.
 
 Release assets are checksum-verified when the release ships a checksum file.
 
+### What `check` reports
+
+`check` writes nothing, and answers before `-f` is considered — forcing a
+reinstall is an `update` decision, not a reporting one.
+
+| Installed vs release | Reported |
+| --- | --- |
+| Same release | `up to date` |
+| Release is newer | `update available: <installed> -> <tag>` |
+| Release is older | `<tag> is older than the installed <version>` |
+
+The last row is reachable rather than theoretical: `SCRUTINY_VERSION` pins a
+tag, so a `check` against a pinned older release says so instead of calling it
+an update. Run `update` on the same pair and it warns and asks before going
+ahead.
+
+Versions are compared with the leading `v` stripped, because the release tag
+carries one and `<collector> --version` does not — `1.69.1` and `v1.69.1` are
+one release, not an available update.
+
 ## Env vars for `-y`
 
 | Variable | Meaning |

--- a/docs/reference/common.md
+++ b/docs/reference/common.md
@@ -90,8 +90,21 @@ See [State versus config](../writing-a-module.md#state-versus-config).
 `rollback_binary <target>`
 : Restores `<target>.prev`.
 
+`version_bare <version>`
+: Strips a leading `v` or `V`. A release tag carries one and `--version` output
+  usually does not, so the same release arrives spelled two ways.
+
 `is_newer <candidate> <current>`
-: Version sort, so a downgrade can be caught and confirmed.
+: Version sort with both sides stripped, so a downgrade can be caught and
+  confirmed. An exact tie is not newer. An empty or `unknown` *current* means
+  anything is an upgrade; an empty or `unknown` *candidate* is never one.
+
+    !!! note "Prereleases"
+
+        `sort -V` on its own puts `1.70.0-rc1` *above* `1.70.0`, which would
+        make a stable release read as a downgrade from its own candidate. It
+        does sort `~` below everything, so `is_newer` maps `-` across before
+        comparing and a prerelease sorts under the release it belongs to.
 
 ## systemd
 

--- a/docs/writing-a-module.md
+++ b/docs/writing-a-module.md
@@ -142,7 +142,7 @@ Everything in `lib/common.sh` is already sourced:
 `info` `ok` `warn` `die` `step` `dim` · `ask` `ask_yn` `ask_secret` `confirm` ·
 `require_root` `require_pve` `in_lxc` · `detect_arch` `pkg_ensure` `have_zfs`
 `have_mdadm` · `gh_release` `install_release_binary` `rollback_binary`
-`is_newer` · `state_*` `conf_*` · `systemd_oneshot` `systemd_remove`
+`version_bare` `is_newer` · `state_*` `conf_*` · `systemd_oneshot` `systemd_remove`
 `wait_for_idle` `run_unit` · `backup_file` `install_toolbox_lib` ·
 [`discord_notify`](reference/discord.md)
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -219,15 +219,21 @@ rollback_binary() { # rollback_binary <target-name>
 
 # A release tag usually carries a leading v; `--version` output usually does
 # not. Compare the two bare, or v1.69.1 reads as an update over 1.69.1.
-version_bare() { printf '%s' "${1#v}"; }
+version_bare() { printf '%s' "${1#[vV]}"; }
 
 # is_newer <candidate> <current> -> 0 if candidate sorts strictly above current
 is_newer() {
-    local a=${1#v} b=${2#v}
-    [[ -z $b || $b == unknown ]] && return 0
+    local a b
+    a=$(version_bare "$1"); b=$(version_bare "$2")
+    [[ -z $a || $a == unknown ]] && return 1   # nothing to offer
+    [[ -z $b || $b == unknown ]] && return 0   # nothing known to beat
     # sort -V puts equal versions at the tail too, so a tie has to be caught
     # here rather than left to the comparison below.
     [[ $a == "$b" ]] && return 1
+    # sort -V has no notion of a prerelease: it puts 1.70.0-rc1 *above* 1.70.0,
+    # so a stable release would read as a downgrade from its own candidate. It
+    # does sort ~ below everything, which is the ordering wanted, so borrow it.
+    a=${a//-/\~}; b=${b//-/\~}
     [[ $(printf '%s\n%s\n' "$a" "$b" | sort -V | tail -n1) == "$a" ]]
 }
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -217,13 +217,18 @@ rollback_binary() { # rollback_binary <target-name>
     warn "rolled back $1"
 }
 
+# A release tag usually carries a leading v; `--version` output usually does
+# not. Compare the two bare, or v1.69.1 reads as an update over 1.69.1.
+version_bare() { printf '%s' "${1#v}"; }
+
 # is_newer <candidate> <current> -> 0 if candidate sorts strictly above current
 is_newer() {
-    [[ $1 == "$2" ]] && return 1
-    [[ -z $2 || $2 == unknown ]] && return 0
-    local top
-    top=$(printf '%s\n%s\n' "${1#v}" "${2#v}" | sort -V | tail -n1)
-    [[ $top == "${1#v}" ]]
+    local a=${1#v} b=${2#v}
+    [[ -z $b || $b == unknown ]] && return 0
+    # sort -V puts equal versions at the tail too, so a tie has to be caught
+    # here rather than left to the comparison below.
+    [[ $a == "$b" ]] && return 1
+    [[ $(printf '%s\n%s\n' "$a" "$b" | sort -V | tail -n1) == "$a" ]]
 }
 
 # ------------------------------------------------------------------ state --

--- a/modules/scrutiny-collectors/module.sh
+++ b/modules/scrutiny-collectors/module.sh
@@ -63,6 +63,15 @@ _sc_installed() {
     return 0
 }
 
+# _sc_compare <installed> <tag> -> same | upgrade | downgrade
+#
+# Pure, so the decision `update` and `check` share can be tested without a
+# release API or an installed collector.
+_sc_compare() {
+    [[ $(version_bare "$1") == "$(version_bare "$2")" ]] && { printf 'same'; return 0; }
+    if is_newer "$2" "$1"; then printf 'upgrade'; else printf 'downgrade'; fi
+}
+
 _sc_version() {
     local v
     v=$(state_get "$MODULE_NAME" VERSION)
@@ -220,17 +229,25 @@ module_update() {
     printf '  installed  %s (%s)\n' "$current" "${SC_PRESENT[*]}"
     printf '  available  %s\n' "$GH_TAG"
 
-    if [[ $(version_bare "$current") == "$(version_bare "$GH_TAG")" \
-          && ${FORCE:-0} -eq 0 ]]; then
-        ok "up to date"
-        return 0
-    fi
+    local rel; rel=$(_sc_compare "$current" "$GH_TAG")
+
+    # -f means "reinstall anyway", not "report differently", so check answers
+    # before FORCE is consulted - otherwise `-f check` claims an update to the
+    # release already installed.
     if [[ $check_only -eq 1 ]]; then
-        info "update available: $current -> $GH_TAG"
+        case $rel in
+            same)      ok "up to date"; return 0 ;;
+            upgrade)   info "update available: $current -> $GH_TAG" ;;
+            downgrade) warn "$GH_TAG is older than the installed $current" ;;
+        esac
         dim "  https://github.com/$REPO/releases/tag/$GH_TAG"
         return 0
     fi
-    if ! is_newer "$GH_TAG" "$current" && [[ ${FORCE:-0} -eq 0 ]]; then
+    if [[ $rel == same && ${FORCE:-0} -eq 0 ]]; then
+        ok "up to date"
+        return 0
+    fi
+    if [[ $rel == downgrade && ${FORCE:-0} -eq 0 ]]; then
         warn "$GH_TAG is not newer than $current - this would be a downgrade"
         confirm "proceed anyway?" "n" || return 0
     fi

--- a/modules/scrutiny-collectors/module.sh
+++ b/modules/scrutiny-collectors/module.sh
@@ -220,7 +220,8 @@ module_update() {
     printf '  installed  %s (%s)\n' "$current" "${SC_PRESENT[*]}"
     printf '  available  %s\n' "$GH_TAG"
 
-    if [[ $current == "$GH_TAG" && ${FORCE:-0} -eq 0 ]]; then
+    if [[ $(version_bare "$current") == "$(version_bare "$GH_TAG")" \
+          && ${FORCE:-0} -eq 0 ]]; then
         ok "up to date"
         return 0
     fi

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -82,6 +82,16 @@ pass "bash completion"
 
 # --- version comparison -----------------------------------------------------
 
+# Sourced in-process, so point every path at a throwaway first. Without this
+# the rest of the file inherits /usr/local/bin and /var/lib/pve-toolbox, and
+# anything added below could write to the host it is testing on.
+TOOLBOX_BIN_DIR=$(tmp)
+TOOLBOX_LIB_DIR=$(tmp)
+TOOLBOX_CONF_DIR=$(tmp)
+TOOLBOX_STATE_DIR=$(tmp)
+TOOLBOX_SYSTEMD_DIR=$(tmp)
+export TOOLBOX_BIN_DIR TOOLBOX_LIB_DIR TOOLBOX_CONF_DIR TOOLBOX_STATE_DIR TOOLBOX_SYSTEMD_DIR
+
 # shellcheck source=lib/common.sh
 source "$ROOT/lib/common.sh"
 
@@ -112,4 +122,40 @@ newer_is 1.9.0  1.10.0 no
 newer_is 1.0.0 ""        yes
 newer_is 1.0.0 "unknown" yes
 
+# ...but an unknown candidate is not an upgrade over anything.
+newer_is ""        1.0.0     no
+newer_is "unknown" 1.0.0     no
+newer_is "unknown" "unknown" no
+
+# sort -V puts 1.70.0-rc1 above 1.70.0 on its own; a prerelease has to sort
+# below the release it is a candidate for.
+newer_is 1.70.0-rc1 1.70.0     no
+newer_is 1.70.0     1.70.0-rc1 yes
+newer_is 1.70.0-rc2 1.70.0-rc1 yes
+
 pass "version comparison"
+
+# --- the update/check decision ----------------------------------------------
+
+# module.sh is contracted to be side-effect free at source time, which is what
+# lets this be tested without a release API or an installed collector.
+# shellcheck source=modules/scrutiny-collectors/module.sh
+source "$ROOT/modules/scrutiny-collectors/module.sh"
+
+compare_is() { # compare_is <installed> <tag> <expected>
+    local got; got=$(_sc_compare "$1" "$2")
+    [[ $got == "$3" ]] || fail "_sc_compare '$1' '$2' returned $got, wanted $3"
+}
+
+# The reported bug: one release, two spellings, reported as an update.
+compare_is 1.69.1 v1.69.1 same
+compare_is v1.69.1 1.69.1 same
+compare_is 1.69.1 1.69.1  same
+
+compare_is 1.69.1 v1.70.0 upgrade
+compare_is 1.70.0 v1.69.1 downgrade
+
+# An install that predates the state file reports unknown; anything beats it.
+compare_is unknown v1.69.1 upgrade
+
+pass "update decision"

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -79,3 +79,37 @@ got=$(complete_words 2 ./pve-toolbox link "")
 [[ -z $got ]] || fail "link takes no arguments, got: $got"
 
 pass "bash completion"
+
+# --- version comparison -----------------------------------------------------
+
+# shellcheck source=lib/common.sh
+source "$ROOT/lib/common.sh"
+
+# is_newer <candidate> <current> <expected yes|no>
+newer_is() {
+    local got=no
+    is_newer "$1" "$2" && got=yes
+    [[ $got == "$3" ]] || fail "is_newer '$1' '$2' returned $got, wanted $3"
+}
+
+# A release tag carries a leading v and `--version` output does not, so the
+# two arrive spelled differently for the same release. Comparing them raw made
+# every check report the installed version as an available update.
+newer_is v1.69.1 1.69.1  no
+newer_is 1.69.1  v1.69.1 no
+newer_is 1.69.1  1.69.1  no
+newer_is v1.69.1 v1.69.1 no
+
+newer_is v1.70.0 1.69.1  yes
+newer_is 1.70.0  v1.69.1 yes
+newer_is 1.69.1  1.70.0  no
+
+# Version order, not string order.
+newer_is 1.10.0 1.9.0  yes
+newer_is 1.9.0  1.10.0 no
+
+# Nothing known about the current version means anything is an upgrade.
+newer_is 1.0.0 ""        yes
+newer_is 1.0.0 "unknown" yes
+
+pass "version comparison"


### PR DESCRIPTION
Reported from a live host:

```
Scrutiny collectors
  installed  1.69.1 (metrics zfs performance)
  available  v1.69.1
==> update available: 1.69.1 -> v1.69.1
```

Same release, two spellings — a GitHub tag carries a leading `v`, `--version` output does not. Two comparisons took them raw.

## `is_newer` (`lib/common.sh`)

```bash
is_newer() {
    [[ $1 == "$2" ]] && return 1          # runs before the v is stripped
    ...
    top=$(printf '%s\n%s\n' "${1#v}" "${2#v}" | sort -V | tail -n1)
    [[ $top == "${1#v}" ]]                # true for a tie, not just a win
}
```

Two defects, either of which is enough on its own:

- the equality guard compares raw strings, so `v1.69.1` and `1.69.1` are never recognised as the same release
- `sort -V | tail -n1` returns the candidate on a tie, so the final test is "sorts above **or equal**", contradicting the function's own `-> 0 if candidate sorts strictly above current`

Normalising first and catching the tie explicitly fixes both.

## The scrutiny module's up-to-date check

`if [[ $current == "$GH_TAG" && ... ]]` compared the same two spellings raw, so the `ok up to date` short-circuit never fired and `update` offered to reinstall the release already on disk. Goes through the new `version_bare` now.

## Impact

Low — the worst case was re-downloading a release already installed. But `check` reported an update on every single run, which is the one thing it exists to report truthfully.

## Tests

`tests/smoke.sh` gains a table for `is_newer`:

| case | why |
|---|---|
| `v1.69.1` vs `1.69.1`, and reversed | the reported bug, both directions |
| `1.69.1` vs `1.69.1`, `v1.69.1` vs `v1.69.1` | ties |
| `v1.70.0` vs `1.69.1` | a real upgrade still reads as one |
| `1.69.1` vs `1.70.0` | a downgrade does not |
| `1.10.0` vs `1.9.0`, and reversed | guards the version sort against regressing to a string sort |
| `1.0.0` vs `""` and `unknown` | nothing known means anything is an upgrade |

Verified the table fails without the fix:

```
FAIL is_newer 'v1.69.1' '1.69.1' returned yes, wanted no
```

`make lint` and `make test` pass locally and in a `debian:13` container, ui suite included.