### PR TITLE
test: cover the untested half of the library and the command line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y --no-install-recommends \
-            make git ca-certificates whiptail expect
+            make git ca-certificates whiptail expect zsh
 
       - uses: actions/checkout@v4
 
@@ -51,3 +51,4 @@ jobs:
       - run: make test
         env:
           TUI_TEST_REQUIRED: "1"
+          ZSH_TEST_REQUIRED: "1"

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ syntax:
 
 test: syntax
 	@./tests/lib.sh
+	@./tests/discord.sh
 	@./tests/smoke.sh
 	@./tests/completion-zsh.sh
 	@./tests/tui.sh

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,9 @@ syntax:
 	@for f in $(FILES); do bash -n $$f && echo "ok  $$f"; done
 
 test: syntax
+	@./tests/lib.sh
 	@./tests/smoke.sh
+	@./tests/completion-zsh.sh
 	@./tests/tui.sh
 
 # Split out so it can be demanded explicitly; `test` skips it when expect

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -242,14 +242,22 @@ is_newer() {
 _state_file() { printf '%s/%s.state' "$TOOLBOX_STATE_DIR" "$1"; }
 
 state_set() { # state_set <module> <key> <value>
-    local f; f=$(_state_file "$1")
+    local f tmp; f=$(_state_file "$1")
     mkdir -p "$TOOLBOX_STATE_DIR"
-    touch "$f"; chmod 0644 "$f"
-    if grep -q "^$2=" "$f" 2>/dev/null; then
-        sed -i "s|^$2=.*|$2=$3|" "$f"
-    else
-        printf '%s=%s\n' "$2" "$3" >> "$f"
-    fi
+    [[ -f $f ]] || : > "$f"
+    tmp=$(mktemp)
+    # Same shape as conf_set, and for the same reason. The value went through
+    # `sed s|^K=.*|K=$3|` before, which read & as "the whole match", ate
+    # backslashes, and died outright on a |, leaving the old value in place
+    # and the error on stderr where nothing looked at it.
+    _STATE_V=$3 awk -v k="$2" '
+        $0 ~ "^" k "=" { print k "=" ENVIRON["_STATE_V"]; found = 1; next }
+        { print }
+        END { if (!found) print k "=" ENVIRON["_STATE_V"] }
+    ' "$f" > "$tmp"
+    cat "$tmp" > "$f"
+    rm -f "$tmp"
+    chmod 0644 "$f"
 }
 
 state_get() { # state_get <module> <key>

--- a/pve-toolbox
+++ b/pve-toolbox
@@ -218,7 +218,12 @@ cmd_each() { # cmd_each <function> [--check] <modules...>
     [[ ${#list[@]} -eq 0 ]] && { warn "no installed modules"; return 0; }
     for m in "${list[@]}"; do
         step "$(meta "$m" MODULE_TITLE)"
-        if [[ -n $extra ]]; then
+        if [[ $fn == module_status_long ]]; then
+            # module_status exits 1 to mean "not installed", which is the
+            # answer status was asked for. Naming a module that is not
+            # installed is a legitimate thing to do; it is not a failure.
+            run_module "$m" "$fn" || true
+        elif [[ -n $extra ]]; then
             run_module "$m" "$fn" "$extra" || warn "$m failed"
         else
             run_module "$m" "$fn" || warn "$m failed"

--- a/tests/completion-zsh.sh
+++ b/tests/completion-zsh.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# The zsh completion, driven the way zsh would drive it.
+#
+# completions/_pve-toolbox is the only shipped file nothing else covers. It is
+# zsh, so neither `bash -n` nor the linter can read it, and the bash completion
+# tests in smoke.sh say nothing about it. The two are meant to offer the same
+# candidates, so the cases here mirror those.
+#
+# Needs zsh, and skips without it. CI sets ZSH_TEST_REQUIRED=1 where zsh is
+# installed, so a missing dependency there fails rather than passing quietly.
+#
+set -euo pipefail
+
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
+
+if ! command -v zsh >/dev/null 2>&1; then
+    if [[ ${ZSH_TEST_REQUIRED:-0} -eq 1 ]]; then
+        printf 'FAIL zsh completion test required but zsh is not installed\n' >&2
+        exit 1
+    fi
+    printf 'skip zsh completion test, no zsh\n'
+    exit 0
+fi
+
+# The completion file is autoloaded by zsh with #compdef and ends by calling
+# the function it defines. Loading the body without that trailing call lets
+# _pve-toolbox be invoked directly with a hand-built `words`/`CURRENT`, and
+# compadd is replaced with something that prints what it was handed.
+zsh -f -e -c '
+cd '"$PWD"'
+fail() { print -r -- "FAIL $1"; exit 1 }
+
+eval "${$(<completions/_pve-toolbox)%%$'"'"'\n'"'"'_pve-toolbox \"\$@\"*}"
+
+compadd() {
+    # The real compadd takes -a <arrayname>; print what that array holds.
+    local -a a; a=(${(P)2})
+    print -r -- "${a[*]}"
+}
+
+# offers <cword> <word>... -> the candidates, space separated
+offers() {
+    local cur=$1; shift
+    words=("$@"); CURRENT=$cur
+    _pve-toolbox || print -r -- ""
+}
+
+got=$(offers 2 ./pve-toolbox "")
+[[ $got == *" install "* || $got == install* ]] || fail "no commands offered: $got"
+[[ $got == *ui* ]] || fail "ui missing from the commands: $got"
+print "ok  zsh offers commands"
+
+got=$(offers 3 ./pve-toolbox install "")
+[[ $got == *zfs-scrub* ]] || fail "no modules offered for install: $got"
+print "ok  zsh offers modules after install"
+
+got=$(offers 4 ./pve-toolbox install zfs-scrub "")
+[[ $got != *zfs-scrub* ]] || fail "re-offered a module already on the line: $got"
+[[ $got == *zfs-replication* ]] || fail "dropped the modules still available: $got"
+print "ok  zsh drops what is already on the line"
+
+got=$(offers 3 ./pve-toolbox list "")
+[[ $got == *storage* ]] || fail "no tags offered for list: $got"
+print "ok  zsh offers tags after list"
+
+got=$(offers 4 ./pve-toolbox list storage "")
+[[ -z $got ]] || fail "list takes one tag, got: $got"
+print "ok  zsh stops after one tag"
+
+# Flags are accepted anywhere, so the command is the first non-flag word.
+got=$(offers 4 ./pve-toolbox -y install "")
+[[ $got == *zfs-scrub* ]] || fail "a flag before the command broke it: $got"
+print "ok  zsh finds the command past a flag"
+
+for verb in ui link self-update; do
+    got=$(offers 3 ./pve-toolbox $verb "")
+    [[ -z $got ]] || fail "$verb takes no arguments, got: $got"
+done
+print "ok  zsh offers nothing for argumentless commands"
+'

--- a/tests/completion-zsh.sh
+++ b/tests/completion-zsh.sh
@@ -5,7 +5,10 @@
 # completions/_pve-toolbox is the only shipped file nothing else covers. It is
 # zsh, so neither `bash -n` nor the linter can read it, and the bash completion
 # tests in smoke.sh say nothing about it. The two are meant to offer the same
-# candidates, so the cases here mirror those.
+# candidates, so the cases here mirror those - except prefix filtering, which
+# zsh does itself rather than the script, and flags, which go through _values
+# rather than compadd. Both are covered on the bash side, where compgen and
+# COMPREPLY make them observable.
 #
 # Needs zsh, and skips without it. CI sets ZSH_TEST_REQUIRED=1 where zsh is
 # installed, so a missing dependency there fails rather than passing quietly.
@@ -46,10 +49,13 @@ offers() {
     _pve-toolbox || print -r -- ""
 }
 
+has() { [[ " $1 " == *" $2 "* ]] }
+
 got=$(offers 2 ./pve-toolbox "")
-[[ $got == *" install "* || $got == install* ]] || fail "no commands offered: $got"
-[[ $got == *ui* ]] || fail "ui missing from the commands: $got"
-print "ok  zsh offers commands"
+for verb in menu ui list install update check status uninstall link self-update; do
+    has $got $verb || fail "commands missing $verb: $got"
+done
+print "ok  zsh offers every command"
 
 got=$(offers 3 ./pve-toolbox install "")
 [[ $got == *zfs-scrub* ]] || fail "no modules offered for install: $got"
@@ -60,8 +66,18 @@ got=$(offers 4 ./pve-toolbox install zfs-scrub "")
 [[ $got == *zfs-replication* ]] || fail "dropped the modules still available: $got"
 print "ok  zsh drops what is already on the line"
 
+for verb in update check status; do
+    got=$(offers 3 ./pve-toolbox $verb "")
+    has $got zfs-scrub || fail "$verb offered no modules: $got"
+done
+print "ok  zsh offers modules for update, check and status"
+
+got=$(offers 3 ./pve-toolbox uninstall "")
+[[ -z $got ]] || fail "uninstall offered a module in a bare checkout: $got"
+print "ok  zsh offers only installed modules for uninstall"
+
 got=$(offers 3 ./pve-toolbox list "")
-[[ $got == *storage* ]] || fail "no tags offered for list: $got"
+has $got storage || fail "no tags offered for list: $got"
 print "ok  zsh offers tags after list"
 
 got=$(offers 4 ./pve-toolbox list storage "")
@@ -73,7 +89,7 @@ got=$(offers 4 ./pve-toolbox -y install "")
 [[ $got == *zfs-scrub* ]] || fail "a flag before the command broke it: $got"
 print "ok  zsh finds the command past a flag"
 
-for verb in ui link self-update; do
+for verb in menu ui link self-update definitely-not-a-command; do
     got=$(offers 3 ./pve-toolbox $verb "")
     [[ -z $got ]] || fail "$verb takes no arguments, got: $got"
 done

--- a/tests/discord.sh
+++ b/tests/discord.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# Tests for lib/discord.sh.
+#
+# Only the payload builders, which are pure. discord_notify's delivery path
+# needs a webhook and is not exercised here; its no-webhook branch is, since
+# that is the one every module hits on a host that was never configured.
+#
+# The point of assembling the payload with jq rather than by hand is that a
+# value holding quotes, backticks, backslashes or newlines survives instead of
+# breaking the JSON. That claim is what most of this file checks.
+#
+set -euo pipefail
+
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
+ROOT=$PWD
+
+command -v jq >/dev/null 2>&1 || { printf 'skip discord tests, no jq\n'; exit 0; }
+
+pass() { printf 'ok  %s\n' "$1"; }
+fail() { printf 'FAIL %s\n' "$1" >&2; exit 1; }
+
+# shellcheck source=lib/discord.sh
+source "$ROOT/lib/discord.sh"
+
+# jq field accessors, so a failure names the path that was wrong.
+at() { jq -r "$1" <<<"$2"; }
+
+# --- the payload is JSON at all ----------------------------------------------
+
+payload=$(discord_payload "$DISCORD_OK" "Title" "Body" "Pool" "rpool")
+jq -e . >/dev/null 2>&1 <<<"$payload" || fail "payload is not valid JSON: $payload"
+[[ $(at '.embeds | length' "$payload") == 1 ]] || fail "expected one embed"
+[[ $(at '.embeds[0].title' "$payload") == Title ]] || fail "title did not survive"
+[[ $(at '.embeds[0].description' "$payload") == Body ]] || fail "description did not survive"
+pass "discord_payload builds one embed"
+
+# The colour is --argjson, so it has to arrive as a number. Discord rejects a
+# string, and it would only be noticed on a live webhook.
+[[ $(at '.embeds[0].color | type' "$payload") == number ]] || fail "color is not a number"
+[[ $(at '.embeds[0].color' "$payload") == "$DISCORD_OK" ]] || fail "color did not survive"
+pass "colour is a number"
+
+[[ -n $(at '.embeds[0].footer.text' "$payload") ]] || fail "footer is empty"
+pass "footer is set"
+
+# --- values that would break hand-built JSON ---------------------------------
+
+AWKWARD=(
+    'say "hi"'
+    "it's"
+    'a\b'
+    'back`tick`'
+    'brace}and{brace'
+    'new
+line'
+    'tab	separated'
+    'emoji ✅ and ümlaut'
+    '{"looks":"like json"}'
+    '$(whoami) `id`'
+)
+
+for v in "${AWKWARD[@]}"; do
+    p=$(discord_payload "$DISCORD_ERR" "$v" "$v" "Field" "$v")
+    jq -e . >/dev/null 2>&1 <<<"$p" || fail "payload broke on [$v]"
+    [[ $(at '.embeds[0].title' "$p")           == "$v" ]] || fail "title mangled [$v]"
+    [[ $(at '.embeds[0].description' "$p")     == "$v" ]] || fail "description mangled [$v]"
+    [[ $(at '.embeds[0].fields[0].value' "$p") == "$v" ]] || fail "field value mangled [$v]"
+done
+pass "quotes, newlines, backslashes and unicode survive the round trip"
+
+# --- fields ------------------------------------------------------------------
+
+p=$(discord_payload "$DISCORD_INFO" t d "One" "1" "Two" "2")
+[[ $(at '.embeds[0].fields | length' "$p") == 2 ]] || fail "expected two fields"
+[[ $(at '.embeds[0].fields[0].name' "$p")  == One ]] || fail "first field name"
+[[ $(at '.embeds[0].fields[1].value' "$p") == 2 ]] || fail "second field value"
+[[ $(at '.embeds[0].fields[0].inline' "$p") == true ]] || fail "fields are not inline"
+pass "field pairs map to name and value"
+
+p=$(discord_payload "$DISCORD_INFO" t d)
+[[ $(at '.embeds[0].fields | length' "$p") == 0 ]] || fail "no pairs should mean no fields"
+pass "no field pairs is an empty array"
+
+# An empty value would render as a blank box, and an odd trailing name has no
+# value at all; both become a dash rather than nothing.
+p=$(discord_payload "$DISCORD_INFO" t d "Empty" "" "Dangling")
+[[ $(at '.embeds[0].fields[0].value' "$p") == - ]] || fail "empty value is not a dash"
+[[ $(at '.embeds[0].fields[1].value' "$p") == - ]] || fail "missing value is not a dash"
+[[ $(at '.embeds[0].fields[1].name' "$p") == Dangling ]] || fail "dangling name was dropped"
+pass "empty and missing field values become a dash"
+
+# --- Discord's limits --------------------------------------------------------
+
+long=$(printf 'x%.0s' $(seq 1 5000))
+p=$(discord_payload "$DISCORD_WARN" "$long" "$long" "Field" "$long")
+[[ $(at '.embeds[0].title' "$p" | wc -c) -le $((DISCORD_MAX_TITLE + 1)) ]] \
+    || fail "title was not truncated to $DISCORD_MAX_TITLE"
+[[ $(at '.embeds[0].description' "$p" | wc -c) -le $((DISCORD_MAX_DESC + 1)) ]] \
+    || fail "description was not truncated to $DISCORD_MAX_DESC"
+[[ $(at '.embeds[0].fields[0].value' "$p" | wc -c) -le $((DISCORD_MAX_FIELD + 1)) ]] \
+    || fail "field value was not truncated to $DISCORD_MAX_FIELD"
+jq -e . >/dev/null 2>&1 <<<"$p" || fail "truncated payload is not valid JSON"
+pass "title, description and fields are truncated to Discord's limits"
+
+# --- discord_fence -----------------------------------------------------------
+
+fenced=$(discord_fence "line one")
+[[ $fenced == '```'* ]] || fail "fence does not open with a code block"
+[[ $fenced == *'```' ]] || fail "fence does not close with a code block"
+[[ $fenced == *"line one"* ]] || fail "fence lost its content"
+pass "discord_fence wraps in a code block"
+
+# A log tail is what gets fenced, so an over-long one must keep the end.
+fenced=$(discord_fence "$(printf 'HEAD%s TAIL' "$(printf 'x%.0s' $(seq 1 200))")" 50)
+[[ $fenced == *TAIL* ]] || fail "fence trimmed the tail instead of the head"
+[[ $fenced != *HEAD* ]] || fail "fence kept the head, so it trimmed the wrong end"
+pass "discord_fence keeps the tail when it has to trim"
+
+# --- discord_notify without a webhook ----------------------------------------
+
+# The path every module takes on a host nobody configured. It must not attempt
+# delivery, must say so, and must report failure so a --test mode can be loud.
+out=$(discord_notify "" "$DISCORD_OK" "Some title" "body" 2>&1) && rc=0 || rc=$?
+[[ $rc -eq 1 ]] || fail "discord_notify with no webhook returned $rc, wanted 1"
+[[ $out == *"no Discord webhook configured"* ]] || fail "no explanation given: $out"
+[[ $out == *"Some title"* ]] || fail "the message that went unsent was not named: $out"
+pass "discord_notify without a webhook fails loudly and sends nothing"

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+#
+# Tests for lib/common.sh: the helpers modules are told to build on.
+#
+# Everything here is pure or writes only into a throwaway directory, so it
+# runs anywhere `make test` does - no root, no systemd, no network.
+#
+set -euo pipefail
+
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
+ROOT=$PWD
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+pass() { printf 'ok  %s\n' "$1"; }
+fail() { printf 'FAIL %s\n' "$1" >&2; exit 1; }
+
+# GNU stat on the target, BSD stat on the machine this is usually written on.
+mode_of() { # mode_of <path> -> permission bits, octal
+    stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"
+}
+
+# Nothing may reach the host: these are the paths the helpers write to.
+TOOLBOX_BIN_DIR=$(mktemp -d "$WORK/XXXXXX")
+TOOLBOX_LIB_DIR=$(mktemp -d "$WORK/XXXXXX")
+TOOLBOX_CONF_DIR=$(mktemp -d "$WORK/XXXXXX")
+TOOLBOX_STATE_DIR=$(mktemp -d "$WORK/XXXXXX")
+TOOLBOX_SYSTEMD_DIR=$(mktemp -d "$WORK/XXXXXX")
+export TOOLBOX_BIN_DIR TOOLBOX_LIB_DIR TOOLBOX_CONF_DIR TOOLBOX_STATE_DIR \
+       TOOLBOX_SYSTEMD_DIR
+
+# shellcheck source=lib/common.sh
+source "$ROOT/lib/common.sh"
+
+# The values that have historically broken one storage layer or another: shell
+# metacharacters, sed replacement syntax, and awk -v escape expansion.
+AWKWARD=(
+    'hello'
+    'a|b'
+    'a&b'
+    "it's"
+    'say "hi"'
+    'a\b'
+    'a`b`'
+    'a$HOME'
+    'a  b'
+    'a=b=c'
+    'https://discord.com/api/webhooks/123/aB-c_dE'
+    '/mnt/pool/some dir'
+)
+
+# --- conf: what the operator set ---------------------------------------------
+
+# conf is where webhook URLs and tokens go, so a value that does not survive
+# the round trip is a broken install, not a cosmetic bug.
+for v in "${AWKWARD[@]}"; do
+    conf_set roundtrip KEY "$v"
+    got=$(conf_get roundtrip KEY)
+    [[ $got == "$v" ]] || fail "conf_set/conf_get mangled [$v] into [$got]"
+    conf_clear roundtrip
+done
+pass "conf round-trips awkward values"
+
+# Overwriting a key must replace it, not append a second one.
+conf_set overwrite KEY "first"
+conf_set overwrite KEY "second"
+conf_set overwrite OTHER "kept"
+[[ $(conf_get overwrite KEY) == second ]] || fail "conf_set did not overwrite"
+[[ $(conf_get overwrite OTHER) == kept ]] || fail "conf_set clobbered another key"
+[[ $(grep -c '^KEY=' "$(conf_file overwrite)") -eq 1 ]] \
+    || fail "conf_set left a duplicate KEY line"
+pass "conf_set overwrites in place"
+
+# The documented promise: a helper script installed into TOOLBOX_BIN_DIR can
+# source the file directly rather than depending on this library.
+conf_set sourceable WEBHOOK "https://example.invalid/a'b\$c"
+got=$(bash -c 'set -eu; . "$1"; printf "%s" "$WEBHOOK"' _ "$(conf_file sourceable)")
+[[ $got == "https://example.invalid/a'b\$c" ]] \
+    || fail "conf file is not sourceable intact, got [$got]"
+pass "conf files stay sourceable"
+
+# Secrets live here, so the modes are part of the contract.
+[[ $(mode_of "$(conf_file sourceable)") == 600 ]] \
+    || fail "conf file is not 0600"
+[[ $(mode_of "$TOOLBOX_CONF_DIR") == 750 ]] \
+    || fail "conf dir is not 0750"
+pass "conf modes are 0600 in a 0750 dir"
+
+conf_exists sourceable || fail "conf_exists said no for a file that exists"
+conf_clear sourceable
+conf_exists sourceable && fail "conf_exists said yes after conf_clear"
+pass "conf_exists tracks conf_clear"
+
+# --- state: what the module knows --------------------------------------------
+
+# state_set used to update through `sed s|^K=.*|K=$v|`, which read & as the
+# whole match, ate backslashes and failed outright on a |. The update path is
+# the one that broke, so every value is written twice.
+for v in "${AWKWARD[@]}"; do
+    state_set roundtrip KEY "placeholder"
+    state_set roundtrip KEY "$v"
+    got=$(state_get roundtrip KEY)
+    [[ $got == "$v" ]] || fail "state_set/state_get mangled [$v] into [$got]"
+    state_clear roundtrip
+done
+pass "state round-trips awkward values"
+
+state_set overwrite KEY "first"
+state_set overwrite OTHER "kept"
+state_set overwrite KEY "second"
+[[ $(state_get overwrite KEY) == second ]] || fail "state_set did not overwrite"
+[[ $(state_get overwrite OTHER) == kept ]] || fail "state_set clobbered another key"
+[[ $(grep -c '^KEY=' "$TOOLBOX_STATE_DIR/overwrite.state") -eq 1 ]] \
+    || fail "state_set left a duplicate KEY line"
+pass "state_set overwrites in place"
+
+# state is safe to print, unlike conf.
+[[ $(mode_of "$TOOLBOX_STATE_DIR/overwrite.state") == 644 ]] \
+    || fail "state file is not 0644"
+pass "state files are 0644"
+
+[[ -z $(state_get overwrite ABSENT) ]] || fail "state_get invented a value"
+[[ -z $(state_get nosuchmodule KEY) ]] || fail "state_get read a missing file"
+state_exists overwrite || fail "state_exists said no for a file that exists"
+state_clear overwrite
+state_exists overwrite && fail "state_exists said yes after state_clear"
+pass "state_get and state_exists handle absence"
+
+# --- version helpers ---------------------------------------------------------
+
+[[ $(version_bare v1.69.1) == 1.69.1 ]] || fail "version_bare left the v"
+[[ $(version_bare V1.69.1) == 1.69.1 ]] || fail "version_bare left a capital V"
+[[ $(version_bare 1.69.1)  == 1.69.1 ]] || fail "version_bare altered a bare version"
+[[ $(version_bare "")      == ""     ]] || fail "version_bare invented a value"
+pass "version_bare"
+
+newer_is() { # newer_is <candidate> <current> <yes|no>
+    local got=no
+    is_newer "$1" "$2" && got=yes
+    [[ $got == "$3" ]] || fail "is_newer '$1' '$2' returned $got, wanted $3"
+}
+
+# A release tag carries a leading v and `--version` output does not, so the
+# two arrive spelled differently for the same release. Comparing them raw made
+# every check report the installed version as an available update.
+newer_is v1.69.1 1.69.1  no
+newer_is 1.69.1  v1.69.1 no
+newer_is 1.69.1  1.69.1  no
+newer_is v1.69.1 v1.69.1 no
+
+newer_is v1.70.0 1.69.1  yes
+newer_is 1.70.0  v1.69.1 yes
+newer_is 1.69.1  1.70.0  no
+
+# Version order, not string order.
+newer_is 1.10.0 1.9.0  yes
+newer_is 1.9.0  1.10.0 no
+
+# Nothing known about the current version means anything is an upgrade...
+newer_is 1.0.0 ""        yes
+newer_is 1.0.0 "unknown" yes
+
+# ...but an unknown candidate is not an upgrade over anything.
+newer_is ""        1.0.0     no
+newer_is "unknown" 1.0.0     no
+newer_is "unknown" "unknown" no
+
+# sort -V puts 1.70.0-rc1 above 1.70.0 on its own; a prerelease has to sort
+# below the release it is a candidate for.
+newer_is 1.70.0-rc1 1.70.0     no
+newer_is 1.70.0     1.70.0-rc1 yes
+newer_is 1.70.0-rc2 1.70.0-rc1 yes
+pass "is_newer"
+
+# --- backup_file -------------------------------------------------------------
+
+# Every restore-shaped write is supposed to go through this first.
+target="$WORK/target.conf"
+printf 'original\n' > "$target"
+backup_file "$target" >/dev/null
+mapfile -t backups < <(find "$WORK" -name 'target.conf.bak.*' -type f)
+[[ ${#backups[@]} -eq 1 ]] || fail "backup_file made ${#backups[@]} backups, wanted 1"
+[[ $(cat "${backups[0]}") == original ]] || fail "backup does not match the original"
+[[ $(cat "$target") == original ]] || fail "backup_file altered the original"
+pass "backup_file copies before an overwrite"
+
+backup_file "$WORK/does-not-exist" >/dev/null || fail "backup_file failed on a missing file"
+[[ ! -e $WORK/does-not-exist ]] || fail "backup_file created the missing file"
+pass "backup_file is a no-op on a missing file"
+
+# --- the scrutiny update decision --------------------------------------------
+
+# Module logic rather than lib, but pure, and it shares the version helpers
+# above. module.sh is contracted to be side-effect free at source time, which
+# is what lets this run without a release API or an installed collector.
+# shellcheck source=modules/scrutiny-collectors/module.sh
+source "$ROOT/modules/scrutiny-collectors/module.sh"
+
+compare_is() { # compare_is <installed> <tag> <expected>
+    local got; got=$(_sc_compare "$1" "$2")
+    [[ $got == "$3" ]] || fail "_sc_compare '$1' '$2' returned $got, wanted $3"
+}
+
+# One release, two spellings, once reported as an available update.
+compare_is 1.69.1  v1.69.1 same
+compare_is v1.69.1 1.69.1  same
+compare_is 1.69.1  1.69.1  same
+
+compare_is 1.69.1 v1.70.0 upgrade
+compare_is 1.70.0 v1.69.1 downgrade
+
+# An install predating the state file reports unknown; anything beats it.
+compare_is unknown v1.69.1 upgrade
+pass "update decision"

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -80,82 +80,29 @@ got=$(complete_words 2 ./pve-toolbox link "")
 
 pass "bash completion"
 
-# --- version comparison -----------------------------------------------------
+# --- usage -------------------------------------------------------------------
 
-# Sourced in-process, so point every path at a throwaway first. Without this
-# the rest of the file inherits /usr/local/bin and /var/lib/pve-toolbox, and
-# anything added below could write to the host it is testing on.
-TOOLBOX_BIN_DIR=$(tmp)
-TOOLBOX_LIB_DIR=$(tmp)
-TOOLBOX_CONF_DIR=$(tmp)
-TOOLBOX_STATE_DIR=$(tmp)
-TOOLBOX_SYSTEMD_DIR=$(tmp)
-export TOOLBOX_BIN_DIR TOOLBOX_LIB_DIR TOOLBOX_CONF_DIR TOOLBOX_STATE_DIR TOOLBOX_SYSTEMD_DIR
+# usage() read a hardcoded line range of the header comment, so growing that
+# header spilled `set -euo pipefail` and the code under it into --help.
+help=$(launch ./pve-toolbox --help)
+[[ $help == *"pve-toolbox list [tag]"* ]] || fail "--help lost the command list"
+[[ $help == *"Flags:"* ]]                 || fail "--help lost the flags line"
+[[ $help != *"set -euo"* ]]               || fail "--help leaked shell code"
+[[ $help != *"#"* ]]                      || fail "--help leaked a comment marker"
+pass "usage stops at the end of the header"
 
-# shellcheck source=lib/common.sh
-source "$ROOT/lib/common.sh"
+# --- installed detection -----------------------------------------------------
 
-# is_newer <candidate> <current> <expected yes|no>
-newer_is() {
-    local got=no
-    is_newer "$1" "$2" && got=yes
-    [[ $got == "$3" ]] || fail "is_newer '$1' '$2' returned $got, wanted $3"
-}
-
-# A release tag carries a leading v and `--version` output does not, so the
-# two arrive spelled differently for the same release. Comparing them raw made
-# every check report the installed version as an available update.
-newer_is v1.69.1 1.69.1  no
-newer_is 1.69.1  v1.69.1 no
-newer_is 1.69.1  1.69.1  no
-newer_is v1.69.1 v1.69.1 no
-
-newer_is v1.70.0 1.69.1  yes
-newer_is 1.70.0  v1.69.1 yes
-newer_is 1.69.1  1.70.0  no
-
-# Version order, not string order.
-newer_is 1.10.0 1.9.0  yes
-newer_is 1.9.0  1.10.0 no
-
-# Nothing known about the current version means anything is an upgrade.
-newer_is 1.0.0 ""        yes
-newer_is 1.0.0 "unknown" yes
-
-# ...but an unknown candidate is not an upgrade over anything.
-newer_is ""        1.0.0     no
-newer_is "unknown" 1.0.0     no
-newer_is "unknown" "unknown" no
-
-# sort -V puts 1.70.0-rc1 above 1.70.0 on its own; a prerelease has to sort
-# below the release it is a candidate for.
-newer_is 1.70.0-rc1 1.70.0     no
-newer_is 1.70.0     1.70.0-rc1 yes
-newer_is 1.70.0-rc2 1.70.0-rc1 yes
-
-pass "version comparison"
-
-# --- the update/check decision ----------------------------------------------
-
-# module.sh is contracted to be side-effect free at source time, which is what
-# lets this be tested without a release API or an installed collector.
-# shellcheck source=modules/scrutiny-collectors/module.sh
-source "$ROOT/modules/scrutiny-collectors/module.sh"
-
-compare_is() { # compare_is <installed> <tag> <expected>
-    local got; got=$(_sc_compare "$1" "$2")
-    [[ $got == "$3" ]] || fail "_sc_compare '$1' '$2' returned $got, wanted $3"
-}
-
-# The reported bug: one release, two spellings, reported as an update.
-compare_is 1.69.1 v1.69.1 same
-compare_is v1.69.1 1.69.1 same
-compare_is 1.69.1 1.69.1  same
-
-compare_is 1.69.1 v1.70.0 upgrade
-compare_is 1.70.0 v1.69.1 downgrade
-
-# An install that predates the state file reports unknown; anything beats it.
-compare_is unknown v1.69.1 upgrade
-
-pass "update decision"
+# status_line normalises an empty status to the exact string is_installed
+# compares against, and every caller - update, check, uninstall completion -
+# turns on getting that right. Nothing is installed in a checkout, so every
+# module has to report so and none may appear as installed.
+list=$(launch ./pve-toolbox list)
+while read -r mod; do
+    [[ $list == *"$mod"* ]] || fail "list did not mention $mod"
+done < <(launch ./pve-toolbox _complete modules)
+[[ $(launch ./pve-toolbox list | grep -c 'status: not installed') -eq 3 ]] \
+    || fail "expected three uninstalled modules in list"
+[[ -z $(launch ./pve-toolbox _complete installed) ]] \
+    || fail "_complete installed named a module in a bare checkout"
+pass "nothing reads as installed in a checkout"

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -158,3 +158,42 @@ done < <(launch ./pve-toolbox _complete modules)
 [[ -z $(launch ./pve-toolbox _complete installed) ]] \
     || fail "_complete installed named a module in a bare checkout"
 pass "nothing reads as installed in a checkout"
+
+# --- the command line's per-module dispatch ----------------------------------
+
+# cmd_each is what install/update/check/status/uninstall all go through, and
+# nothing exercised it. With no module names it filters to what is installed,
+# which in a checkout is nothing.
+for verb in update check status; do
+    res=$(launch ./pve-toolbox "$verb" 2>&1) || fail "$verb with no args exited non-zero"
+    [[ $res == *"no installed modules"* ]] || fail "$verb said: $res"
+done
+pass "update, check and status do nothing when nothing is installed"
+
+# install and uninstall refuse to guess, because both are destructive in a way
+# update and status are not.
+for verb in install uninstall; do
+    launch ./pve-toolbox "$verb" >/dev/null 2>&1 \
+        && fail "$verb with no module name should have failed"
+    res=$(launch ./pve-toolbox "$verb" 2>&1 || true)
+    [[ $res == *"needs a module name"* ]] || fail "$verb said: $res"
+done
+pass "install and uninstall demand a module name"
+
+# A named module is acted on whether or not it is installed - that is how you
+# ask about one. module_status exits 1 to mean "not installed", so status has
+# to read that as the answer rather than announcing a failure.
+res=$(launch ./pve-toolbox status zfs-scrub 2>&1) || fail "status <module> exited non-zero"
+[[ $res == *"not installed"* ]] || fail "status did not report the state: $res"
+[[ $res != *"failed"* ]] || fail "status called a not-installed module failed: $res"
+pass "status names an uninstalled module without calling it a failure"
+
+launch ./pve-toolbox status definitely-not-a-module >/dev/null 2>&1 \
+    && fail "an unknown module should have failed"
+res=$(launch ./pve-toolbox status definitely-not-a-module 2>&1 || true)
+[[ $res == *"unknown module"* ]] || fail "unknown module said: $res"
+pass "an unknown module is rejected"
+
+launch ./pve-toolbox definitely-not-a-command >/dev/null 2>&1 \
+    && fail "an unknown command should have failed"
+pass "an unknown command is rejected"

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -61,24 +61,76 @@ complete_words() { # complete_words <cword> <word>... -> prints candidates
     printf '%s' "${COMPREPLY[*]:-}"
 }
 
+has()    { [[ " $1 " == *" $2 "* ]]; }
+has_not() { [[ " $1 " != *" $2 "* ]]; }
+
+# Commands, and every verb the launcher dispatches.
 got=$(complete_words 1 ./pve-toolbox "")
-[[ " $got " == *" install "* ]] || fail "no commands offered, got: $got"
+for verb in menu ui list install update check status uninstall link self-update; do
+    has "$got" "$verb" || fail "commands missing $verb, got: $got"
+done
+pass "bash offers every command"
+
+# compgen filters by prefix; the completion only supplies the candidates.
+got=$(complete_words 1 ./pve-toolbox "in")
+[[ $got == install ]] || fail "prefix in<TAB> should give install alone, got: $got"
+got=$(complete_words 1 ./pve-toolbox "self")
+[[ $got == self-update ]] || fail "prefix self<TAB> should give self-update, got: $got"
+pass "bash filters commands by prefix"
 
 got=$(complete_words 2 ./pve-toolbox install "")
-[[ " $got " == *" zfs-scrub "* ]] || fail "no modules offered, got: $got"
+has "$got" zfs-scrub || fail "no modules offered for install, got: $got"
+got=$(complete_words 2 ./pve-toolbox install "zfs-")
+has "$got" zfs-scrub       || fail "prefix zfs-<TAB> dropped zfs-scrub, got: $got"
+has "$got" zfs-replication || fail "prefix zfs-<TAB> dropped zfs-replication, got: $got"
+has_not "$got" scrutiny-collectors || fail "prefix zfs-<TAB> kept a non-match, got: $got"
+pass "bash offers modules, filtered by prefix"
 
-# A module already on the line must not be offered again.
+# A module already on the line is not offered a second time.
 got=$(complete_words 3 ./pve-toolbox install zfs-scrub "")
-[[ " $got " != *" zfs-scrub "* ]] || fail "re-offered a module already given"
+has_not "$got" zfs-scrub       || fail "re-offered a module already given, got: $got"
+has "$got" zfs-replication     || fail "dropped the modules still available, got: $got"
+pass "bash drops what is already on the line"
+
+# update, check and status take module names too.
+for verb in update check status; do
+    got=$(complete_words 2 ./pve-toolbox "$verb" "")
+    has "$got" zfs-scrub || fail "$verb offered no modules, got: $got"
+done
+pass "bash offers modules for update, check and status"
+
+# uninstall offers only what is installed, which in a checkout is nothing.
+got=$(complete_words 2 ./pve-toolbox uninstall "")
+[[ -z $got ]] || fail "uninstall offered a module in a bare checkout, got: $got"
+pass "bash offers only installed modules for uninstall"
+
+# list takes a single tag, gathered from every module's MODULE_TAGS.
+got=$(complete_words 2 ./pve-toolbox list "")
+has "$got" storage || fail "list offered no tags, got: $got"
+has "$got" zfs     || fail "list dropped a tag, got: $got"
+got=$(complete_words 3 ./pve-toolbox list storage "")
+[[ -z $got ]] || fail "list takes one tag, got: $got"
+pass "bash offers tags for list, once"
 
 # Flags are accepted anywhere, so the command is the first non-flag word.
 got=$(complete_words 3 ./pve-toolbox -y install "")
-[[ " $got " == *" zfs-scrub "* ]] || fail "flag before command broke it, got: $got"
+has "$got" zfs-scrub || fail "a flag before the command broke it, got: $got"
+pass "bash finds the command past a flag"
 
-got=$(complete_words 2 ./pve-toolbox link "")
-[[ -z $got ]] || fail "link takes no arguments, got: $got"
+got=$(complete_words 1 ./pve-toolbox "-")
+for flag in -y --yes -f --force -h --help; do
+    has "$got" "$flag" || fail "flags missing $flag, got: $got"
+done
+got=$(complete_words 1 ./pve-toolbox "--f")
+[[ $got == --force ]] || fail "prefix --f<TAB> should give --force, got: $got"
+pass "bash offers flags"
 
-pass "bash completion"
+# menu, ui, link and self-update take nothing, and neither does a typo.
+for verb in menu ui link self-update definitely-not-a-command; do
+    got=$(complete_words 2 ./pve-toolbox "$verb" "")
+    [[ -z $got ]] || fail "$verb should offer nothing, got: $got"
+done
+pass "bash offers nothing where nothing is taken"
 
 # --- usage -------------------------------------------------------------------
 


### PR DESCRIPTION
Split out of #6, which is now just the ui prompt fix.

A coverage audit — running the suite under `SHELLOPTS=xtrace` and intersecting traced calls against every function the repo defines — put `lib/discord.sh` at **0 of 5** functions and `cmd_each` at never called. Filling those gaps found two bugs.

## Bugs the tests found

**`state_set` corrupted values.** It updated an existing key through `sed "s|^$2=.*|$2=$3|"`, so on Debian:

```
state  pipe        MISMATCH got [first]      want [a|b]    <- sed died, old value kept
state  ampersand   MISMATCH got [aK=firstb]  want [a&b]    <- & expanded to the match
state  backslash   MISMATCH got [ab]         want [a\b]    <- backslash eaten
```

`sed` exited non-zero and nothing checked it. `conf_set` never had this — it goes through awk with the value in the environment, and the comment there says why. `state_set` does the same now. Not reachable from the modules in tree, which store pool names and checksums; reachable by the next module that stores a path.

**`pve-toolbox status <module>` called a not-installed module a failure.**

```
ZFS scrub + Discord
  !! not installed
  !! zfs-scrub failed
```

Same defect as the one fixed in `ui_run` in #6, in the other loop, surviving because nothing drove the command line's per-module path. `module_status` exits 1 to mean "not installed" — the answer `status` was asked for.

## What is now covered

| File | New coverage |
| --- | --- |
| `tests/lib.sh` | conf and state round-trip 12 values that break shell quoting, sed replacement syntax or `awk -v` escapes; overwrite replaces rather than appends; conf files stay *sourceable*; conf `0600` in a `0750` dir, state `0644`; `version_bare`, `is_newer`, `backup_file`, `_sc_compare` |
| `tests/discord.sh` | ten awkward values through title, description and a field, parsed back with jq; colour as a number not a string; Discord's three length limits; empty and dangling fields becoming `-`; `discord_fence` keeping the tail; the no-webhook branch |
| `tests/completion-zsh.sh` | the zsh completion had no coverage at all — it isn't bash, so neither `bash -n` nor shellcheck reads it |
| `tests/smoke.sh` | bash completion 5 → 10 cases incl. prefix filtering and flags; `cmd_each`; `--help` not leaking shell code; nothing reading as installed in a checkout |

CI installs `zsh` and sets `ZSH_TEST_REQUIRED=1`, so a missing dependency fails rather than passing quietly.

## Verification

89 assertions, up from 34. Every group mutation-checked by breaking what it guards:

```
dedupe removed              -> re-offered a module already given
list nargs guard removed    -> list takes one tag, got: backup monitoring...
uninstall reads all modules -> uninstall offered a module in a bare checkout
flag branch removed         -> flags missing -y
ui dropped from _complete   -> commands missing ui
colour passed as a string   -> color is not a number
fence trims the wrong end   -> fence trimmed the tail instead of the head
field truncation removed    -> field value was not truncated to 1000
empty-value dash removed    -> empty value is not a dash
cmd_each fix reverted       -> status called a not-installed module failed
old state_set restored      -> suite exits 1
```

`mode_of` falls back from GNU to BSD `stat`, so `tests/lib.sh` runs on macOS as well as the target — worth noting, because the `state_set` bug was invisible there for an unrelated reason (BSD `sed -i` needs an argument, so it never ran at all).

## Still uncovered

Module `install`/`update`/`uninstall` internals (need systemd and a fake `zpool`), `menu`/`print_table`, `link_completions`, and the `gh_*` release helpers.