### PR TITLE
fix(ui): let a module's prompts reach the terminal

### DIFF
--- a/modules/zfs-scrub/module.sh
+++ b/modules/zfs-scrub/module.sh
@@ -310,6 +310,9 @@ module_update() {
 
     local missing=() stale=() p
     if have_zfs; then
+        # `done <` redirects stdin for the whole body, so nothing in here may
+        # prompt - ask and confirm would read pool names instead of the
+        # operator, and bash hides a read prompt when stdin is not a terminal.
         while read -r p; do
             [[ -n $p ]] || continue
             [[ " ${ZS_SCHEDULED[*]} " == *" $p "* ]] || missing+=("$p")

--- a/pve-toolbox
+++ b/pve-toolbox
@@ -262,9 +262,19 @@ ui_pick() { # ui_pick <title> <all|installed> <on|off> -> sets UI_PICKED
 
 ui_run() { # ui_run <fn> <modules> [extra-arg]
     local fn=$1 picked=$2 extra=${3:-} m
-    tui_clear
+    local -a mods=()
+
+    # Collect the whole list before running anything. `done <<<` redirects
+    # stdin for the entire loop body, so a module's ask/ask_secret/confirm
+    # would read the remains of this list rather than the terminal - and since
+    # ask swallows a failed read and keeps its default, every prompt in an
+    # install would flash past unanswered.
     while IFS= read -r m; do
-        [[ -z $m ]] && continue
+        [[ -n $m ]] && mods+=("$m")
+    done <<<"$picked"
+
+    tui_clear
+    for m in "${mods[@]}"; do
         step "$(meta "$m" MODULE_TITLE)"
         if [[ $fn == module_status_long ]]; then
             # module_status exits 1 to mean "not installed". That is what the
@@ -275,7 +285,7 @@ ui_run() { # ui_run <fn> <modules> [extra-arg]
         else
             run_module "$m" "$fn" || warn "$m failed"
         fi
-    done <<<"$picked"
+    done
     echo
     read -rsn1 -p "press any key to go back to the menu " _ || true
     echo

--- a/tests/tui.exp
+++ b/tests/tui.exp
@@ -2,7 +2,12 @@
 # handles the dependency check and TERM.
 #
 # Menu entries are chosen by counting Down presses, so reordering the menu in
-# cmd_ui means reordering the sends here.
+# cmd_ui means reordering the sends here. The module checklist is navigated the
+# same way; tests/tui.sh asserts the module ordering before this runs, so a
+# module added to the repo fails there rather than being installed here by
+# mistake. Do not try to assert it from the screen instead - the checklist
+# renders every module's title, so matching one proves nothing about which row
+# is selected.
 #
 set timeout 25
 log_user 0
@@ -84,9 +89,12 @@ if {$code == 0} { puts "ok  quit exits 0" } else { puts "FAIL exit $code"; exit 
 # list, hit EOF, and silently kept their defaults. An install could not be
 # configured at all through the ui.
 #
-# zfs-scrub is the third module and prompts via require_pve on a host with no
-# pveversion. Answering it only gets as far as the zpool check if the answer
-# was actually read.
+# zfs-scrub is driven because it prompts early, through require_pve, and then
+# stops at have_zfs. Both of those depend on what the host does *not* have -
+# no pveversion, so there is a prompt; no zpool, so the run stops before it
+# installs anything. That holds on debian:13 and in a PVE-less container; it
+# would not hold on a real PVE host, which is why tests/tui.sh points every
+# TOOLBOX_*_DIR at a throwaway before this runs.
 if {[info exists env(TUI_TEST_ROOT)] && $env(TUI_TEST_ROOT) == 1} {
     spawn ./pve-toolbox ui
     need {Install or reconfigure modules} "menu, for the prompt case"

--- a/tests/tui.exp
+++ b/tests/tui.exp
@@ -78,6 +78,36 @@ catch wait result
 set code [lindex $result 3]
 if {$code == 0} { puts "ok  quit exits 0" } else { puts "FAIL exit $code"; exit 1 }
 
+# A module's own prompts have to reach the terminal. ui_run iterated the picked
+# list with `while read ... done <<<`, which redirects stdin for the whole loop
+# body - so ask/ask_secret/confirm inside a module read the remains of that
+# list, hit EOF, and silently kept their defaults. An install could not be
+# configured at all through the ui.
+#
+# zfs-scrub is the third module and prompts via require_pve on a host with no
+# pveversion. Answering it only gets as far as the zpool check if the answer
+# was actually read.
+if {[info exists env(TUI_TEST_ROOT)] && $env(TUI_TEST_ROOT) == 1} {
+    spawn ./pve-toolbox ui
+    need {Install or reconfigure modules} "menu, for the prompt case"
+    send -- "\r"
+    need {Space toggles} "install checklist"
+    send -- "\033\[B\033\[B"
+    send -- " "
+    send -- "\r"
+    need {continue anyway} "a module prompt reaches the terminal"
+    send -- "y\r"
+    need {no zpool binary} "the answer was read rather than defaulted"
+    need {press any key to go back} "back to the pause"
+    send -- " "
+    need {Install or reconfigure modules} "back at the menu"
+    send -- "\033"
+    expect eof
+    puts "ok  install prompts are answerable"
+} else {
+    puts "skip install prompt case, not root"
+}
+
 # An override that is not installed exits 127, which after a widget has run
 # is as indistinguishable from Cancel as anything else. It has to be caught
 # before the first widget, or the ui just clears the screen and exits 0.

--- a/tests/tui.sh
+++ b/tests/tui.sh
@@ -27,4 +27,10 @@ case ${TERM:-} in
     ""|dumb|unknown) export TERM=xterm ;;
 esac
 
+# The interactive-install case needs require_root to pass before a module gets
+# as far as prompting. CI runs as root in the container; someone running
+# `make test-tui` on their laptop usually does not, so that one case is gated
+# rather than made to fail.
+if [[ $EUID -eq 0 ]]; then export TUI_TEST_ROOT=1; else export TUI_TEST_ROOT=0; fi
+
 exec expect tests/tui.exp

--- a/tests/tui.sh
+++ b/tests/tui.sh
@@ -27,10 +27,45 @@ case ${TERM:-} in
     ""|dumb|unknown) export TERM=xterm ;;
 esac
 
-# The interactive-install case needs require_root to pass before a module gets
-# as far as prompting. CI runs as root in the container; someone running
-# `make test-tui` on their laptop usually does not, so that one case is gated
-# rather than made to fail.
-if [[ $EUID -eq 0 ]]; then export TUI_TEST_ROOT=1; else export TUI_TEST_ROOT=0; fi
+# Same contract as smoke.sh: nothing here may touch the host it runs on. This
+# matters more than it used to - the install case drives a real module_install
+# as root, and without these it would write to /etc/pve-toolbox,
+# /usr/local/bin and /etc/systemd/system for real. Today it only gets as far
+# as the zpool check, but that is a property of the image, not of the test.
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+for d in BIN LIB CONF STATE SYSTEMD; do
+    printf -v "TOOLBOX_${d}_DIR" '%s' "$(mktemp -d "$WORK/XXXXXX")"
+    export "TOOLBOX_${d}_DIR"
+done
 
-exec expect tests/tui.exp
+# The install case needs require_root to pass before a module gets as far as
+# prompting. CI runs as root in the container; someone running `make test-tui`
+# on their laptop usually does not, so it is skipped there rather than made to
+# fail - but where the suite is declared required, a silent skip of the one
+# case covering an operator-visible bug is not acceptable either.
+if [[ $EUID -eq 0 ]]; then
+    export TUI_TEST_ROOT=1
+elif [[ ${TUI_TEST_REQUIRED:-0} -eq 1 ]]; then
+    printf 'FAIL tui test required but not running as root\n' >&2
+    exit 1
+else
+    export TUI_TEST_ROOT=0
+fi
+
+# tui.exp reaches zfs-scrub by counting rows in the module checklist, and the
+# screen cannot be used to confirm which row is selected - the checklist draws
+# every module's title, so matching one proves nothing. Assert the ordering
+# here, where it is cheap and fails before anything is driven, rather than
+# finding out by answering a prompt belonging to another module.
+want=3
+got=$(./pve-toolbox _complete modules | grep -nx 'zfs-scrub' | cut -d: -f1)
+if [[ $got != "$want" ]]; then
+    printf 'FAIL tui.exp expects zfs-scrub at row %s of the module list, found %s\n' \
+        "$want" "${got:-no row}" >&2
+    exit 1
+fi
+
+# Not exec'd: that would replace this shell and the cleanup trap would never
+# run.
+expect tests/tui.exp


### PR DESCRIPTION
Reported: the ui does not allow interactive configuration while installing a module.

Confirmed — and worse than it sounds. The prompts were not merely defaulted, they were never displayed.

## Cause

`ui_run` walked the picked modules with:

```bash
while IFS= read -r m; do
    ...
    run_module "$m" "$fn" || warn "$m failed"
done <<<"$picked"
```

`done <<<` redirects stdin for the **whole loop body**, not just the `read`. So every module function ran with stdin attached to the leftovers of that list instead of the terminal.

`ask`/`ask_yn` use `read -r -p`, and bash displays a `read` prompt *only when stdin is a terminal*. With the herestring attached the prompt was suppressed, the read hit EOF, `|| true` swallowed the failure, and the default was taken. From the operator's side the install ran to completion having asked nothing at all.

The command line was never affected — `cmd_each` iterates an array with a plain `for` and redirects nothing, which is why `pve-toolbox install <mod>` always worked.

## Fix

Collect the list into an array before running anything, so the redirection is over by the time a module starts.

Reproduced against a throwaway module that asks one question, before and after:

```
TUI, before:  PROBE_GOT[THE-DEFAULT]        <- never waited
TUI, after:   PROBE_GOT[typed-in-the-tui]
CLI, either:  PROBE_GOT[typed-on-stdin]
```

## Test

`tests/tui.exp` now drives a real install: pick `zfs-scrub`, which prompts through `require_pve` on a host with no `pveversion`, answer `y`, and check the run reaches the zpool check — which it can only do if the answer was actually read rather than defaulted.

That case needs `require_root` to pass, so `tests/tui.sh` gates it on `EUID` and skips it for anyone running `make test-tui` as themselves. CI runs as root in the Debian container, where it does run.

Verified failing without the fix:

```
FAIL timeout: a module prompt reaches the terminal
```

`make lint` and `make test` pass locally and in `debian:13`.