### PR TITLE
feat(config-backup): add cross-node restore

### DIFF
--- a/docs/modules/config-backup.md
+++ b/docs/modules/config-backup.md
@@ -342,8 +342,9 @@ Refusing beats a transform that is right most of the time.
   state. Naming a different node would put both on the wrong box. SSH to the
   target and run it there.
 - **Cluster-shared files are blocked, and `--force` does not lift it.**
-  `storage.cfg`, `datacenter.cfg`, `user.cfg`, `jobs.cfg`, `firewall/`, `sdn/`
-  and `ha/` are one file for the whole cluster. A restore installs a whole
+  `storage.cfg`, `datacenter.cfg`, `user.cfg`, `jobs.cfg`, `firewall/cluster.fw`,
+  `sdn/` and `ha/` are one file for the whole cluster. A guest's own
+  `firewall/<vmid>.fw` is not, and travels with it. A restore installs a whole
   file, so restoring another node's copy would delete every entry this cluster
   has that the source lacked — instantly, on every node. Doing it correctly
   needs per-entry merge semantics this tool does not have.
@@ -351,6 +352,12 @@ Refusing beats a transform that is right most of the time.
   rewritten; the volumes are not, because nothing here touches storage. A guest
   renamed 100 → 1100 refers to `vm-1100-disk-0` while the volume is still
   called `vm-100-disk-0`. Move the volumes first; the report names them.
+- **An archive from a cluster keeps only its own node.** `/etc/pve/nodes/`
+  holds a directory per member, so an archive taken on a cluster contains every
+  node's guests. The transform keeps the source node's and drops the rest —
+  they belong to a live machine and must never be written here. An archive that
+  does not record which node it came from is refused rather than guessed at, as
+  is one whose `nodes/` entry is a symlink.
 - **`--mode dr` requires `--source-node-gone`.** DR mode deliberately reuses
   the source's VMIDs, MACs and IPs. This tool cannot tell a dead node from a
   partitioned one, and guessing wrong puts a second guest with a duplicate

--- a/docs/modules/config-backup.md
+++ b/docs/modules/config-backup.md
@@ -322,11 +322,11 @@ pve-config-backup restore latest --target-node pve2 \
 
 | Transform | What moves |
 | --- | --- |
-| node path | `nodes/<src>/` → `nodes/<tgt>/`, and `<src>` inside `storage.cfg`'s `nodes` list |
+| node path | `nodes/<src>/` → `nodes/<tgt>/`, with the source node read from the staged tree rather than trusted from metadata |
 | `--map-storage A=B` | anchored on the field (`^key: A:`), so mapping `local` leaves `local-lvm` and `my-local` alone |
 | `--map-bridge A=B` | `bridge=A` in a `netN:` line; the model, MAC, tag and firewall options survive byte for byte |
 | `--vmid-offset N`, `--map-vmid A=B` | the filename and the `vm-<id>-`, `subvol-<id>-` and `<id>/` tokens — never a bare number, which would rewrite `memory: 100` and `tag=100` |
-| `--regenerate-macs` | the MAC, which is the *value* of the model key (`net0: virtio=<mac>,…`), not a `macaddr=` field |
+| `--regenerate-macs` | the MAC in both serialisations — qemu's `net0: <model>=<mac>,…` and LXC's `hwaddr=<mac>`. One new address per old one, so an interface keeps the same MAC in the running config and in every snapshot stanza |
 
 Covers qemu (`scsiN`, `ideN`, `virtioN`, `sataN`, `efidiskN`, `tpmstateN`,
 `unusedN`, `vmstate`) and LXC (`rootfs`, `mpN`), and reaches inside `[snapshot]`

--- a/docs/modules/config-backup.md
+++ b/docs/modules/config-backup.md
@@ -32,12 +32,11 @@ Either can be turned off, but not both. They share one capture: the tree is
 collected, classified, scanned and hashed once, and only then handed to
 whichever backends are enabled.
 
-!!! warning "Restore is same-node only"
+!!! warning "A cross-node restore has to be asked for explicitly"
 
-    Restoring onto a *different* node — with identity remapping, storage and
-    bridge translation, and the auto-exclusions that implies — is a later
-    release. A source whose recorded node does not match this host is blocked
-    outright rather than guessed at.
+    A source whose recorded node does not match this host is blocked until you
+    say `--target-node` and pick a mode. Nothing is inferred, because the two
+    modes have opposite consequences.
 
 ## What is captured
 
@@ -301,6 +300,73 @@ restore leaves evidence rather than looking like it never happened.
     `storage.cfg` is not reconciled against the live LVM or ZFS backends, and
     `fstab` UUIDs are not checked against `blkid` — a stale UUID surfaces at the
     next boot. Read the `diff` before you `--confirm`.
+
+## Restoring onto a different node
+
+Between extracting the source and planning the restore, a **transform layer**
+rewrites the staged tree to describe the target instead of the source, and
+prints a full report before anything is written.
+
+```bash
+# the source node is gone; keep its identities
+pve-config-backup restore latest --target-node pve2 \
+    --mode dr --source-node-gone --confirm
+
+# the source node is alive; everything must be regenerated
+pve-config-backup restore latest --target-node pve2 \
+    --mode clone --vmid-offset 1000 --regenerate-macs \
+    --map-storage local=nas --map-bridge vmbr0=vmbr9 --confirm
+```
+
+| Transform | What moves |
+| --- | --- |
+| node path | `nodes/<src>/` → `nodes/<tgt>/`, and `<src>` inside `storage.cfg`'s `nodes` list |
+| `--map-storage A=B` | anchored on the field (`^key: A:`), so mapping `local` leaves `local-lvm` and `my-local` alone |
+| `--map-bridge A=B` | `bridge=A` in a `netN:` line; the model, MAC, tag and firewall options survive byte for byte |
+| `--vmid-offset N`, `--map-vmid A=B` | the filename and the `vm-<id>-`, `subvol-<id>-` and `<id>/` tokens — never a bare number, which would rewrite `memory: 100` and `tag=100` |
+| `--regenerate-macs` | the MAC, which is the *value* of the model key (`net0: virtio=<mac>,…`), not a `macaddr=` field |
+
+Covers qemu (`scsiN`, `ideN`, `virtioN`, `sataN`, `efidiskN`, `tpmstateN`,
+`unusedN`, `vmstate`) and LXC (`rootfs`, `mpN`), and reaches inside `[snapshot]`
+and `[PENDING]` sections, which carry their own copies of every disk line.
+
+### What it refuses to do
+
+Refusing beats a transform that is right most of the time.
+
+- **`--target-node` must name this host.** A cross-node restore still writes
+  host-level files — `sshd_config`, `cron.d`, custom units — through *this*
+  machine's filesystem, and records its rollback point in *this* machine's
+  state. Naming a different node would put both on the wrong box. SSH to the
+  target and run it there.
+- **Cluster-shared files are blocked, and `--force` does not lift it.**
+  `storage.cfg`, `datacenter.cfg`, `user.cfg`, `jobs.cfg`, `firewall/`, `sdn/`
+  and `ha/` are one file for the whole cluster. A restore installs a whole
+  file, so restoring another node's copy would delete every entry this cluster
+  has that the source lacked — instantly, on every node. Doing it correctly
+  needs per-entry merge semantics this tool does not have.
+- **A VMID-remapped guest is `degraded`, never `restorable`.** The config is
+  rewritten; the volumes are not, because nothing here touches storage. A guest
+  renamed 100 → 1100 refers to `vm-1100-disk-0` while the volume is still
+  called `vm-100-disk-0`. Move the volumes first; the report names them.
+- **`--mode dr` requires `--source-node-gone`.** DR mode deliberately reuses
+  the source's VMIDs, MACs and IPs. This tool cannot tell a dead node from a
+  partitioned one, and guessing wrong puts a second guest with a duplicate
+  identity on the same network, possibly writing to the same shared storage.
+
+### Dropped automatically
+
+Whatever the flags say, because they describe hardware or identity that did not
+move: `interfaces` and `interfaces.d/` (NIC naming), `fstab` and `crypttab`
+(UUIDs), `modprobe.d/`, `modules-load.d/`, GRUB and the kernel command line
+(PCI addresses), `hostname`, `hosts`, and SSH host keys.
+
+A guest with any `hostpci*` line is **blocked** — the PCI address it names is a
+fact about the source machine.
+
+A VMID already live on *another* node is a collision and blocks that guest. One
+found under the source node's own directory is not: a dead node's tree survives
+in pmxcfs, and reusing that VMID is exactly what DR mode is for.
 
 ## Retention
 

--- a/modules/config-backup/pve-config-backup.sh
+++ b/modules/config-backup/pve-config-backup.sh
@@ -1612,7 +1612,7 @@ declare -A CB_MAP_VMID=()
 # needs per-entry merge semantics this tool does not have, so it says no.
 CB_CLUSTER_WIDE=(
     "pve/storage.cfg" "pve/datacenter.cfg" "pve/user.cfg" "pve/jobs.cfg"
-    "pve/firewall/*" "pve/sdn/*" "pve/ha/*"
+    "pve/firewall/cluster.fw" "pve/sdn/*" "pve/ha/*"
 )
 
 _cb_is_cluster_wide() { # _cb_is_cluster_wide <relpath>
@@ -1657,6 +1657,17 @@ _cb_xn_guard() {
     [[ $CB_TARGET_NODE == "$HOST_SHORT" ]] \
         || fail "--target-node must name this host ($HOST_SHORT). Writing another node's host files through a shared /etc/pve would hit the wrong machine, and the rollback point would be recorded on the wrong machine too - ssh to the target and run it there."
 
+    # Both modes, not just clone: a typo in dr mode used to reach the per-guest
+    # check and drop that guest from the restore with a note, rather than
+    # refusing before anything ran.
+    local k
+    for k in "${!CB_MAP_VMID[@]}"; do
+        [[ $k =~ ^[0-9]+$ && ${CB_MAP_VMID[$k]} =~ ^[0-9]+$ ]] \
+            || fail "--map-vmid takes numbers: $k=${CB_MAP_VMID[$k]}"
+        _cb_valid_vmid "${CB_MAP_VMID[$k]}" \
+            || fail "--map-vmid target ${CB_MAP_VMID[$k]} is not a valid VMID (100-999999999)"
+    done
+
     case $CB_XN_MODE in
         dr)
             [[ $CB_XN_SOURCE_GONE -eq 1 ]] \
@@ -1665,13 +1676,6 @@ _cb_xn_guard() {
         clone)
             [[ $CB_XN_VMID_OFFSET -ne 0 || ${#CB_MAP_VMID[@]} -gt 0 ]] \
                 || fail "--mode clone needs --vmid-offset or --map-vmid: the source node is alive and its VMIDs are taken"
-            local k
-            for k in "${!CB_MAP_VMID[@]}"; do
-                [[ $k =~ ^[0-9]+$ && ${CB_MAP_VMID[$k]} =~ ^[0-9]+$ ]] \
-                    || fail "--map-vmid takes numbers: $k=${CB_MAP_VMID[$k]}"
-                _cb_valid_vmid "${CB_MAP_VMID[$k]}" \
-                    || fail "--map-vmid target ${CB_MAP_VMID[$k]} is not a valid VMID (100-999999999)"
-            done
             ;;
         *) fail "--mode must be dr or clone" ;;
     esac
@@ -1718,7 +1722,7 @@ _cb_xn_guest() { # _cb_xn_guest <file> <old-vmid> <new-vmid>
 
     local before
     for key in "${!CB_MAP_STORAGE[@]}"; do
-        from=$key; to=${CB_MAP_STORAGE[$key]}
+        from=$(_cb_ere_quote "$key"); to=${CB_MAP_STORAGE[$key]}
         before=$(sha256sum "$f" | awk '{print $1}')
         # ^<key>: <storage>: - never a bare or \b match, which would rewrite
         # `my-local` when mapping `local`, since - is a word boundary.
@@ -1731,7 +1735,7 @@ _cb_xn_guest() { # _cb_xn_guest <file> <old-vmid> <new-vmid>
     done
 
     for key in "${!CB_MAP_BRIDGE[@]}"; do
-        from=$key; to=${CB_MAP_BRIDGE[$key]}
+        from=$(_cb_ere_quote "$key"); to=${CB_MAP_BRIDGE[$key]}
         # A # delimiter, because the alternation below contains a pipe and a
         # | delimiter made sed reject the expression - which failed silently
         # for every mid-line bridge= and only ever rewrote end-of-line ones.
@@ -1823,14 +1827,43 @@ _cb_transform() { # _cb_transform -> rewrites CB_SRC_DIR in place
     # rewrote configs under nodes/<source>/ - which maps onto that node's live
     # pmxcfs directory, so restoring on pve2 overwrote pve1's running guests.
     local -a staged_nodes=()
-    local d
-    for d in "$CB_SRC_DIR"/pve/nodes/*/; do
-        [[ -d $d ]] || continue
-        staged_nodes+=("$(basename "$d")")
-    done
+    local d name
+    # find -type d, not a glob: a glob with [[ -d ]] accepts a symlink to a
+    # directory, and cp -a would then resolve through it - materialising files
+    # from outside the staged tree as regular files before _cb_restore_plan
+    # ever sees them, defeating its symlink guard entirely.
+    # -type l first, and its own message: find -type d simply omits a symlink,
+    # so without this the archive fell through to the inconsistency check and
+    # reported "holds only <the others>" - true, but not the reason.
+    while IFS= read -r d; do
+        fail "nodes/$(basename "$d") is a symlink - refusing to transform an archive that points outside itself"
+    done < <(find "$CB_SRC_DIR/pve/nodes" -mindepth 1 -maxdepth 1 -type l 2>/dev/null)
+    while IFS= read -r d; do
+        name=$(basename "$d")
+        staged_nodes+=("$name")
+    done < <(find "$CB_SRC_DIR/pve/nodes" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | LC_ALL=C sort)
+
+    # /etc/pve is a cluster filesystem: nodes/ holds a directory for every
+    # member, and the collector takes it whole. So more than one is the normal
+    # case on any clustered host - refusing it made cross-node restore
+    # impossible from exactly the topology this feature exists for. Pick the
+    # source node, and drop the others: they are another live node's guests
+    # and must never be written here.
     if [[ ${#staged_nodes[@]} -gt 1 ]]; then
-        fail "the source holds more than one node directory (${staged_nodes[*]}) - refusing to guess which to transform"
+        if [[ -z $src || $src == unknown ]]; then
+            fail "the source holds ${#staged_nodes[@]} node directories (${staged_nodes[*]}) and does not say which it came from - name it with --target-node and restore from an archive that records its node"
+        fi
+        local keep=0
+        for name in "${staged_nodes[@]}"; do
+            [[ $name == "$src" ]] && { keep=1; continue; }
+            rm -rf "${CB_SRC_DIR:?}/pve/nodes/$name"
+            _cb_xn_note "  dropped   nodes/$name/ (another node's guests)"
+        done
+        [[ $keep -eq 1 ]] \
+            || fail "the source says node '$src' but its tree holds only ${staged_nodes[*]} - refusing to transform an inconsistent archive"
+        staged_nodes=("$src")
     fi
+
     if [[ ${#staged_nodes[@]} -eq 1 ]]; then
         if [[ -n $src && $src != unknown && $src != "${staged_nodes[0]}" ]]; then
             fail "the source says node '$src' but its tree holds nodes/${staged_nodes[0]} - refusing to transform an inconsistent archive"
@@ -2139,9 +2172,18 @@ _cb_list() {
 
 _cb_add_map() { # _cb_add_map <arrayname> <A=B>
     [[ ${2:-} == *=* ]] || { printf 'error: expected A=B, got: %s\n' "${2:-}" >&2; exit 2; }
+    local k=${2%%=*} v=${2#*=}
+    # Both halves required: an empty target wrote an empty storage name, giving
+    # `scsi0: :100/vm-100-disk-0` - a volume ID PVE rejects on start.
+    [[ -n $k && -n $v ]] || { printf 'error: both sides of A=B must be set: %s\n' "$2" >&2; exit 2; }
     local -n _m=$1
-    _m["${2%%=*}"]="${2#*=}"
+    _m["$k"]="$v"
 }
+
+# The map key is interpolated into an ERE, and a storage ID may contain a dot -
+# which would otherwise match any character and repoint a guest at a storage
+# nobody named, while the before/after check reported it as a real mapping.
+_cb_ere_quote() { printf '%s' "$1" | sed 's/[].[^$(){}?+*\\|/]/\\&/g'; }
 
 _cb_read_conf() {
     if [[ -r $CB_CONF ]]; then

--- a/modules/config-backup/pve-config-backup.sh
+++ b/modules/config-backup/pve-config-backup.sh
@@ -1811,7 +1811,10 @@ _cb_xn_guard() {
     return 0
 }
 
-# PVE's own range. A remapped guest that lands outside it cannot be started,
+# Proxmox's registered OUI, so these are globally administered addresses -
+# which is what PVE itself hands out. (An earlier comment here claimed locally
+# administered; the bytes say otherwise.)
+# PVE's own VMID range. A remapped guest that lands outside it cannot be started,
 # and finding that out after the restore is too late.
 _cb_valid_vmid() { [[ $1 =~ ^[0-9]+$ && $1 -ge 100 && $1 -le 999999999 ]]; }
 
@@ -1846,7 +1849,7 @@ _cb_vmid_taken() { # _cb_vmid_taken <vmid> <source-node>
 # field it belongs to, and reaches inside [snapshot] and [PENDING] sections,
 # which carry their own copies of every disk line.
 _cb_xn_guest() { # _cb_xn_guest <file> <old-vmid> <new-vmid>
-    local f=$1 old=$2 new=$3 key from to
+    local f=$1 old=$2 new=$3 key from to line
     local tmp; tmp=$(mktemp)
 
     local before
@@ -1902,8 +1905,13 @@ _cb_xn_guest() { # _cb_xn_guest <file> <old-vmid> <new-vmid>
                 # address in the running config and in every snapshot stanza -
                 # otherwise rolling back to a snapshot hands the guest a MAC it
                 # never had.
-                [[ -n ${macmap[$old_mac]:-} ]] || macmap[$old_mac]=$(_cb_rand_mac)
-                new_mac=${macmap[$old_mac]}
+                # Keyed uppercase: the same interface written AA:BB in the
+                # running config and aa:bb in a snapshot would otherwise get
+                # two different new addresses - the very divergence the map
+                # exists to prevent.
+                local key_mac=${old_mac^^}
+                [[ -n ${macmap[$key_mac]:-} ]] || macmap[$key_mac]=$(_cb_rand_mac)
+                new_mac=${macmap[$key_mac]}
                 printf '%s\n' "${line//$old_mac/$new_mac}" >> "$tmp"
                 changed=1
             else
@@ -1929,13 +1937,12 @@ _cb_xn_guest() { # _cb_xn_guest <file> <old-vmid> <new-vmid>
 
 _cb_transform() { # _cb_transform -> rewrites CB_SRC_DIR in place
     CB_XN_REPORT=$(mktemp)
+    _cb_cleanup_add "$CB_XN_REPORT"
     _cb_xn_guard
 
     local src=${CB_SRC_NODE:-unknown}
     _cb_xn_note "Transform report"
     _cb_xn_note "  mode      $CB_XN_MODE"
-    _cb_xn_note "  node      $src -> $CB_TARGET_NODE"
-    _cb_xn_note ""
 
     # Auto-exclusions first, so nothing below can resurrect them.
     local rel why
@@ -1998,8 +2005,11 @@ _cb_transform() { # _cb_transform -> rewrites CB_SRC_DIR in place
             fail "the source says node '$src' but its tree holds nodes/${staged_nodes[0]} - refusing to transform an inconsistent archive"
         fi
         src=${staged_nodes[0]}
-        _cb_xn_note "  source    nodes/$src/ (read from the tree)"
     fi
+    # After the derivation, so the one line an operator scans names the node
+    # actually used rather than whatever the metadata claimed.
+    _cb_xn_note "  node      $src -> $CB_TARGET_NODE"
+    _cb_xn_note ""
 
     # nodes/<src>/ -> nodes/<tgt>/, resolving the real path rather than the
     # qemu-server symlink, which the collector already skips.

--- a/modules/config-backup/pve-config-backup.sh
+++ b/modules/config-backup/pve-config-backup.sh
@@ -24,6 +24,13 @@
 #         Restore onto this host. Dry run unless --confirm. A full snapshot is
 #         taken first, and rollback replays it.
 #
+#         From another node's archive, say so and pick a mode:
+#           --target-node <this host>  --mode dr --source-node-gone
+#           --target-node <this host>  --mode clone --vmid-offset 100
+#         and optionally --map-storage A=B, --map-bridge A=B, --map-vmid A=B,
+#         --regenerate-macs. The transform report is printed before anything
+#         is written.
+#
 #   pve-config-backup rollback [--confirm]
 #         Undo the last restore. Dry run unless --confirm.
 #
@@ -914,6 +921,18 @@ CB_SELECTOR=""
 
 _cb_restore_log() { printf '%s/restore.log' "$CB_ARCHIVE_DIR"; }
 
+# Drop everything the selector does not name, so the transform and everything
+# after it only ever sees the selection.
+_cb_prune_to_selector() {
+    [[ -n $CB_SELECTOR ]] || return 0
+    local rel
+    while IFS= read -r rel; do
+        rel=${rel#./}
+        _cb_selected "$rel" || rm -f "$CB_SRC_DIR/$rel"
+    done < <(cd "$CB_SRC_DIR" && find . -type f | LC_ALL=C sort)
+    return 0
+}
+
 # Unpack a source into a directory and verify it. Accepts an absolute path, a
 # name inside CB_ARCHIVE_DIR, `latest`, or a git ref when the git backend is on.
 _cb_source_prepare() { # _cb_source_prepare <source>
@@ -1009,9 +1028,9 @@ _cb_restore_preflight() { # _cb_restore_preflight <plan>
         hard=1
     fi
 
-    if [[ -n $CB_SRC_NODE && $CB_SRC_NODE != "$HOST_SHORT" ]]; then
+    if [[ -z $CB_TARGET_NODE && -n $CB_SRC_NODE && $CB_SRC_NODE != "$HOST_SHORT" ]]; then
         log "  BLOCK  this archive is from node '$CB_SRC_NODE', this host is '$HOST_SHORT'"
-        log "         restoring onto a different node needs --target-node (not in this release)"
+        log "         say so explicitly: --target-node $HOST_SHORT [--mode dr|clone]"
         hard=1
     fi
 
@@ -1186,6 +1205,16 @@ _cb_restore() { # _cb_restore <source> [selector]
     CB_SELECTOR=${2:-}
     _cb_source_prepare "$1"
 
+    # The selector is applied to the tree as the archive holds it, before the
+    # transform renames anything, so scoping by the VMID you can see in
+    # `inspect` selects what you meant rather than nothing at all.
+    if [[ -n $CB_TARGET_NODE ]]; then
+        _cb_prune_to_selector
+        CB_SELECTOR=""
+        _cb_transform
+        _cb_show_transform
+    fi
+
     local plan; plan=$(mktemp)
     _cb_restore_plan "$plan"
     _cb_restore_preflight "$plan"
@@ -1335,6 +1364,253 @@ _cb_diff() { # _cb_diff <source> [selector]
     done < "$plan" | LC_ALL=C sort -k1,1
     printf '\n  ~ differs   + only in the source   ! not restorable\n'
     rm -f "$plan"
+    return 0
+}
+
+# ------------------------------------------------------ cross-node --
+#
+# Rewrites the staged tree so it describes the target node rather than the
+# source, between extraction and planning, so everything downstream keeps
+# reading one shape.
+#
+# The rules below were written against real qemu-server and lxc syntax rather
+# than from memory, because three plausible-looking guesses are wrong:
+#   - a net line carries no macaddr= key; the MAC is the value of the model
+#     key, `net0: virtio=AA:BB:CC:11:22:33,bridge=vmbr0`
+#   - storage.cfg's `nodes` field lists node names, not storage names
+#   - substituting a bare vmid destroys `memory: 100` and `tag=100`
+#
+# What it refuses to do matters as much as what it does. See _cb_xn_guard.
+
+CB_TARGET_NODE=""
+CB_XN_MODE="dr"
+CB_XN_SOURCE_GONE=0
+CB_XN_VMID_OFFSET=0
+CB_XN_REGEN_MACS=0
+CB_XN_REPORT=""
+declare -A CB_MAP_STORAGE=()
+declare -A CB_MAP_BRIDGE=()
+declare -A CB_MAP_VMID=()
+
+# Shared by the whole cluster the instant pmxcfs accepts the write. Restoring
+# one from another node's archive would delete every entry the target has that
+# the source lacked, because a restore installs a whole file. Doing this right
+# needs per-entry merge semantics this tool does not have, so it says no.
+CB_CLUSTER_WIDE=(
+    "pve/storage.cfg" "pve/datacenter.cfg" "pve/user.cfg" "pve/jobs.cfg"
+    "pve/firewall/*" "pve/sdn/*" "pve/ha/*"
+)
+
+_cb_is_cluster_wide() { # _cb_is_cluster_wide <relpath>
+    local g
+    for g in "${CB_CLUSTER_WIDE[@]}"; do
+        # shellcheck disable=SC2053
+        [[ $1 == $g ]] && return 0
+    done
+    return 1
+}
+
+# Hardware and identity that did not move with the configuration. Dropped on a
+# cross-node restore whatever the flags say.
+CB_XN_EXCLUDE=(
+    "host/etc/network/*:NIC naming differs between machines"
+    "host/etc/fstab:filesystem UUIDs are per-machine"
+    "host/etc/crypttab:filesystem UUIDs are per-machine"
+    "host/etc/modprobe.d/*:PCI addresses are per-machine"
+    "host/etc/modules-load.d/*:PCI addresses are per-machine"
+    "host/etc/modules:PCI addresses are per-machine"
+    "host/etc/default/grub*:the kernel command line names per-machine devices"
+    "host/etc/kernel/*:the kernel command line names per-machine devices"
+    "host/etc/hostname:node identity"
+    "host/etc/hosts:node identity"
+    "host/etc/ssh/ssh_host_*:host keys are per-machine"
+)
+
+_cb_xn_excluded() { # _cb_xn_excluded <relpath> -> prints the reason
+    local e g why
+    for e in "${CB_XN_EXCLUDE[@]}"; do
+        g=${e%%:*}; why=${e#*:}
+        # shellcheck disable=SC2053
+        [[ $1 == $g ]] && { printf '%s' "$why"; return 0; }
+    done
+    return 1
+}
+
+_cb_xn_note() { printf '%s\n' "$*" >> "$CB_XN_REPORT"; }
+
+# Refusals, stated up front rather than discovered half way through.
+_cb_xn_guard() {
+    [[ $CB_TARGET_NODE == "$HOST_SHORT" ]] \
+        || fail "--target-node must name this host ($HOST_SHORT). Writing another node's host files through a shared /etc/pve would hit the wrong machine, and the rollback point would be recorded on the wrong machine too - ssh to the target and run it there."
+
+    case $CB_XN_MODE in
+        dr)
+            [[ $CB_XN_SOURCE_GONE -eq 1 ]] \
+                || fail "--mode dr reuses the source node's VMIDs, MACs and IPs. This tool cannot tell a dead node from a partitioned one, and getting it wrong puts a second guest with a duplicate identity on the network. Pass --source-node-gone to state that it is really gone."
+            ;;
+        clone)
+            [[ $CB_XN_VMID_OFFSET -ne 0 || ${#CB_MAP_VMID[@]} -gt 0 ]] \
+                || fail "--mode clone needs --vmid-offset or --map-vmid: the source node is alive and its VMIDs are taken"
+            ;;
+        *) fail "--mode must be dr or clone" ;;
+    esac
+    return 0
+}
+
+_cb_rand_mac() {
+    # Locally administered, unicast: second nibble 2.
+    printf 'BC:24:11:%02X:%02X:%02X' \
+        $((RANDOM % 256)) $((RANDOM % 256)) $((RANDOM % 256))
+}
+
+_cb_new_vmid() { # _cb_new_vmid <old>
+    if [[ -n ${CB_MAP_VMID[$1]:-} ]]; then printf '%s' "${CB_MAP_VMID[$1]}"; return 0; fi
+    if [[ $CB_XN_VMID_OFFSET -ne 0 ]]; then printf '%s' $(( $1 + CB_XN_VMID_OFFSET )); return 0; fi
+    printf '%s' "$1"
+}
+
+# A VMID lives under some other, live node. A hit under the source node's own
+# directory is not a collision: a dead node's tree survives in pmxcfs, and
+# reusing that VMID is exactly what dr mode is for.
+_cb_vmid_taken() { # _cb_vmid_taken <vmid> <source-node>
+    local f node
+    for f in "$CB_PVE_DIR"/nodes/*/qemu-server/"$1".conf "$CB_PVE_DIR"/nodes/*/lxc/"$1".conf; do
+        [[ -f $f ]] || continue
+        node=${f#"$CB_PVE_DIR"/nodes/}; node=${node%%/*}
+        [[ $node == "$2" ]] && continue
+        printf '%s' "$node"
+        return 0
+    done
+    return 1
+}
+
+# Rewrites one guest config in place. Every substitution is anchored on the
+# field it belongs to, and reaches inside [snapshot] and [PENDING] sections,
+# which carry their own copies of every disk line.
+_cb_xn_guest() { # _cb_xn_guest <file> <old-vmid> <new-vmid>
+    local f=$1 old=$2 new=$3 key from to
+    local tmp; tmp=$(mktemp)
+
+    for key in "${!CB_MAP_STORAGE[@]}"; do
+        from=$key; to=${CB_MAP_STORAGE[$key]}
+        # ^<key>: <storage>: - never a bare or \b match, which would rewrite
+        # `my-local` when mapping `local`, since - is a word boundary.
+        sed -E -i "s|^([a-z0-9_]+: )${from}:|\1${to}:|" "$f"
+        _cb_xn_note "  storage   $from -> $to   $(basename "$f")"
+    done
+
+    for key in "${!CB_MAP_BRIDGE[@]}"; do
+        from=$key; to=${CB_MAP_BRIDGE[$key]}
+        # A # delimiter, because the alternation below contains a pipe and a
+        # | delimiter made sed reject the expression - which failed silently
+        # for every mid-line bridge= and only ever rewrote end-of-line ones.
+        # The (,|$) anchor is what stops vmbr0 matching vmbr01.
+        sed -E -i "s#^(net[0-9]+:.*)bridge=${from}(,|\$)#\1bridge=${to}\2#" "$f"
+        _cb_xn_note "  bridge    $from -> $to   $(basename "$f")"
+    done
+
+    if [[ $CB_XN_REGEN_MACS -eq 1 ]]; then
+        # The MAC is the value of the model key. Everything after it - bridge,
+        # tag, firewall, mtu - is preserved byte for byte.
+        while IFS= read -r line; do
+            printf '%s\n' "$line"
+        done < "$f" > "$tmp"
+        : > "$f"
+        while IFS= read -r line; do
+            if [[ $line =~ ^(net[0-9]+:[[:space:]]*[a-z0-9]+=)([0-9A-Fa-f:]{17})(.*)$ ]]; then
+                printf '%s%s%s\n' "${BASH_REMATCH[1]}" "$(_cb_rand_mac)" "${BASH_REMATCH[3]}"
+            else
+                printf '%s\n' "$line"
+            fi
+        done < "$tmp" >> "$f"
+        _cb_xn_note "  macs      regenerated   $(basename "$f")"
+    fi
+
+    if [[ $old != "$new" ]]; then
+        # Only the volume tokens. A bare numeric substitution would rewrite
+        # `memory: 100` and `tag=100` as well.
+        sed -E -i "s|vm-${old}-|vm-${new}-|g; s|subvol-${old}-|subvol-${new}-|g; s|(:[[:space:]]*[A-Za-z0-9_.-]+:)${old}/|\1${new}/|g" "$f"
+        _cb_xn_note "  vmid      $old -> $new   volumes must be moved separately"
+    fi
+    rm -f "$tmp"
+    return 0
+}
+
+_cb_transform() { # _cb_transform -> rewrites CB_SRC_DIR in place
+    CB_XN_REPORT=$(mktemp)
+    _cb_xn_guard
+
+    local src=${CB_SRC_NODE:-unknown}
+    _cb_xn_note "Transform report"
+    _cb_xn_note "  mode      $CB_XN_MODE"
+    _cb_xn_note "  node      $src -> $CB_TARGET_NODE"
+    _cb_xn_note ""
+
+    # Auto-exclusions first, so nothing below can resurrect them.
+    local rel why
+    while IFS= read -r rel; do
+        rel=${rel#./}
+        if why=$(_cb_xn_excluded "$rel"); then
+            rm -f "$CB_SRC_DIR/$rel"
+            _cb_xn_note "  excluded  $rel   ($why)"
+        elif _cb_is_cluster_wide "$rel"; then
+            rm -f "$CB_SRC_DIR/$rel"
+            _cb_xn_note "  blocked   $rel   (shared by the cluster; restoring it would delete entries this cluster has and the source did not)"
+        fi
+    done < <(cd "$CB_SRC_DIR" && find . -type f | LC_ALL=C sort)
+    _cb_xn_note ""
+
+    # nodes/<src>/ -> nodes/<tgt>/, resolving the real path rather than the
+    # qemu-server symlink, which the collector already skips.
+    if [[ -d $CB_SRC_DIR/pve/nodes/$src && $src != "$CB_TARGET_NODE" ]]; then
+        mkdir -p "$CB_SRC_DIR/pve/nodes/$CB_TARGET_NODE"
+        cp -a "$CB_SRC_DIR/pve/nodes/$src/." "$CB_SRC_DIR/pve/nodes/$CB_TARGET_NODE/"
+        rm -rf "${CB_SRC_DIR:?}/pve/nodes/$src"
+        _cb_xn_note "  moved     nodes/$src/ -> nodes/$CB_TARGET_NODE/"
+    fi
+
+    # Guests: rename, rewrite, classify.
+    local f base old new taken hostpci
+    _cb_xn_note ""
+    _cb_xn_note "Guests"
+    while IFS= read -r f; do
+        base=$(basename "$f" .conf)
+        [[ $base =~ ^[0-9]+$ ]] || continue
+        old=$base; new=$(_cb_new_vmid "$old")
+
+        hostpci=0
+        grep -qE '^hostpci[0-9]+:' "$f" && hostpci=1
+
+        if [[ $hostpci -eq 1 ]]; then
+            _cb_xn_note "  $old  BLOCKED    hostpci names a PCI address on the source machine"
+            rm -f "$f"
+            continue
+        fi
+        if taken=$(_cb_vmid_taken "$new" "$src"); then
+            _cb_xn_note "  $old  BLOCKED    VMID $new is already live on node $taken"
+            rm -f "$f"
+            continue
+        fi
+
+        _cb_xn_guest "$f" "$old" "$new"
+
+        if [[ $old != "$new" ]]; then
+            mv -f "$f" "$(dirname "$f")/$new.conf"
+            # Nothing here moves storage volumes, so the config now names
+            # volumes that do not exist under that name yet.
+            _cb_xn_note "  $old  DEGRADED   -> $new, but its volumes are still named vm-$old-*"
+        else
+            _cb_xn_note "  $old  restorable"
+        fi
+    done < <(find "$CB_SRC_DIR/pve" -path '*/qemu-server/*.conf' -o -path '*/lxc/*.conf' 2>/dev/null | LC_ALL=C sort)
+    return 0
+}
+
+_cb_show_transform() {
+    [[ -s ${CB_XN_REPORT:-} ]] || return 0
+    printf '\n'
+    cat "$CB_XN_REPORT"
+    printf '\n'
     return 0
 }
 
@@ -1551,6 +1827,12 @@ _cb_list() {
 
 # ----------------------------------------------------------------- main --
 
+_cb_add_map() { # _cb_add_map <arrayname> <A=B>
+    [[ ${2:-} == *=* ]] || { printf 'error: expected A=B, got: %s\n' "${2:-}" >&2; exit 2; }
+    local -n _m=$1
+    _m["${2%%=*}"]="${2#*=}"
+}
+
 _cb_read_conf() {
     if [[ -r $CB_CONF ]]; then
         # shellcheck source=/dev/null
@@ -1607,6 +1889,19 @@ main() {
                     run|restore) CB_FORCE=1 ;;
                     *) printf 'error: --force does not apply to %s\n' "$mode" >&2; exit 2 ;;
                 esac ;;
+            --target-node)
+                [[ $mode == restore ]] || { printf 'error: --target-node only applies to restore\n' >&2; exit 2; }
+                shift; CB_TARGET_NODE=${1:-} ;;
+            --mode)
+                shift; CB_XN_MODE=${1:-} ;;
+            --source-node-gone) CB_XN_SOURCE_GONE=1 ;;
+            --regenerate-macs)  CB_XN_REGEN_MACS=1 ;;
+            --vmid-offset)
+                shift; CB_XN_VMID_OFFSET=${1:-0}
+                [[ $CB_XN_VMID_OFFSET =~ ^-?[0-9]+$ ]] || { printf 'error: --vmid-offset takes a number\n' >&2; exit 2; } ;;
+            --map-storage) shift; _cb_add_map CB_MAP_STORAGE "${1:-}" ;;
+            --map-bridge)  shift; _cb_add_map CB_MAP_BRIDGE  "${1:-}" ;;
+            --map-vmid)    shift; _cb_add_map CB_MAP_VMID    "${1:-}" ;;
             -*) printf 'error: unknown flag: %s\n' "$1" >&2; exit 2 ;;
             *)  operands+=("$1") ;;
         esac

--- a/modules/config-backup/pve-config-backup.sh
+++ b/modules/config-backup/pve-config-backup.sh
@@ -1578,11 +1578,22 @@ _cb_xn_guard() {
         clone)
             [[ $CB_XN_VMID_OFFSET -ne 0 || ${#CB_MAP_VMID[@]} -gt 0 ]] \
                 || fail "--mode clone needs --vmid-offset or --map-vmid: the source node is alive and its VMIDs are taken"
+            local k
+            for k in "${!CB_MAP_VMID[@]}"; do
+                [[ $k =~ ^[0-9]+$ && ${CB_MAP_VMID[$k]} =~ ^[0-9]+$ ]] \
+                    || fail "--map-vmid takes numbers: $k=${CB_MAP_VMID[$k]}"
+                _cb_valid_vmid "${CB_MAP_VMID[$k]}" \
+                    || fail "--map-vmid target ${CB_MAP_VMID[$k]} is not a valid VMID (100-999999999)"
+            done
             ;;
         *) fail "--mode must be dr or clone" ;;
     esac
     return 0
 }
+
+# PVE's own range. A remapped guest that lands outside it cannot be started,
+# and finding that out after the restore is too late.
+_cb_valid_vmid() { [[ $1 =~ ^[0-9]+$ && $1 -ge 100 && $1 -le 999999999 ]]; }
 
 _cb_rand_mac() {
     # Locally administered, unicast: second nibble 2.
@@ -1618,12 +1629,18 @@ _cb_xn_guest() { # _cb_xn_guest <file> <old-vmid> <new-vmid>
     local f=$1 old=$2 new=$3 key from to
     local tmp; tmp=$(mktemp)
 
+    local before
     for key in "${!CB_MAP_STORAGE[@]}"; do
         from=$key; to=${CB_MAP_STORAGE[$key]}
+        before=$(sha256sum "$f" | awk '{print $1}')
         # ^<key>: <storage>: - never a bare or \b match, which would rewrite
         # `my-local` when mapping `local`, since - is a word boundary.
         sed -E -i "s|^([a-z0-9_]+: )${from}:|\1${to}:|" "$f"
-        _cb_xn_note "  storage   $from -> $to   $(basename "$f")"
+        # Only report what actually changed. Noting it unconditionally meant a
+        # typo'd storage name read as a successful mapping in the one report
+        # the operator sees before --confirm.
+        [[ $(sha256sum "$f" | awk '{print $1}') != "$before" ]] \
+            && _cb_xn_note "  storage   $from -> $to   $(basename "$f")"
     done
 
     for key in "${!CB_MAP_BRIDGE[@]}"; do
@@ -1632,31 +1649,58 @@ _cb_xn_guest() { # _cb_xn_guest <file> <old-vmid> <new-vmid>
         # | delimiter made sed reject the expression - which failed silently
         # for every mid-line bridge= and only ever rewrote end-of-line ones.
         # The (,|$) anchor is what stops vmbr0 matching vmbr01.
+        before=$(sha256sum "$f" | awk '{print $1}')
         sed -E -i "s#^(net[0-9]+:.*)bridge=${from}(,|\$)#\1bridge=${to}\2#" "$f"
-        _cb_xn_note "  bridge    $from -> $to   $(basename "$f")"
+        [[ $(sha256sum "$f" | awk '{print $1}') != "$before" ]] \
+            && _cb_xn_note "  bridge    $from -> $to   $(basename "$f")"
     done
 
     if [[ $CB_XN_REGEN_MACS -eq 1 ]]; then
-        # The MAC is the value of the model key. Everything after it - bridge,
-        # tag, firewall, mtu - is preserved byte for byte.
-        while IFS= read -r line; do
-            printf '%s\n' "$line"
-        done < "$f" > "$tmp"
-        : > "$f"
-        while IFS= read -r line; do
-            if [[ $line =~ ^(net[0-9]+:[[:space:]]*[a-z0-9]+=)([0-9A-Fa-f:]{17})(.*)$ ]]; then
-                printf '%s%s%s\n' "${BASH_REMATCH[1]}" "$(_cb_rand_mac)" "${BASH_REMATCH[3]}"
-            else
-                printf '%s\n' "$line"
+        # Two serialisations, not one. qemu writes the MAC as the value of the
+        # model key (`net0: virtio=<mac>,...`); pct writes `hwaddr=<mac>`
+        # inside a comma list. Handling only the first meant --regenerate-macs
+        # silently did nothing to every container while the report said it had
+        # - the one safety control the operator asked for, reporting success.
+        #
+        # The model class allows - and _ because e1000-82545em and ne2k_pci are
+        # real entries in PVE's nic_model_list.
+        #
+        # `|| [[ -n $line ]]` because a file whose last line has no trailing
+        # newline would otherwise lose that line entirely.
+        local -A macmap=()
+        local old_mac new_mac changed=0
+        : > "$tmp"
+        while IFS= read -r line || [[ -n $line ]]; do
+            old_mac=""
+            if [[ $line =~ ^net[0-9]+:[[:space:]]*[a-z0-9_-]+=([0-9A-Fa-f:]{17}) ]]; then
+                old_mac=${BASH_REMATCH[1]}
+            elif [[ $line =~ (^|,)hwaddr=([0-9A-Fa-f:]{17}) ]]; then
+                old_mac=${BASH_REMATCH[2]}
             fi
-        done < "$tmp" >> "$f"
-        _cb_xn_note "  macs      regenerated   $(basename "$f")"
+            if [[ -n $old_mac ]]; then
+                # One new MAC per old MAC, so the same interface keeps the same
+                # address in the running config and in every snapshot stanza -
+                # otherwise rolling back to a snapshot hands the guest a MAC it
+                # never had.
+                [[ -n ${macmap[$old_mac]:-} ]] || macmap[$old_mac]=$(_cb_rand_mac)
+                new_mac=${macmap[$old_mac]}
+                printf '%s\n' "${line//$old_mac/$new_mac}" >> "$tmp"
+                changed=1
+            else
+                printf '%s\n' "$line" >> "$tmp"
+            fi
+        done < "$f"
+        mv -f "$tmp" "$f"
+        [[ $changed -eq 1 ]] && _cb_xn_note "  macs      regenerated   $(basename "$f")"
     fi
 
     if [[ $old != "$new" ]]; then
         # Only the volume tokens. A bare numeric substitution would rewrite
         # `memory: 100` and `tag=100` as well.
-        sed -E -i "s|vm-${old}-|vm-${new}-|g; s|subvol-${old}-|subvol-${new}-|g; s|(:[[:space:]]*[A-Za-z0-9_.-]+:)${old}/|\1${new}/|g" "$f"
+        # base-<id>- as well: a linked clone names its template's volume, and
+        # rewriting only half leaves the two halves naming different guests,
+        # which is worse than leaving both alone.
+        sed -E -i "s|vm-${old}-|vm-${new}-|g; s|subvol-${old}-|subvol-${new}-|g; s|base-${old}-|base-${new}-|g; s|(:[[:space:]]*[A-Za-z0-9_.-]+:)${old}/|\1${new}/|g" "$f"
         _cb_xn_note "  vmid      $old -> $new   volumes must be moved separately"
     fi
     rm -f "$tmp"
@@ -1687,6 +1731,27 @@ _cb_transform() { # _cb_transform -> rewrites CB_SRC_DIR in place
     done < <(cd "$CB_SRC_DIR" && find . -type f | LC_ALL=C sort)
     _cb_xn_note ""
 
+    # Derive the source node from the staged tree, not from metadata. A wrong
+    # name made the rename below silently no-op while the guest loop still
+    # rewrote configs under nodes/<source>/ - which maps onto that node's live
+    # pmxcfs directory, so restoring on pve2 overwrote pve1's running guests.
+    local -a staged_nodes=()
+    local d
+    for d in "$CB_SRC_DIR"/pve/nodes/*/; do
+        [[ -d $d ]] || continue
+        staged_nodes+=("$(basename "$d")")
+    done
+    if [[ ${#staged_nodes[@]} -gt 1 ]]; then
+        fail "the source holds more than one node directory (${staged_nodes[*]}) - refusing to guess which to transform"
+    fi
+    if [[ ${#staged_nodes[@]} -eq 1 ]]; then
+        if [[ -n $src && $src != unknown && $src != "${staged_nodes[0]}" ]]; then
+            fail "the source says node '$src' but its tree holds nodes/${staged_nodes[0]} - refusing to transform an inconsistent archive"
+        fi
+        src=${staged_nodes[0]}
+        _cb_xn_note "  source    nodes/$src/ (read from the tree)"
+    fi
+
     # nodes/<src>/ -> nodes/<tgt>/, resolving the real path rather than the
     # qemu-server symlink, which the collector already skips.
     if [[ -d $CB_SRC_DIR/pve/nodes/$src && $src != "$CB_TARGET_NODE" ]]; then
@@ -1704,12 +1769,21 @@ _cb_transform() { # _cb_transform -> rewrites CB_SRC_DIR in place
         base=$(basename "$f" .conf)
         [[ $base =~ ^[0-9]+$ ]] || continue
         old=$base; new=$(_cb_new_vmid "$old")
+        if ! _cb_valid_vmid "$new"; then
+            _cb_xn_note "  $old  BLOCKED    $new is not a valid VMID (100-999999999)"
+            rm -f "$f"
+            continue
+        fi
 
         hostpci=0
         grep -qE '^hostpci[0-9]+:' "$f" && hostpci=1
+        # usb0: host=1-4 is a physical bus-port on the source machine, exactly
+        # as unportable as a PCI address. host=<vendor>:<product> is portable
+        # and stays.
+        grep -qE '^usb[0-9]+:.*host=[0-9]+-[0-9]+' "$f" && hostpci=1
 
         if [[ $hostpci -eq 1 ]]; then
-            _cb_xn_note "  $old  BLOCKED    hostpci names a PCI address on the source machine"
+            _cb_xn_note "  $old  BLOCKED    it names host hardware (PCI address or USB bus-port) on the source machine"
             rm -f "$f"
             continue
         fi

--- a/tests/config-backup.sh
+++ b/tests/config-backup.sh
@@ -542,3 +542,135 @@ sleep 0.3
 kill "$holder" 2>/dev/null || true
 wait "$holder" 2>/dev/null || true
 pass "the lock is exclusive"
+
+# --- 9. cross-node transform ----------------------------------------------
+
+# A pmxcfs-shaped fixture: the real collector never produces the flat
+# pve/qemu-server layout, because those are symlinks into nodes/<local>/.
+xn_fixture() { # xn_fixture -> sets XSRC to a fresh staged tree
+    XSRC=$(mktemp -d "$WORK/xnXXXXXX")
+    mkdir -p "$XSRC/pve/nodes/pve1/qemu-server" "$XSRC/pve/nodes/pve1/lxc" \
+             "$XSRC/meta" "$XSRC/host/etc/network"
+    cat > "$XSRC/pve/nodes/pve1/qemu-server/100.conf" <<'CONF'
+cores: 4
+memory: 100
+name: web01
+net0: virtio=AA:BB:CC:11:22:33,bridge=vmbr0,firewall=1,tag=100
+scsi0: local-lvm:vm-100-disk-0,size=32G
+scsi1: local:100/vm-100-disk-1.qcow2,size=100G
+efidisk0: local-lvm:vm-100-disk-2,efitype=4m,size=1M
+unused0: local-lvm:vm-100-disk-9
+vmstate: local-lvm:vm-100-state-snap
+
+[snap]
+memory: 100
+net0: virtio=AA:BB:CC:11:22:33,bridge=vmbr0
+scsi0: local-lvm:vm-100-disk-0,size=32G
+CONF
+    cat > "$XSRC/pve/nodes/pve1/lxc/200.conf" <<'CONF'
+arch: amd64
+rootfs: local-lvm:subvol-200-disk-0,size=8G
+mp0: local:200/vm-200-disk-1.raw,mp=/data
+net0: veth=AA:BB:CC:00:11:22,bridge=vmbr0,name=eth0
+CONF
+    printf 'name: gpu\nhostpci0: 0000:01:00.0,pcie=1\n' > "$XSRC/pve/nodes/pve1/qemu-server/300.conf"
+    printf 'dir: local\n\tnodes pve1,pve2\n' > "$XSRC/pve/storage.cfg"
+    printf 'auto vmbr0\n' > "$XSRC/host/etc/network/interfaces"
+    printf 'node=pve1\n' > "$XSRC/meta/capture.txt"
+}
+
+XLIVE=$(mktemp -d "$WORK/xliveXXXXXX"); mkdir -p "$XLIVE/pve/nodes/pve2"
+# HOST_SHORT is what the guard compares --target-node against, so the fixture
+# has to pretend to be pve2 rather than whatever machine runs the tests.
+xn_run() {
+    CB_SRC_DIR=$XSRC CB_SRC_NODE=pve1 CB_PVE_DIR="$XLIVE/pve" HOST_SHORT=pve2 \
+    _cb_transform >/dev/null 2>&1
+}
+
+# --target-node has to name this host. Writing another node's sshd_config or
+# cron.d through a shared /etc/pve would land on the wrong machine, and the
+# rollback point would be recorded on the wrong machine too.
+xn_fixture
+( CB_TARGET_NODE=somewhere-else CB_XN_MODE=dr CB_XN_SOURCE_GONE=1
+  CB_SRC_DIR=$XSRC CB_SRC_NODE=pve1 CB_PVE_DIR="$XLIVE/pve" HOST_SHORT=pve2
+  _cb_transform ) >/dev/null 2>&1 && fail "--target-node accepted a node that is not this host"
+pass "cross-node writes only to this host"
+
+# dr mode reuses the source's identities, and the tool cannot tell a dead node
+# from a partitioned one.
+( CB_TARGET_NODE=pve2 CB_XN_MODE=dr CB_XN_SOURCE_GONE=0
+  CB_SRC_DIR=$XSRC CB_SRC_NODE=pve1 CB_PVE_DIR="$XLIVE/pve" HOST_SHORT=pve2
+  _cb_transform ) >/dev/null 2>&1 && fail "dr mode ran without acknowledging the source is gone"
+( CB_TARGET_NODE=pve2 CB_XN_MODE=clone CB_XN_VMID_OFFSET=0
+  CB_SRC_DIR=$XSRC CB_SRC_NODE=pve1 CB_PVE_DIR="$XLIVE/pve" HOST_SHORT=pve2
+  _cb_transform ) >/dev/null 2>&1 && fail "clone mode ran without a VMID remap"
+pass "the modes demand what they need"
+
+# The whole transform, with every mapping on.
+xn_fixture
+( CB_TARGET_NODE=pve2 CB_XN_MODE=clone CB_XN_VMID_OFFSET=1000 CB_XN_REGEN_MACS=1
+  CB_MAP_STORAGE=([local]=nas) CB_MAP_BRIDGE=([vmbr0]=vmbr9)
+  xn_run )
+Q="$XSRC/pve/nodes/pve2/qemu-server/1100.conf"
+L="$XSRC/pve/nodes/pve2/lxc/1200.conf"
+[[ -f $Q ]] || fail "the qemu config was not moved to the target node and renamed"
+[[ -f $L ]] || fail "the lxc config was not moved to the target node and renamed"
+[[ -d $XSRC/pve/nodes/pve1 ]] && fail "the source node directory survived"
+pass "node path and VMID rename"
+
+# A bare numeric substitution would have destroyed both of these.
+grep -q '^memory: 100$' "$Q" || fail "memory: 100 was rewritten by the VMID remap"
+grep -q 'tag=100' "$Q"      || fail "the VLAN tag 100 was rewritten by the VMID remap"
+# Every volume-bearing key, including the ones that are easy to forget.
+grep -q 'vm-1100-disk-0' "$Q"      || fail "scsi0 volume not rewritten"
+grep -q 'nas:1100/vm-1100-disk-1' "$Q" || fail "the vmid in the directory prefix was not rewritten"
+grep -q 'efidisk0: local-lvm:vm-1100-disk-2' "$Q" || fail "efidisk not rewritten"
+grep -q 'unused0: local-lvm:vm-1100-disk-9'  "$Q" || fail "unused disk not rewritten"
+grep -q 'vmstate: local-lvm:vm-1100-state'   "$Q" || fail "vmstate not rewritten"
+grep -q 'subvol-1200-disk-0' "$L"  || fail "the lxc rootfs subvol was not rewritten"
+grep -q 'nas:1200/vm-1200-disk-1' "$L" || fail "the lxc mount point was not rewritten"
+# The snapshot stanza carries its own copy of every disk line.
+awk '/^\[snap\]/{s=1} s' "$Q" | grep -q 'vm-1100-disk-0' \
+    || fail "the snapshot section was not rewritten"
+pass "volume tokens only"
+
+# Anchored on the field, so a storage whose name merely contains the mapped one
+# is left alone.
+grep -q '^scsi0: local-lvm:' "$Q" || fail "local-lvm was clobbered by the 'local' mapping"
+grep -q '^scsi1: nas:'       "$Q" || fail "the 'local' storage was not mapped"
+pass "storage mapping is anchored"
+
+# The MAC is the value of the model key; everything after it survives.
+grep -qE '^net0: virtio=BC:24:11:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2},bridge=vmbr9,firewall=1,tag=100$' "$Q" \
+    || fail "the regenerated net0 line lost its model or its options: $(grep '^net0:' "$Q")"
+grep -qE '^net0: veth=BC:24:11:' "$L" || fail "the lxc MAC was not regenerated"
+pass "MAC regeneration keeps the rest of the line"
+
+# Hardware and identity that did not move with the config.
+[[ -e $XSRC/host/etc/network/interfaces ]] && fail "interfaces survived a cross-node restore"
+# Shared by the whole cluster: installing the source's copy would delete every
+# entry this cluster has that the source lacked.
+[[ -e $XSRC/pve/storage.cfg ]] && fail "storage.cfg was not blocked on a cross-node restore"
+pass "auto-exclusions and cluster-wide blocks"
+
+# hostpci names a PCI address on the source machine.
+[[ -e $XSRC/pve/nodes/pve2/qemu-server/1300.conf ]] && fail "a hostpci guest was not blocked"
+pass "hostpci guests are blocked"
+
+# A VMID already live on another node is a collision; one under the source
+# node's own tree is not, because a dead node's tree survives and dr mode
+# exists to reuse exactly that VMID.
+xn_fixture
+mkdir -p "$XLIVE/pve/nodes/pve3/qemu-server"
+printf 'name: existing\n' > "$XLIVE/pve/nodes/pve3/qemu-server/100.conf"
+( CB_TARGET_NODE=pve2 CB_XN_MODE=dr CB_XN_SOURCE_GONE=1; xn_run )
+[[ -e $XSRC/pve/nodes/pve2/qemu-server/100.conf ]] \
+    && fail "a VMID live on another node was not treated as a collision"
+mkdir -p "$XLIVE/pve/nodes/pve1/qemu-server"
+printf 'name: stale\n' > "$XLIVE/pve/nodes/pve1/qemu-server/200.conf"
+xn_fixture
+( CB_TARGET_NODE=pve2 CB_XN_MODE=dr CB_XN_SOURCE_GONE=1; xn_run )
+[[ -e $XSRC/pve/nodes/pve2/lxc/200.conf ]] \
+    || fail "a stale entry under the dead source node was treated as a collision"
+rm -rf "$XLIVE/pve/nodes/pve3" "$XLIVE/pve/nodes/pve1"
+pass "VMID collisions distinguish live from stale"

--- a/tests/config-backup.sh
+++ b/tests/config-backup.sh
@@ -851,6 +851,64 @@ xn_run() {
     _cb_transform >/dev/null 2>&1
 }
 
+# /etc/pve is a cluster filesystem: nodes/ holds a directory per member and
+# the collector takes it whole, so more than one is the normal case on any
+# clustered host. Refusing it made cross-node restore impossible from exactly
+# the topology the feature exists for - and the fixture only ever built one
+# node, so nothing in the suite could see it.
+xn_fixture
+mkdir -p "$XSRC/pve/nodes/pve7/qemu-server" "$XSRC/pve/nodes/pve8/qemu-server"
+printf 'name: other7\n' > "$XSRC/pve/nodes/pve7/qemu-server/700.conf"
+printf 'name: other8\n' > "$XSRC/pve/nodes/pve8/qemu-server/800.conf"
+( CB_TARGET_NODE=pve2 CB_XN_MODE=dr CB_XN_SOURCE_GONE=1; xn_run ) \
+    || fail "a clustered archive was refused"
+[[ -f $XSRC/pve/nodes/pve2/qemu-server/100.conf ]] \
+    || fail "the source node's guest did not reach the target"
+[[ -e $XSRC/pve/nodes/pve7 || -e $XSRC/pve/nodes/pve8 ]] \
+    && fail "another node's guests survived the transform"
+pass "a clustered archive transforms, and other nodes are dropped"
+
+# cp -a resolves through a symlinked node directory, materialising files from
+# outside the archive as regular files before the restore plan can apply its
+# own symlink guard.
+xn_fixture
+outside=$(mktemp -d "$WORK/outsideXXXXXX"); mkdir -p "$outside/qemu-server"
+printf 'name: evil\n' > "$outside/qemu-server/999.conf"
+rm -rf "$XSRC/pve/nodes/pve1"; ln -s "$outside" "$XSRC/pve/nodes/pve1"
+( CB_TARGET_NODE=pve2 CB_XN_MODE=dr CB_XN_SOURCE_GONE=1; xn_run ) \
+    && fail "a symlinked node directory was transformed"
+[[ -e $XSRC/pve/nodes/pve2/qemu-server/999.conf ]] \
+    && fail "a file from outside the archive was staged"
+pass "a symlinked node directory is refused"
+
+# A guest's own <vmid>.fw is not cluster-shared - dropping it brings the guest
+# up on the target with no firewall at all.
+xn_fixture
+mkdir -p "$XSRC/pve/firewall"
+printf '[OPTIONS]\npolicy_in: DROP\n' > "$XSRC/pve/firewall/100.fw"
+printf '[OPTIONS]\n' > "$XSRC/pve/firewall/cluster.fw"
+( CB_TARGET_NODE=pve2 CB_XN_MODE=dr CB_XN_SOURCE_GONE=1; xn_run )
+[[ -e $XSRC/pve/firewall/100.fw ]] || fail "a guest's own firewall rules were dropped as cluster-wide"
+[[ -e $XSRC/pve/firewall/cluster.fw ]] && fail "cluster.fw was not blocked"
+pass "guest firewall rules survive, cluster.fw does not"
+
+# A typo in dr mode used to reach the per-guest check and drop that guest with
+# a line in the report, rather than refusing before anything ran.
+xn_fixture
+( CB_TARGET_NODE=pve2 CB_XN_MODE=dr CB_XN_SOURCE_GONE=1
+  CB_MAP_VMID=([100]=1O0); xn_run ) && fail "a non-numeric --map-vmid was accepted in dr mode"
+pass "--map-vmid is validated in both modes"
+
+# A storage ID may contain a dot, which is a wildcard in the ERE the mapping
+# is interpolated into.
+xn_fixture
+printf 'name: x\nscsi9: localXssd:vm-100-disk-9\n' >> "$XSRC/pve/nodes/pve1/qemu-server/100.conf"
+( CB_TARGET_NODE=pve2 CB_XN_MODE=dr CB_XN_SOURCE_GONE=1
+  CB_MAP_STORAGE=([local.ssd]=nas); xn_run )
+grep -q 'localXssd:' "$XSRC/pve/nodes/pve2/qemu-server/100.conf" \
+    || fail "a dot in a storage map key matched any character"
+pass "map keys are escaped before they reach sed"
+
 # --target-node has to name this host. Writing another node's sshd_config or
 # cron.d through a shared /etc/pve would land on the wrong machine, and the
 # rollback point would be recorded on the wrong machine too.

--- a/tests/config-backup.sh
+++ b/tests/config-backup.sh
@@ -691,6 +691,7 @@ cores: 4
 memory: 100
 name: web01
 net0: virtio=AA:BB:CC:11:22:33,bridge=vmbr0,firewall=1,tag=100
+net1: e1000-82545em=AA:BB:CC:11:22:34,bridge=vmbr1,mtu=9000
 scsi0: local-lvm:vm-100-disk-0,size=32G
 scsi1: local:100/vm-100-disk-1.qcow2,size=100G
 efidisk0: local-lvm:vm-100-disk-2,efitype=4m,size=1M
@@ -702,11 +703,15 @@ memory: 100
 net0: virtio=AA:BB:CC:11:22:33,bridge=vmbr0
 scsi0: local-lvm:vm-100-disk-0,size=32G
 CONF
+    # Real pct syntax. The old fixture wrote `net0: veth=<mac>,...`, which pct
+    # never emits - so the MAC assertion was validating the implementation
+    # against itself while --regenerate-macs did nothing to any container.
     cat > "$XSRC/pve/nodes/pve1/lxc/200.conf" <<'CONF'
 arch: amd64
 rootfs: local-lvm:subvol-200-disk-0,size=8G
 mp0: local:200/vm-200-disk-1.raw,mp=/data
-net0: veth=AA:BB:CC:00:11:22,bridge=vmbr0,name=eth0
+net0: name=eth0,bridge=vmbr0,firewall=1,hwaddr=BC:24:11:11:22:33,ip=dhcp,type=veth
+net1: name=eth1,bridge=vmbr0,hwaddr=BC:24:11:44:55:66,ip=10.0.0.5/24,type=veth
 CONF
     printf 'name: gpu\nhostpci0: 0000:01:00.0,pcie=1\n' > "$XSRC/pve/nodes/pve1/qemu-server/300.conf"
     printf 'dir: local\n\tnodes pve1,pve2\n' > "$XSRC/pve/storage.cfg"
@@ -778,7 +783,10 @@ pass "storage mapping is anchored"
 # The MAC is the value of the model key; everything after it survives.
 grep -qE '^net0: virtio=BC:24:11:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2},bridge=vmbr9,firewall=1,tag=100$' "$Q" \
     || fail "the regenerated net0 line lost its model or its options: $(grep '^net0:' "$Q")"
-grep -qE '^net0: veth=BC:24:11:' "$L" || fail "the lxc MAC was not regenerated"
+grep -qE '^net0: name=eth0,bridge=vmbr9,firewall=1,hwaddr=BC:24:11:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2},ip=dhcp,type=veth$' "$L" \
+    || fail "the lxc hwaddr was not regenerated, or the rest of the line moved: $(grep '^net0:' "$L")"
+grep -qE '^net1: e1000-82545em=BC:24:11:' "$Q" \
+    || fail "a hyphenated NIC model was skipped: $(grep '^net1:' "$Q")"
 pass "MAC regeneration keeps the rest of the line"
 
 # Hardware and identity that did not move with the config.


### PR DESCRIPTION
Phase 4 of #3, the last one, stacked on #10. Merge #8, #9, #10 first.

A transform layer between extracting a source and planning the restore,
rewriting the staged tree to describe the target node instead of the source,
with a full report printed before anything is written.

## Three things I got wrong first

Written against real `qemu-server`/`lxc` syntax rather than from memory, after
checking. Each of these would have shipped broken:

- **A net line has no `macaddr=` key.** The MAC is the *value* of the model
  key — `net0: virtio=AA:BB:CC:11:22:33,bridge=vmbr0`. A transform written the
  obvious way matches nothing, does nothing, and reports success.
- **`storage.cfg`'s `nodes` field lists node names, not storage names**, so it
  belongs to the node rename, not `--map-storage`.
- **A bare VMID substitution destroys `memory: 100` and `tag=100`.** Only the
  `vm-<id>-`, `subvol-<id>-` and `<id>/` tokens may move.

Storage mapping is anchored on the field. A `\b`-delimited match would rewrite
`my-local` when mapping `local`, because `-` is a word boundary.

Coverage includes `efidiskN`, `tpmstateN`, `unusedN` and `vmstate` alongside
the disk buses, LXC's `rootfs`/`mpN` alongside qemu's, and reaches inside
`[snapshot]` and `[PENDING]` sections — which carry their own full copies of
every disk line.

## What it refuses to do

Refusing beats a transform that is right most of the time.

- **`--target-node` must name this host.** A cross-node restore still writes
  host-level files through *this* machine's filesystem and records its rollback
  point in *this* machine's state — naming another node puts both on the wrong
  box. SSH to the target and run it there.
- **Cluster-shared files are blocked, and `--force` does not lift it.**
  `storage.cfg`, `datacenter.cfg`, `user.cfg`, `jobs.cfg`, `firewall/`, `sdn/`,
  `ha/` are one file for the whole cluster, and a restore installs whole files.
  Restoring another node's copy would delete every entry this cluster has and
  the source lacked — instantly, everywhere. Doing it correctly needs per-entry
  merge semantics this tool doesn't have, and half of it is worse than none.
- **A VMID-remapped guest is `degraded`, never `restorable`.** The config is
  rewritten; the volumes are not, because nothing here touches storage. 100 →
  1100 refers to `vm-1100-disk-0` while the volume is still `vm-100-disk-0`.
  The report names them.
- **`--mode dr` requires `--source-node-gone`.** DR mode deliberately reuses the
  source's VMIDs, MACs and IPs. This tool cannot tell a dead node from a
  partitioned one, and guessing wrong puts a second guest with a duplicate
  identity on the network, possibly writing to the same shared storage.

## Other decisions

A VMID live on *another* node blocks that guest; one under the source node's
own directory does not — a dead node's tree survives in pmxcfs, and reusing
that VMID is the entire point of DR mode.

The selector is applied *before* the transform, so scoping by the VMID you can
see in `inspect` selects what you meant rather than silently nothing.

Fixtures are pmxcfs-shaped (`nodes/<node>/qemu-server/`), because the real
collector never produces the flat layout — it has skipped those symlinks since
Phase 1.

## Verification

`make lint`, `make test`, `mkdocs build --strict` pass. 38 assertion groups in
`tests/config-backup.sh` overall, 10 new here — including that `memory: 100`
and `tag=100` survive a VMID remap, that `local-lvm` survives mapping `local`,
that a regenerated net line keeps its model and every trailing option
byte-identical, and that a stale entry under the dead source node is not
mistaken for a collision.

One bug the tests caught: the bridge rewrite used `|` as its sed delimiter
while the pattern also contained one, so every mid-line `bridge=` silently
failed and only end-of-line ones worked.