### PR TITLE
fix(modules): harden destructive and scheduled operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ test: syntax
 	@./tests/lib.sh
 	@./tests/discord.sh
 	@./tests/config-backup.sh
+	@./tests/hardening.sh
 	@./tests/smoke.sh
 	@./tests/completion-zsh.sh
 	@./tests/tui.sh

--- a/docs/modules/config-backup.md
+++ b/docs/modules/config-backup.md
@@ -427,6 +427,13 @@ A failed capture always reports. `CB_NOTIFY_ON_CHANGE=1` additionally reports
 when the configuration changed — off by default, because editing a guest is
 routine and a channel that pings on every edit stops being read.
 
+Archive and Git directories are canonicalized before installation, every
+runner invocation, and deletion. Filesystem roots and broad system locations
+such as `/`, `/etc`, `/etc/pve`, `/var/lib` and the toolbox's own shared
+directories are refused; use a dedicated child directory instead. The same
+check follows existing symlinks, so a harmless-looking path cannot redirect a
+recursive operation onto a protected root.
+
 ## Env vars for `-y`
 
 | Variable | Default | Meaning |
@@ -512,6 +519,6 @@ and the timer's `OnCalendar` is read back off disk and preserved.
 `check` reports whether the runner or the config is out of sync and changes
 nothing. `-f` forces the reinstall even when everything already matches.
 
-Uninstall removes the runner, the unit and the state, asks before removing the
-config, and asks separately before deleting the archives — defaulting to
-keeping them.
+Uninstall validates both data paths before removing anything, then removes the
+runner, unit and state. It asks independently before removing the config, the
+archives, and the Git history; both data stores default to being kept.

--- a/docs/modules/scrutiny-collectors.md
+++ b/docs/modules/scrutiny-collectors.md
@@ -27,14 +27,19 @@ there is no `zpool` binary.
 
 `update` does more than swap binaries:
 
-1. Pauses the timers and waits for any in-flight collection to finish.
-2. Replaces each binary, keeping the old one as `.prev`.
-3. Smoke-tests each collector by running its unit once.
-4. Rolls back the ones that failed, and re-tests them on the previous build.
-5. Resumes the timers.
+1. Downloads and checksum-verifies every required binary while the installed
+   release and timers remain operational.
+2. Pauses the timers and waits for any in-flight collection to finish.
+3. Replaces every binary, keeping the old ones as `.prev`.
+4. Smoke-tests each collector by running its unit once.
+5. Rolls back the whole release if any collector fails, avoiding mixed
+   versions, and re-tests the previous build.
+6. Resumes every timer, including on replacement or smoke-test failure.
 
 The recorded version only advances if **every** collector passed. If any
-rolled back, state stays at the old version and the run says which ones.
+rolled back, state stays at the old version and the run says which ones. A
+missing asset, failed download or bad checksum is detected before timers are
+paused or installed binaries are touched.
 
 Release assets are checksum-verified when the release ships a checksum file.
 

--- a/docs/modules/zfs-replication.md
+++ b/docs/modules/zfs-replication.md
@@ -42,7 +42,10 @@ JOB_APPDATA_PATH=''                 # blank = the target's own mountpoint
 
 Job keys are the job name uppercased with anything non-alphanumeric turned
 into `_`. Job names must match `^[A-Za-z][A-Za-z0-9_.:-]*$`, because they
-become systemd instance names.
+become systemd instance names. The normalized key must also be unique:
+`app-data` and `app_data` cannot coexist because both would become
+`JOB_APP_DATA_*`. Install, update, status and the runner all reject that
+configuration instead of choosing one silently.
 
 ## What the report says
 
@@ -63,17 +66,26 @@ code and the last 25 log lines in a code block.
 
 **`flock` per job.** A run that overruns its schedule will not have a second
 copy started on top of it — the next trigger sees the lock, logs, and exits 0.
+Locks live under root-owned, mode `0700` `/run/pve-toolbox`, are opened without
+truncation, and fail closed if the directory or lock cannot be verified.
 
 **Logs are not in `/tmp`.** Each run writes `/var/log/pve-toolbox/<job>.log`
 at `0640`, keeping the previous run as `.log.prev`.
 
 **Ownership fixups are reported, not assumed.** If `chown`/`chmod` was
-requested but the target has no mountpoint, or the path is not a directory,
-the run finishes **yellow** and says so, instead of reporting a clean success.
+requested but the target has no local mountpoint, the path is not a directory,
+or either command fails, the run records a degraded result, finishes yellow,
+and exits non-zero instead of reporting a clean success.
 
 **The target path is derived.** With `JOB_*_PATH` blank the fixup applies to
 the target dataset's own `mountpoint`, so there is no hardcoded `/mnt/...` to
-go stale.
+go stale. An explicit path must resolve to that mountpoint or one of its
+children. Broad roots such as `/`, `/etc`, `/var` and `/mnt` are always
+refused before a recursive permission change.
+
+Every schedule is validated with `systemd-analyze calendar` before its timer is
+written. A timer that systemd cannot enable fails installation or update rather
+than being counted as a working job.
 
 !!! tip "Why the payload is built with `jq`"
 
@@ -125,5 +137,6 @@ schedule, and the outcome of its last run.
 
 `update` re-syncs the installed runner and the unit files with the checkout,
 offers to remove timers for jobs no longer in `JOBS`, and prompts for the
-settings of jobs that are configured but have no timer. `check` reports that
+settings of jobs that are configured but have no timer. Invalid schedules are
+reported and rewritten through the same validated prompt. `check` reports that
 without changing anything.

--- a/docs/modules/zfs-scrub.md
+++ b/docs/modules/zfs-scrub.md
@@ -83,7 +83,13 @@ The webhook URL is the only credential Discord checks, so it goes through
 | `ZFS_SCRUB_SCHEDULE_<POOL>` | staggered | `OnCalendar` for that pool        |
 
 `<POOL>` is the pool name uppercased with anything non-alphanumeric turned
-into `_`, so `tank-ssd` reads `ZFS_SCRUB_SCHEDULE_TANK_SSD`.
+into `_`, so `tank-ssd` reads `ZFS_SCRUB_SCHEDULE_TANK_SSD`. Two selected pools
+must not normalize to the same variable: `tank-ssd` and `tank_ssd` are rejected
+instead of silently receiving one shared schedule.
+
+Schedules are validated with `systemd-analyze calendar` before timer files are
+written. A timer enable failure fails installation or update, and existing
+invalid timer schedules are surfaced by status and repaired through update.
 
 ## Conflicting timers
 
@@ -107,5 +113,5 @@ alone and exits 0.
 
 There is no upstream release to track. `update` re-syncs the installed watcher
 and the unit files with the checkout, removes timers for pools that no longer
-exist, and offers to schedule pools created since the last run. `check`
-reports all of that without changing anything.
+exist, offers to schedule pools created since the last run, and repairs invalid
+schedules. `check` reports all of that without changing anything.

--- a/modules/config-backup/module.sh
+++ b/modules/config-backup/module.sh
@@ -102,6 +102,25 @@ _cb_archive_dir() {
     printf '%s' "${d:-/var/lib/pve-toolbox/config-backup}"
 }
 
+# Resolve a data directory before anything changes its mode or removes it.
+# Dedicated directories below these roots are fine; the roots themselves are
+# not. An operator typo such as CB_ARCHIVE_DIR=/ must never turn an install into
+# `chmod 0700 /` or an uninstall into `rm -rf /`.
+_cb_safe_data_dir() { # _cb_safe_data_dir <path> -> canonical path, or 1
+    local p
+    [[ ${1:-} == /* ]] || return 1
+    p=$(realpath -m -- "$1" 2>/dev/null) || return 1
+    case $p in
+        /|/bin|/boot|/dev|/etc|/etc/pve|/home|/lib|/lib64|/media|/mnt|/opt|/proc|/root|/run|/sbin|/srv|/sys|/tmp|/usr|/usr/local|/var|/var/lib|/var/lib/pve-cluster|/var/lib/pve-toolbox|/var/lib/vz)
+            return 1 ;;
+    esac
+    case $p in
+        "$TOOLBOX_BIN_DIR"|"$TOOLBOX_CONF_DIR"|"$TOOLBOX_LIB_DIR"|"$TOOLBOX_STATE_DIR"|"$TOOLBOX_SYSTEMD_DIR")
+            return 1 ;;
+    esac
+    printf '%s' "$p"
+}
+
 _cb_webhook_shown() {
     local f url
     f=$(conf_file "$MODULE_NAME")
@@ -294,8 +313,8 @@ module_install() {
     require_pve
     _cb_defaults
     _cb_seed_from_conf
-    # git belongs to the git backend, which is a later release. curl and jq are
-    # what discord.sh needs; tar and gzip are essential and always present.
+    # curl and jq are what discord.sh needs; tar and gzip are essential and
+    # always present. Git and rsync are installed only when that backend is on.
     pkg_ensure curl:curl jq:jq util-linux:flock
 
     step "Discord webhook"
@@ -324,7 +343,8 @@ module_install() {
 
     step "Archives"
     ask CB_ARCHIVE_DIR "directory for the archives" "$CB_ARCHIVE_DIR"
-    [[ $CB_ARCHIVE_DIR == /* ]] || die "the archive directory has to be an absolute path"
+    CB_ARCHIVE_DIR=$(_cb_safe_data_dir "$CB_ARCHIVE_DIR") \
+        || die "refusing unsafe archive directory: $CB_ARCHIVE_DIR"
 
     ask CB_RETENTION_COUNT "keep at least this many archives, whatever their age" "$CB_RETENTION_COUNT"
     ask CB_RETENTION_DAYS  "beyond that, prune archives older than this many days" "$CB_RETENTION_DAYS"
@@ -357,7 +377,8 @@ module_install() {
         pkg_ensure git:git rsync:rsync
         ask CB_GIT_DIR    "working clone directory" "$CB_GIT_DIR"
         ask CB_GIT_BRANCH "branch"                  "$CB_GIT_BRANCH"
-        [[ $CB_GIT_DIR == /* ]] || die "the git directory has to be an absolute path"
+        CB_GIT_DIR=$(_cb_safe_data_dir "$CB_GIT_DIR") \
+            || die "refusing unsafe git directory: $CB_GIT_DIR"
         _cb_dirs_nested "$CB_GIT_DIR" "$CB_ARCHIVE_DIR" \
             && die "the git directory and the archive directory must not nest"
 
@@ -468,6 +489,13 @@ module_update() {
     [[ $new != "$cur" ]] && drift=1
 
     _cb_missing_conf_keys
+
+    _cb_safe_data_dir "$(_cb_archive_dir)" >/dev/null \
+        || die "refusing unsafe CB_ARCHIVE_DIR in $(conf_file "$MODULE_NAME")"
+    if [[ $(conf_get "$MODULE_NAME" CB_GIT_ENABLED) == 1 ]]; then
+        _cb_safe_data_dir "$(conf_get "$MODULE_NAME" CB_GIT_DIR)" >/dev/null \
+            || die "refusing unsafe CB_GIT_DIR in $(conf_file "$MODULE_NAME")"
+    fi
 
     local count
     count=$(state_get "$MODULE_NAME" ARCHIVE_COUNT)
@@ -653,8 +681,16 @@ module_status_long() {
 
 module_uninstall() {
     require_root
-    local dir
+    local dir gdir
     dir=$(_cb_archive_dir)
+    # Capture both paths before the default config-removal choice erases them.
+    gdir=$(conf_get "$MODULE_NAME" CB_GIT_DIR)
+    # Validate before removing even the units or config. Re-check immediately
+    # before each recursive delete below in case a path is replaced meanwhile.
+    [[ ! -d $dir ]] || _cb_safe_data_dir "$dir" >/dev/null \
+        || die "refusing unsafe archive directory: $dir"
+    [[ -z $gdir || ! -d $gdir ]] || _cb_safe_data_dir "$gdir" >/dev/null \
+        || die "refusing unsafe git directory: $gdir"
 
     systemd_remove "$CB_UNIT"
     rm -f "$TOOLBOX_BIN_DIR/$CB_BIN"
@@ -679,20 +715,25 @@ module_uninstall() {
         local drop_data=n
         ask_yn drop_data "also delete the archives in $dir" "n"
         if [[ $drop_data == y ]]; then
-            rm -rf "${dir:?}"
-            warn "deleted $dir"
+            local safe_dir
+            safe_dir=$(_cb_safe_data_dir "$dir") \
+                || die "refusing to delete unsafe archive directory: $dir"
+            rm -rf -- "${safe_dir:?}"
+            warn "deleted $safe_dir"
         else
             ok "archives left in place: $dir"
         fi
     fi
     # The git history is as much the point of the module as the archives are.
-    local gdir; gdir=$(conf_get "$MODULE_NAME" CB_GIT_DIR)
     if [[ -n $gdir && -d $gdir ]]; then
         local drop_git=n
         ask_yn drop_git "also delete the git history in $gdir" "n"
         if [[ $drop_git == y ]]; then
-            rm -rf "${gdir:?}"
-            warn "deleted $gdir"
+            local safe_gdir
+            safe_gdir=$(_cb_safe_data_dir "$gdir") \
+                || die "refusing to delete unsafe git directory: $gdir"
+            rm -rf -- "${safe_gdir:?}"
+            warn "deleted $safe_gdir"
         else
             ok "git history left in place: $gdir"
         fi

--- a/modules/config-backup/pve-config-backup.sh
+++ b/modules/config-backup/pve-config-backup.sh
@@ -54,9 +54,9 @@ set -Eeuo pipefail
 #     CB_RETENTION_DAYS=90
 #     CB_NOTIFY_ON_CHANGE=0
 #
-# This release captures. It does not restore: every collected path already
-# carries a restore class in the manifest, and the writer that reads them back
-# lands in a later release.
+# Captures and restores use the same manifest classes. The restore path
+# re-derives each class from the current policy rather than trusting an older
+# archive's label.
 
 # ---------------------------------------------------------------- config --
 
@@ -1102,6 +1102,20 @@ CB_SRC_DIR=""
 CB_SRC_HASH=""
 CB_SRC_NODE=""
 CB_SELECTOR=""
+
+# Resolve operator-configured storage paths before any chmod, write, prune or
+# restore-side backup uses them. Dedicated children are allowed; broad system
+# roots are not.
+_cb_safe_data_dir() { # _cb_safe_data_dir <path> -> canonical path, or 1
+    local p
+    [[ ${1:-} == /* ]] || return 1
+    p=$(realpath -m -- "$1" 2>/dev/null) || return 1
+    case $p in
+        /|/bin|/boot|/dev|/etc|/etc/pve|/home|/lib|/lib64|/media|/mnt|/opt|/proc|/root|/run|/sbin|/srv|/sys|/tmp|/usr|/usr/local|/var|/var/lib|/var/lib/pve-cluster|/var/lib/pve-toolbox|/var/lib/vz)
+            return 1 ;;
+    esac
+    printf '%s' "$p"
+}
 
 _cb_restore_log() { printf '%s/restore.log' "$CB_ARCHIVE_DIR"; }
 
@@ -2496,11 +2510,18 @@ _cb_read_conf() {
     [[ $CB_GIT_ENABLED   =~ ^[01]$ ]] || CB_GIT_ENABLED=0
     [[ $CB_GIT_PUSH      =~ ^[01]$ ]] || CB_GIT_PUSH=0
     [[ -n $CB_GIT_BRANCH ]] || CB_GIT_BRANCH=master
+    local safe_dir
+    safe_dir=$(_cb_safe_data_dir "$CB_ARCHIVE_DIR") \
+        || fail "refusing unsafe CB_ARCHIVE_DIR: $CB_ARCHIVE_DIR"
+    CB_ARCHIVE_DIR=$safe_dir
     # Only when the git backend is on. Unguarded this ran on every install,
     # including local-archive-only ones that never pkg_ensure git - so on a
     # host without it every timer firing aborted before collecting anything,
     # wrote no archive, and alerted about a branch name nobody set.
     if [[ $CB_GIT_ENABLED -eq 1 ]]; then
+        safe_dir=$(_cb_safe_data_dir "$CB_GIT_DIR") \
+            || fail "refusing unsafe CB_GIT_DIR: $CB_GIT_DIR"
+        CB_GIT_DIR=$safe_dir
         command -v git >/dev/null 2>&1 \
             || fail "git not found but the git backend is enabled"
         command -v rsync >/dev/null 2>&1 \

--- a/modules/scrutiny-collectors/module.sh
+++ b/modules/scrutiny-collectors/module.sh
@@ -115,6 +115,53 @@ _sc_schedule_for() {
     printf '%s' "${!var}"
 }
 
+SC_UPDATE_STAGE=""
+SC_UPDATE_TIMERS_PAUSED=0
+SC_UPDATE_TIMER_LIST=""
+
+_sc_resume_update_timers() {
+    local s rc=0
+    for s in $SC_UPDATE_TIMER_LIST; do
+        systemctl start "$UNIT_PREFIX-$s.timer" 2>/dev/null \
+            || { warn "could not restart $UNIT_PREFIX-$s.timer"; rc=1; }
+    done
+    return "$rc"
+}
+
+_sc_update_cleanup() {
+    if [[ $SC_UPDATE_TIMERS_PAUSED -eq 1 ]]; then
+        _sc_resume_update_timers || true
+    fi
+    if [[ -n $SC_UPDATE_STAGE && -d $SC_UPDATE_STAGE ]]; then
+        rm -f -- "$SC_UPDATE_STAGE"/*
+        rmdir -- "$SC_UPDATE_STAGE" 2>/dev/null || true
+    fi
+    [[ -n ${CHECKSUM_FILE:-} ]] && rm -f -- "$CHECKSUM_FILE"
+    SC_UPDATE_STAGE=""
+}
+
+_sc_stage_binary() { # _sc_stage_binary <asset-fragment> <arch> <output>
+    local frag=$1 arch=$2 output=$3 url name
+    url=$(gh_asset "$frag" "$arch")
+    if [[ -z $url ]]; then
+        warn "no asset matching '$frag' for $arch in $GH_TAG"
+        return 1
+    fi
+    name=$(basename "$url")
+    info "downloading $name"
+    curl -fsSL --retry 3 -o "$output" "$url" \
+        || { warn "download failed: $url"; return 1; }
+    verify_checksum "$output" "$name" \
+        || { warn "checksum mismatch for $name"; return 1; }
+    return 0
+}
+
+_sc_install_staged() { # _sc_install_staged <staged-file> <target-name>
+    local staged=$1 target="$TOOLBOX_BIN_DIR/$2"
+    cp -a "$target" "$target.prev" || return 1
+    install -m 0755 "$staged" "$target"
+}
+
 # --------------------------------------------------------------- install --
 
 module_install() {
@@ -255,23 +302,46 @@ module_update() {
 
     gh_fetch_checksums
 
-    step "Pausing timers"
+    # Fetch and verify the complete release while the old timers and binaries
+    # are still operational. Nothing below pauses monitoring until every asset
+    # is ready to install.
+    SC_UPDATE_STAGE=$(mktemp -d)
+    SC_UPDATE_TIMER_LIST="${SC_PRESENT[*]}"
+    SC_UPDATE_TIMERS_PAUSED=0
+    trap '_sc_update_cleanup' EXIT
     local s
+    for s in "${SC_PRESENT[@]}"; do
+        if ! _sc_stage_binary "${SC_ASSET[$s]}" "$arch" "$SC_UPDATE_STAGE/${SC_BIN[$s]}"; then
+            trap - EXIT
+            _sc_update_cleanup
+            die "could not stage every collector for $GH_TAG; existing timers and binaries were left untouched"
+        fi
+    done
+
+    step "Pausing timers"
+    SC_UPDATE_TIMERS_PAUSED=1
     for s in "${SC_PRESENT[@]}"; do
         systemctl stop "$UNIT_PREFIX-$s.timer" 2>/dev/null || true
         wait_for_idle "$UNIT_PREFIX-$s"
     done
 
     step "Replacing binaries"
-    local updated=()
+    local updated=() install_failed=""
     for s in "${SC_PRESENT[@]}"; do
-        install_release_binary "${SC_ASSET[$s]}" "$arch" "${SC_BIN[$s]}" && updated+=("$s")
+        if _sc_install_staged "$SC_UPDATE_STAGE/${SC_BIN[$s]}" "${SC_BIN[$s]}"; then
+            updated+=("$s")
+        else
+            install_failed=$s
+            break
+        fi
     done
-    [[ -n ${CHECKSUM_FILE:-} ]] && rm -f "$CHECKSUM_FILE"
-
-    if [[ ${#updated[@]} -eq 0 ]]; then
-        for s in "${SC_PRESENT[@]}"; do systemctl start "$UNIT_PREFIX-$s.timer" 2>/dev/null || true; done
-        die "no binaries replaced - no matching assets in $GH_TAG"
+    if [[ -n $install_failed ]]; then
+        for s in "${updated[@]:-}"; do
+            [[ -n $s ]] && rollback_binary "${SC_BIN[$s]}" || true
+        done
+        trap - EXIT
+        _sc_update_cleanup
+        die "could not replace $install_failed; restored previous binaries and timers"
     fi
 
     step "Smoke test"
@@ -283,17 +353,24 @@ module_update() {
 
     if [[ ${#broken[@]} -gt 0 ]]; then
         step "Rollback"
-        for s in "${broken[@]}"; do
+        # Roll back the whole release, not only the collector whose smoke test
+        # failed, so the installation never sits at mixed versions.
+        for s in "${updated[@]}"; do
             if rollback_binary "${SC_BIN[$s]}"; then
-                run_unit "$UNIT_PREFIX-$s" >/dev/null 2>&1 \
-                    && ok "$s healthy again on the previous build" \
-                    || warn "$s still failing after rollback - check its config"
+                if [[ $s == performance ]]; then
+                    ok "$s restored to the previous build"
+                else
+                    run_unit "$UNIT_PREFIX-$s" >/dev/null 2>&1 \
+                        && ok "$s healthy again on the previous build" \
+                        || warn "$s still failing after rollback - check its config"
+                fi
             fi
         done
     fi
 
     step "Resuming timers"
-    for s in "${SC_PRESENT[@]}"; do systemctl start "$UNIT_PREFIX-$s.timer" 2>/dev/null || true; done
+    _sc_resume_update_timers || die "one or more collector timers could not be restarted"
+    SC_UPDATE_TIMERS_PAUSED=0
 
     if [[ ${#broken[@]} -eq 0 ]]; then
         state_set "$MODULE_NAME" VERSION "$GH_TAG"
@@ -303,6 +380,8 @@ module_update() {
     else
         warn "state kept at $current because these rolled back: ${broken[*]}"
     fi
+    trap - EXIT
+    _sc_update_cleanup
 }
 
 # ---------------------------------------------------------------- status --

--- a/modules/zfs-replication/module.sh
+++ b/modules/zfs-replication/module.sh
@@ -41,8 +41,34 @@ _zr_key() { # _zr_key <job> <KEY>
     printf 'JOB_%s_%s' "${n^^}" "$2"
 }
 
+_zr_job_id() {
+    local n=${1//[^A-Za-z0-9]/_}
+    printf '%s' "${n^^}"
+}
+
+_zr_jobs_unique() { # _zr_jobs_unique <job>...
+    local job id
+    declare -A seen=()
+    ZR_COLLISION=""
+    for job in "$@"; do
+        id=$(_zr_job_id "$job")
+        if [[ -n ${seen[$id]+x} ]]; then
+            ZR_COLLISION="${seen[$id]} and $job"
+            return 1
+        fi
+        seen[$id]=$job
+    done
+    return 0
+}
+
 # Unit names carry the job name; refuse anything systemd would mangle.
 _zr_valid_job() { [[ $1 =~ ^[A-Za-z][A-Za-z0-9_.:-]*$ ]]; }
+
+_zr_valid_schedule() {
+    [[ -n ${1:-} ]] || return 1
+    command -v systemd-analyze >/dev/null 2>&1 || return 1
+    systemd-analyze calendar "$1" >/dev/null 2>&1
+}
 
 _zr_configured() { # -> ZR_JOBS from conf
     ZR_JOBS=()
@@ -117,6 +143,7 @@ EOF
 }
 
 _zr_write_timer() { # _zr_write_timer <job> <OnCalendar>
+    _zr_valid_schedule "$2" || die "invalid systemd OnCalendar for $1: $2"
     cat > "$TOOLBOX_SYSTEMD_DIR/$ZR_UNIT@$1.timer" <<EOF
 [Unit]
 Description=pve-toolbox ZFS replication job $1 (timer)
@@ -137,6 +164,7 @@ _zr_enable() {
         ok "enabled $ZR_UNIT@$1.timer  ($(_zr_schedule_of "$1"))"
     else
         warn "could not enable $ZR_UNIT@$1.timer"
+        return 1
     fi
 }
 
@@ -194,7 +222,13 @@ _zr_ask_job() { # _zr_ask_job <job>
     else
         own=""; mode=""; path=""
     fi
-    ask sched "  schedule (systemd OnCalendar)" "$sched"
+    while true; do
+        ask sched "  schedule (systemd OnCalendar)" "${sched:-$ZFS_REPL_SCHEDULE}"
+        _zr_valid_schedule "$sched" && break
+        [[ $ASSUME_YES -eq 1 ]] && die "invalid systemd OnCalendar for $job: $sched"
+        warn "invalid systemd OnCalendar: $sched"
+        sched=""
+    done
 
     conf_set "$MODULE_NAME" "$(_zr_key "$job" SRC)"   "$src"
     conf_set "$MODULE_NAME" "$(_zr_key "$job" DST)"   "$dst"
@@ -213,7 +247,7 @@ module_install() {
     require_pve
     have_zfs || die "no zfs binary - this module needs ZFS on the host"
     _zr_defaults
-    pkg_ensure curl:curl jq:jq syncoid:sanoid
+    pkg_ensure curl:curl jq:jq syncoid:sanoid util-linux:flock
 
     step "Discord webhook"
     if [[ -z $ZFS_REPL_WEBHOOK && $ASSUME_YES -eq 1 ]]; then
@@ -253,6 +287,8 @@ module_install() {
     for job in "${want[@]}"; do
         _zr_valid_job "$job" || die "job name '$job' cannot be used in a systemd unit name"
     done
+    _zr_jobs_unique "${want[@]}" \
+        || die "job names normalize to the same config key: $ZR_COLLISION"
 
     conf_set "$MODULE_NAME" DISCORD_WEBHOOK "$ZFS_REPL_WEBHOOK"
     conf_set "$MODULE_NAME" LOG_DIR "$ZR_LOG_DIR"
@@ -278,7 +314,9 @@ module_install() {
     chmod 0750 "$ZR_LOG_DIR"
     _zr_write_service
     systemctl daemon-reload
-    for job in "${kept[@]}"; do _zr_enable "$job"; done
+    for job in "${kept[@]}"; do
+        _zr_enable "$job" || die "could not enable the timer for $job"
+    done
 
     step "Verification"
     local t=y
@@ -320,6 +358,8 @@ module_update() {
     [[ ${1:-} == --check ]] && check_only=1
 
     _zr_configured
+    _zr_jobs_unique "${ZR_JOBS[@]}" \
+        || die "job names normalize to the same config key: $ZR_COLLISION"
     _zr_scheduled
     [[ ${#ZR_JOBS[@]} -eq 0 && ${#ZR_SCHEDULED[@]} -eq 0 ]] && die "not installed"
 
@@ -327,12 +367,16 @@ module_update() {
     src=$(_zr_src); dst="$TOOLBOX_BIN_DIR/$ZR_BIN"
     new=$(_zr_sum "$src"); cur=$(_zr_sum "$dst")
 
-    local missing=() stale=() j
+    local missing=() stale=() invalid=() j
     for j in "${ZR_JOBS[@]}"; do
         [[ " ${ZR_SCHEDULED[*]} " == *" $j "* ]] || missing+=("$j")
     done
     for j in "${ZR_SCHEDULED[@]}"; do
-        [[ " ${ZR_JOBS[*]} " == *" $j "* ]] || stale+=("$j")
+        if [[ " ${ZR_JOBS[*]} " == *" $j "* ]]; then
+            _zr_valid_schedule "$(_zr_schedule_of "$j")" || invalid+=("$j")
+        else
+            stale+=("$j")
+        fi
     done
 
     local drift=0
@@ -342,8 +386,9 @@ module_update() {
     printf '  jobs       %s\n' "${ZR_JOBS[*]:-none}"
     if [[ ${#missing[@]} -gt 0 ]]; then warn "configured but no timer: ${missing[*]}"; fi
     if [[ ${#stale[@]} -gt 0 ]];   then warn "timer but not configured: ${stale[*]}"; fi
+    if [[ ${#invalid[@]} -gt 0 ]]; then warn "invalid timer schedule: ${invalid[*]}"; fi
 
-    if [[ $drift -eq 0 && ${#missing[@]} -eq 0 && ${#stale[@]} -eq 0 && ${FORCE:-0} -eq 0 ]]; then
+    if [[ $drift -eq 0 && ${#missing[@]} -eq 0 && ${#stale[@]} -eq 0 && ${#invalid[@]} -eq 0 && ${FORCE:-0} -eq 0 ]]; then
         ok "up to date"
         return 0
     fi
@@ -369,16 +414,20 @@ module_update() {
             fi
         done
     fi
-    if [[ ${#missing[@]} -gt 0 ]]; then
-        step "Jobs with no timer"
-        for j in "${missing[@]}"; do
+    local repair=("${missing[@]}" "${invalid[@]}")
+    if [[ ${#repair[@]} -gt 0 ]]; then
+        step "Jobs needing a timer"
+        for j in "${repair[@]}"; do
+            [[ -n $j ]] || continue
             _zr_ask_job "$j" || continue
         done
     fi
 
     systemctl daemon-reload
     _zr_scheduled
-    for j in "${ZR_SCHEDULED[@]}"; do _zr_enable "$j"; done
+    for j in "${ZR_SCHEDULED[@]}"; do
+        _zr_enable "$j" || die "could not enable the timer for $j"
+    done
 
     state_set "$MODULE_NAME" JOBS "${ZR_SCHEDULED[*]}"
     state_set "$MODULE_NAME" SCRIPT_SUM "$new"
@@ -389,11 +438,23 @@ module_update() {
 # ---------------------------------------------------------------- status --
 
 module_status() {
+    _zr_configured
+    if ! _zr_jobs_unique "${ZR_JOBS[@]}"; then
+        printf 'invalid jobs  [%s]' "$ZR_COLLISION"
+        return 0
+    fi
     _zr_scheduled
     if [[ ${#ZR_SCHEDULED[@]} -eq 0 ]]; then
         printf 'not installed'
         return 1
     fi
+    local schedule_job
+    for schedule_job in "${ZR_SCHEDULED[@]}"; do
+        if ! _zr_valid_schedule "$(_zr_schedule_of "$schedule_job")"; then
+            printf 'invalid schedule  [%s]' "$schedule_job"
+            return 0
+        fi
+    done
     local running=() j
     for j in "${ZR_SCHEDULED[@]}"; do
         if systemctl is-active --quiet "$ZR_UNIT@$j.service" 2>/dev/null; then

--- a/modules/zfs-replication/pve-toolbox-zfs-sync.sh
+++ b/modules/zfs-replication/pve-toolbox-zfs-sync.sh
@@ -30,6 +30,7 @@ CONF="${SYNC_CONF:-/etc/pve-toolbox/zfs-replication.conf}"
 DISCORD_WEBHOOK=""
 JOBS=""
 LOG_DIR="/var/log/pve-toolbox"
+LOCK_DIR="/run/pve-toolbox"
 NOTIFY_START=0
 LOG_TAIL=25
 
@@ -70,6 +71,22 @@ _job_key() {
     printf 'JOB_%s_%s' "${n^^}" "$2"
 }
 
+_job_id() {
+    local n=${1//[^A-Za-z0-9]/_}
+    printf '%s' "${n^^}"
+}
+
+_jobs_unique() {
+    local job id
+    declare -A seen=()
+    for job in $JOBS; do
+        id=$(_job_id "$job")
+        [[ -z ${seen[$id]+x} ]] \
+            || fail "jobs '${seen[$id]}' and '$job' share the same config key"
+        seen[$id]=$job
+    done
+}
+
 _load_job() {
     local var
     var=$(_job_key "$JOB" SRC);   JOB_SRC=${!var:-}
@@ -83,15 +100,100 @@ _load_job() {
     [[ -n $JOB_DST ]] || fail "job '$JOB' has no target"
 }
 
-# Fall back to the target's own mountpoint rather than a hardcoded /mnt path.
-_target_path() {
-    if [[ -n $JOB_PATH ]]; then
-        printf '%s' "$JOB_PATH"
-        return 0
-    fi
-    local mp
+# Resolve a requested permission path beneath the target dataset's own local
+# mountpoint. This blocks both explicit JOB_PATH=/ and a target dataset mounted
+# over a broad system root.
+_resolve_fixup_path() {
+    local mp raw canon mount
+    FIXUP_PATH=""; FIXUP_ERROR=""
     mp=$(zfs get -H -o value mountpoint "$JOB_DST" 2>/dev/null || true)
-    [[ -n $mp && $mp != none && $mp != legacy && $mp != - ]] && printf '%s' "$mp"
+    if [[ -z $mp || $mp == none || $mp == legacy || $mp == - ]]; then
+        FIXUP_ERROR="$JOB_DST has no local mountpoint"
+        return 1
+    fi
+    raw=${JOB_PATH:-$mp}
+    canon=$(realpath -e -- "$raw" 2>/dev/null) \
+        || { FIXUP_ERROR="$raw cannot be resolved"; return 1; }
+    mount=$(realpath -e -- "$mp" 2>/dev/null) \
+        || { FIXUP_ERROR="$mp cannot be resolved"; return 1; }
+    [[ -d $canon ]] \
+        || { FIXUP_ERROR="$canon is not a directory"; return 1; }
+    case $mount in
+        /|/bin|/boot|/dev|/etc|/etc/pve|/home|/lib|/lib64|/media|/mnt|/opt|/proc|/root|/run|/sbin|/srv|/sys|/tmp|/usr|/usr/local|/var|/var/lib|/var/lib/pve-toolbox|/var/lib/vz)
+            FIXUP_ERROR="$mount is a protected target mountpoint"
+            return 1 ;;
+    esac
+    case $canon in
+        /|/bin|/boot|/dev|/etc|/etc/pve|/home|/lib|/lib64|/media|/mnt|/opt|/proc|/root|/run|/sbin|/srv|/sys|/tmp|/usr|/usr/local|/var|/var/lib|/var/lib/pve-toolbox|/var/lib/vz)
+            FIXUP_ERROR="$canon is a protected system root"
+            return 1 ;;
+    esac
+    if [[ $canon != "$mount" && $canon != "$mount"/* ]]; then
+        FIXUP_ERROR="$canon is outside target mountpoint $mount"
+        return 1
+    fi
+    FIXUP_PATH=$canon
+    return 0
+}
+
+_take_lock() {
+    local dir parent parent_owner parent_mode owner mode lock
+    dir=$(realpath -m -- "$LOCK_DIR" 2>/dev/null) || return 2
+    parent=${dir%/*}; [[ -n $parent ]] || parent=/
+    parent_owner=$(stat -c '%u' "$parent" 2>/dev/null) || return 2
+    parent_mode=$(stat -c '%a' "$parent" 2>/dev/null) || return 2
+    [[ $parent_owner == "$EUID" ]] || return 2
+    (( (8#$parent_mode & 0022) == 0 )) || return 2
+    [[ ! -L $LOCK_DIR ]] || return 2
+    mkdir -p "$dir" 2>/dev/null || return 2
+    chmod 0700 "$dir" 2>/dev/null || return 2
+    owner=$(stat -c '%u' "$dir" 2>/dev/null) || return 2
+    mode=$(stat -c '%a' "$dir" 2>/dev/null) || return 2
+    [[ $owner == "$EUID" && $mode == 700 ]] || return 2
+    LOCK_DIR=$dir
+    lock="$dir/pve-toolbox-zfs-sync-$JOB.lock"
+    [[ ! -L $lock ]] || return 2
+    exec 9<>"$lock" || return 2
+    chmod 0600 "$lock" 2>/dev/null || return 2
+    flock -n 9
+}
+
+_apply_fixups() {
+    local path="" failed=0
+    FIXUP_PERMS="not requested"
+    [[ -n $JOB_CHOWN || -n $JOB_CHMOD ]] || return 0
+
+    if ! _resolve_fixup_path; then
+        FIXUP_PERMS="failed, $FIXUP_ERROR"
+        log "warning: $FIXUP_PERMS"
+        return 1
+    fi
+
+    path=$FIXUP_PATH
+    FIXUP_PERMS=""
+    if [[ -n $JOB_CHOWN ]]; then
+        if chown -R "$JOB_CHOWN" "$path"; then
+            FIXUP_PERMS="owner $JOB_CHOWN"
+        else
+            FIXUP_PERMS="owner $JOB_CHOWN failed"
+            failed=1
+        fi
+    fi
+    if [[ -n $JOB_CHMOD ]]; then
+        if chmod -R "$JOB_CHMOD" "$path"; then
+            FIXUP_PERMS="${FIXUP_PERMS:+$FIXUP_PERMS, }mode $JOB_CHMOD"
+        else
+            FIXUP_PERMS="${FIXUP_PERMS:+$FIXUP_PERMS, }mode $JOB_CHMOD failed"
+            failed=1
+        fi
+    fi
+    FIXUP_PERMS="${FIXUP_PERMS:-none} on $path"
+    if [[ $failed -eq 1 ]]; then
+        log "warning: permission fixup failed ($FIXUP_PERMS)"
+        return 1
+    fi
+    log "applied $FIXUP_PERMS"
+    return 0
 }
 
 # --------------------------------------------------------------- reports --
@@ -128,6 +230,7 @@ main() {
     else
         fail "cannot read $CONF"
     fi
+    _jobs_unique
 
     if [[ $mode == list ]]; then
         printf '%s\n' $JOBS
@@ -152,13 +255,16 @@ main() {
 
     command -v syncoid >/dev/null 2>&1 || fail "syncoid not found - apt install sanoid"
     command -v zfs     >/dev/null 2>&1 || fail "zfs not found"
+    command -v flock   >/dev/null 2>&1 || fail "flock not found - apt install util-linux"
 
     # A slow run must not have a second copy started on top of it.
-    local lock="/run/lock/pve-toolbox-zfs-sync-$JOB.lock"
-    exec 9>"$lock"
-    if ! flock -n 9; then
+    local lock_rc=0
+    _take_lock || lock_rc=$?
+    if [[ $lock_rc -eq 1 ]]; then
         log "job $JOB is already running - leaving it alone"
         exit 0
+    elif [[ $lock_rc -ne 0 ]]; then
+        fail "cannot establish a safe lock in $LOCK_DIR"
     fi
 
     _ds_exists "$JOB_SRC" || fail "source dataset does not exist: $JOB_SRC"
@@ -205,27 +311,9 @@ main() {
     fi
 
     # Ownership fixups, only where they were actually asked for.
-    local path perms="not requested"
-    path=$(_target_path)
-    if [[ -n $JOB_CHOWN || -n $JOB_CHMOD ]]; then
-        if [[ -z $path ]]; then
-            perms="skipped, $JOB_DST has no mountpoint"
-            log "warning: $perms"
-        elif [[ ! -d $path ]]; then
-            perms="skipped, $path is not a directory"
-            log "warning: $perms"
-        else
-            perms=""
-            if [[ -n $JOB_CHOWN ]]; then
-                chown -R "$JOB_CHOWN" "$path" && perms="owner $JOB_CHOWN"
-            fi
-            if [[ -n $JOB_CHMOD ]]; then
-                chmod -R "$JOB_CHMOD" "$path" && perms="${perms:+$perms, }mode $JOB_CHMOD"
-            fi
-            perms="${perms:-none} on $path"
-            log "applied $perms"
-        fi
-    fi
+    local perms fixup_failed=0
+    _apply_fixups || fixup_failed=1
+    perms=$FIXUP_PERMS
 
     local after_used after_snaps delta
     after_used=$(_used_bytes "$JOB_DST")
@@ -236,12 +324,16 @@ main() {
     # syncoid succeeded but a requested chown/chmod did not land: the original
     # script reported that as a clean success. Flag it instead.
     local color=$DISCORD_OK verdict="finished"
-    if [[ $perms == skipped* ]]; then
+    if [[ $fixup_failed -eq 1 ]]; then
         color=$DISCORD_WARN
         verdict="finished, permissions not applied"
     fi
 
-    _record ok "$elapsed"
+    if [[ $fixup_failed -eq 1 ]]; then
+        _record degraded "$elapsed"
+    else
+        _record ok "$elapsed"
+    fi
     printf '\nfinished %s after %s\n' "$(date -Is)" "$(_hms "$elapsed")" >> "$logfile"
 
     discord_notify "$DISCORD_WEBHOOK" "$color" "ZFS replication $verdict - $JOB" \
@@ -255,7 +347,9 @@ main() {
         "Target size" "$(_human "$after_used")" \
         Snapshots    "$before_snaps to $after_snaps" \
         Permissions  "$perms" || true
+    [[ $fixup_failed -eq 0 ]] \
+        || fail "replication succeeded but requested permission fixups failed"
     log "done in $(_hms "$elapsed")"
 }
 
-main "$@"
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then main "$@"; fi

--- a/modules/zfs-scrub/module.sh
+++ b/modules/zfs-scrub/module.sh
@@ -43,6 +43,27 @@ _zs_var() { # _zs_var <pool> -> ZFS_SCRUB_SCHEDULE_<POOL>
     printf 'ZFS_SCRUB_SCHEDULE_%s' "${p^^}"
 }
 
+_zs_pools_unique() { # _zs_pools_unique <pool>...
+    local pool var
+    declare -A seen=()
+    ZS_COLLISION=""
+    for pool in "$@"; do
+        var=$(_zs_var "$pool")
+        if [[ -n ${seen[$var]+x} ]]; then
+            ZS_COLLISION="${seen[$var]} and $pool"
+            return 1
+        fi
+        seen[$var]=$pool
+    done
+    return 0
+}
+
+_zs_valid_schedule() {
+    [[ -n ${1:-} ]] || return 1
+    command -v systemd-analyze >/dev/null 2>&1 || return 1
+    systemd-analyze calendar "$1" >/dev/null 2>&1
+}
+
 # Pools share spindles, so stagger them a week apart rather than scrubbing
 # everything on the same night.
 _zs_default_schedule() { # _zs_default_schedule <index>
@@ -117,6 +138,7 @@ EOF
 }
 
 _zs_write_timer() { # _zs_write_timer <pool> <OnCalendar>
+    _zs_valid_schedule "$2" || die "invalid systemd OnCalendar for $1: $2"
     cat > "$TOOLBOX_SYSTEMD_DIR/$ZS_UNIT@$1.timer" <<EOF
 [Unit]
 Description=pve-toolbox ZFS scrub of $1 (timer)
@@ -137,6 +159,7 @@ _zs_enable() { # _zs_enable <pool>
         ok "enabled $ZS_UNIT@$1.timer  ($(_zs_schedule_of "$1"))"
     else
         warn "could not enable $ZS_UNIT@$1.timer"
+        return 1
     fi
 }
 
@@ -217,6 +240,8 @@ module_install() {
     for p in "${want[@]}"; do
         _zs_valid_pool "$p" || die "pool name '$p' cannot be used in a systemd unit name"
     done
+    _zs_pools_unique "${want[@]}" \
+        || die "pool names normalize to the same schedule variable: $ZS_COLLISION"
 
     step "Schedules"
     dim "  staggered a week apart so the pools do not all scrub on the same night"
@@ -224,7 +249,13 @@ module_install() {
     for p in "${want[@]}"; do
         var=$(_zs_var "$p")
         [[ -z ${!var:-} ]] && printf -v "$var" '%s' "$(_zs_default_schedule "$i")"
-        ask "$var" "  $p (systemd OnCalendar)" "${!var}"
+        while true; do
+            ask "$var" "  $p (systemd OnCalendar)" "${!var}"
+            _zs_valid_schedule "${!var}" && break
+            [[ $ASSUME_YES -eq 1 ]] && die "invalid systemd OnCalendar for $p: ${!var}"
+            warn "invalid systemd OnCalendar: ${!var}"
+            printf -v "$var" '%s' "$(_zs_default_schedule "$i")"
+        done
         i=$((i + 1))
     done
     ask ZFS_SCRUB_INTERVAL "how often to check whether a scrub finished (seconds)" \
@@ -257,7 +288,9 @@ module_install() {
         _zs_write_timer "$p" "${!var}"
     done
     systemctl daemon-reload
-    for p in "${want[@]}"; do _zs_enable "$p"; done
+    for p in "${want[@]}"; do
+        _zs_enable "$p" || die "could not enable the timer for $p"
+    done
 
     step "Verification"
     local t=y
@@ -303,12 +336,14 @@ module_update() {
 
     _zs_scheduled
     [[ ${#ZS_SCHEDULED[@]} -eq 0 ]] && die "not installed"
+    _zs_pools_unique "${ZS_SCHEDULED[@]}" \
+        || die "pool names normalize to the same schedule variable: $ZS_COLLISION"
 
     local src dst new cur
     src=$(_zs_src); dst="$TOOLBOX_BIN_DIR/$ZS_BIN"
     new=$(_zs_sum "$src"); cur=$(_zs_sum "$dst")
 
-    local missing=() stale=() p
+    local missing=() stale=() invalid=() p
     if have_zfs; then
         # `done <` redirects stdin for the whole body, so nothing in here may
         # prompt - ask and confirm would read pool names instead of the
@@ -318,7 +353,11 @@ module_update() {
             [[ " ${ZS_SCHEDULED[*]} " == *" $p "* ]] || missing+=("$p")
         done < <(_zs_pools)
         for p in "${ZS_SCHEDULED[@]}"; do
-            zpool list -H -o name "$p" >/dev/null 2>&1 || stale+=("$p")
+            if zpool list -H -o name "$p" >/dev/null 2>&1; then
+                _zs_valid_schedule "$(_zs_schedule_of "$p")" || invalid+=("$p")
+            else
+                stale+=("$p")
+            fi
         done
     fi
 
@@ -329,8 +368,9 @@ module_update() {
     printf '  scheduled  %s\n' "${ZS_SCHEDULED[*]}"
     if [[ ${#missing[@]} -gt 0 ]]; then warn "pools with no scrub timer: ${missing[*]}"; fi
     if [[ ${#stale[@]} -gt 0 ]];   then warn "timers for pools that are gone: ${stale[*]}"; fi
+    if [[ ${#invalid[@]} -gt 0 ]]; then warn "invalid timer schedule: ${invalid[*]}"; fi
 
-    if [[ $drift -eq 0 && ${#missing[@]} -eq 0 && ${#stale[@]} -eq 0 && ${FORCE:-0} -eq 0 ]]; then
+    if [[ $drift -eq 0 && ${#missing[@]} -eq 0 && ${#stale[@]} -eq 0 && ${#invalid[@]} -eq 0 && ${FORCE:-0} -eq 0 ]]; then
         ok "up to date"
         return 0
     fi
@@ -370,16 +410,42 @@ module_update() {
             ask_yn add "  schedule scrubs for $p" "y"
             [[ $add == y ]] || continue
             sched=$(_zs_default_schedule "$i")
-            ask sched "  $p (systemd OnCalendar)" "$sched"
+            while true; do
+                ask sched "  $p (systemd OnCalendar)" "$sched"
+                _zs_valid_schedule "$sched" && break
+                [[ $ASSUME_YES -eq 1 ]] && die "invalid systemd OnCalendar for $p: $sched"
+                warn "invalid systemd OnCalendar: $sched"
+                sched=$(_zs_default_schedule "$i")
+            done
             _zs_write_timer "$p" "$sched"
             added+=("$p")
             i=$((i + 1))
         done
     fi
 
+    if [[ ${#invalid[@]} -gt 0 ]]; then
+        step "Pools with invalid schedules"
+        local repair_index=${#ZS_SCHEDULED[@]}
+        for p in "${invalid[@]}"; do
+            local repair_sched
+            repair_sched=$(_zs_default_schedule "$repair_index")
+            while true; do
+                ask repair_sched "  $p (systemd OnCalendar)" "$repair_sched"
+                _zs_valid_schedule "$repair_sched" && break
+                [[ $ASSUME_YES -eq 1 ]] && die "invalid systemd OnCalendar for $p: $repair_sched"
+                warn "invalid systemd OnCalendar: $repair_sched"
+                repair_sched=$(_zs_default_schedule "$repair_index")
+            done
+            _zs_write_timer "$p" "$repair_sched"
+            added+=("$p")
+            repair_index=$((repair_index + 1))
+        done
+    fi
+
     systemctl daemon-reload
     for p in "${added[@]:-}"; do
-        [[ -n $p ]] && _zs_enable "$p"
+        [[ -n $p ]] || continue
+        _zs_enable "$p" || die "could not enable the timer for $p"
     done
 
     _zs_scheduled
@@ -397,6 +463,17 @@ module_status() {
         printf 'not installed'
         return 1
     fi
+    if ! _zs_pools_unique "${ZS_SCHEDULED[@]}"; then
+        printf 'invalid pools  [%s]' "$ZS_COLLISION"
+        return 0
+    fi
+    local schedule_pool
+    for schedule_pool in "${ZS_SCHEDULED[@]}"; do
+        if ! _zs_valid_schedule "$(_zs_schedule_of "$schedule_pool")"; then
+            printf 'invalid schedule  [%s]' "$schedule_pool"
+            return 0
+        fi
+    done
     local running=() p
     if have_zfs; then
         for p in "${ZS_SCHEDULED[@]}"; do

--- a/tests/hardening.sh
+++ b/tests/hardening.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+#
+# Behaviour-level regression tests for the destructive and scheduled module
+# paths. Everything writes only below one throwaway directory; systemd, ZFS,
+# release downloads and privileged commands are replaced with shell fixtures.
+#
+set -euo pipefail
+
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
+ROOT=$PWD
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+pass() { printf 'ok  %s\n' "$1"; }
+fail() { printf 'FAIL %s\n' "$1" >&2; exit 1; }
+mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"; }
+
+# --- config-backup paths and uninstall --------------------------------------
+
+(
+    PVE_TOOLBOX_LIB="$ROOT/lib"
+    export PVE_TOOLBOX_LIB
+    # shellcheck source=modules/config-backup/pve-config-backup.sh
+    source "$ROOT/modules/config-backup/pve-config-backup.sh"
+
+    if _cb_safe_data_dir / >/dev/null 2>&1; then
+        fail "the runner accepted / as a data directory"
+    fi
+    mkdir -p "$WORK/archive-ok"
+    [[ $(_cb_safe_data_dir "$WORK/archive-ok") == "$WORK/archive-ok" ]] \
+        || fail "the runner rejected a dedicated data directory"
+    ln -s / "$WORK/archive-root-link"
+    if _cb_safe_data_dir "$WORK/archive-root-link" >/dev/null 2>&1; then
+        fail "the runner accepted a symlink resolving to /"
+    fi
+) || exit 1
+pass "config-backup runtime rejects dangerous data paths"
+
+(
+    export TOOLBOX_BIN_DIR="$WORK/cb-bin" TOOLBOX_LIB_DIR="$WORK/cb-lib"
+    export TOOLBOX_CONF_DIR="$WORK/cb-conf" TOOLBOX_STATE_DIR="$WORK/cb-state"
+    export TOOLBOX_SYSTEMD_DIR="$WORK/cb-systemd"
+    mkdir -p "$TOOLBOX_BIN_DIR" "$TOOLBOX_LIB_DIR" "$TOOLBOX_CONF_DIR" \
+             "$TOOLBOX_STATE_DIR" "$TOOLBOX_SYSTEMD_DIR" \
+             "$WORK/cb-archives" "$WORK/cb-git"
+    # shellcheck source=lib/common.sh
+    source "$ROOT/lib/common.sh"
+    # shellcheck source=modules/config-backup/module.sh
+    source "$ROOT/modules/config-backup/module.sh"
+
+    conf_set config-backup CB_ARCHIVE_DIR "$WORK/cb-archives"
+    conf_set config-backup CB_GIT_DIR "$WORK/cb-git"
+    : > "$WORK/cb-prompts"
+    require_root() { :; }
+    systemd_remove() { :; }
+    state_clear() { :; }
+    ask_yn() {
+        printf '%s\n' "$2" >> "$WORK/cb-prompts"
+        case $1 in
+            drop)      printf -v "$1" y ;;
+            drop_data) printf -v "$1" n ;;
+            drop_git)  printf -v "$1" n ;;
+        esac
+    }
+    module_uninstall >/dev/null
+    grep -Fq "also delete the git history in $WORK/cb-git" "$WORK/cb-prompts" \
+        || fail "uninstall lost CB_GIT_DIR after clearing config"
+
+    conf_set config-backup CB_ARCHIVE_DIR /
+    : > "$WORK/cb-mutations"
+    systemd_remove() { printf 'removed unit\n' >> "$WORK/cb-mutations"; }
+    if ( module_uninstall ) >/dev/null 2>&1; then
+        fail "uninstall accepted / as its archive directory"
+    fi
+    [[ ! -s $WORK/cb-mutations ]] \
+        || fail "uninstall mutated the system before validating its data paths"
+) || exit 1
+pass "config-backup uninstall retains both data paths"
+
+# --- zfs-replication --------------------------------------------------------
+
+(
+    export TOOLBOX_BIN_DIR="$WORK/zr-bin" TOOLBOX_LIB_DIR="$WORK/zr-lib"
+    export TOOLBOX_CONF_DIR="$WORK/zr-conf" TOOLBOX_STATE_DIR="$WORK/zr-state"
+    export TOOLBOX_SYSTEMD_DIR="$WORK/zr-systemd"
+    mkdir -p "$TOOLBOX_BIN_DIR" "$TOOLBOX_LIB_DIR" "$TOOLBOX_CONF_DIR" \
+             "$TOOLBOX_STATE_DIR" "$TOOLBOX_SYSTEMD_DIR"
+    # shellcheck source=lib/common.sh
+    source "$ROOT/lib/common.sh"
+    # shellcheck source=modules/zfs-replication/module.sh
+    source "$ROOT/modules/zfs-replication/module.sh"
+
+    if _zr_jobs_unique a-b a_b; then
+        fail "colliding replication job keys were accepted"
+    fi
+    _zr_jobs_unique one two \
+        || fail "distinct replication job keys were rejected"
+
+    systemd-analyze() { [[ $1 == calendar && $2 == daily ]]; }
+    _zr_valid_schedule daily || fail "a valid replication schedule was rejected"
+    if _zr_valid_schedule nonsense; then fail "an invalid replication schedule was accepted"; fi
+    if ( _zr_write_timer job nonsense ) >/dev/null 2>&1; then
+        fail "an invalid replication timer was written"
+    fi
+    [[ ! -e $TOOLBOX_SYSTEMD_DIR/$ZR_UNIT@job.timer ]] \
+        || fail "invalid replication timer content reached disk"
+    systemctl() { return 1; }
+    if _zr_enable job >/dev/null 2>&1; then
+        fail "replication timer enable failure was swallowed"
+    fi
+) || exit 1
+pass "zfs-replication rejects key and timer failures"
+
+(
+    PVE_TOOLBOX_LIB="$ROOT/lib"
+    export PVE_TOOLBOX_LIB
+    # shellcheck source=modules/zfs-replication/pve-toolbox-zfs-sync.sh
+    source "$ROOT/modules/zfs-replication/pve-toolbox-zfs-sync.sh"
+
+    TARGET="$WORK/zr-target"
+    OUTSIDE="$WORK/zr-outside"
+    mkdir -p "$TARGET/child" "$OUTSIDE"
+    JOB_DST=tank/backup
+    zfs() {
+        [[ $1 == get ]] && { printf '%s\n' "$TARGET"; return 0; }
+        return 0
+    }
+
+    JOB_PATH="$TARGET/child"
+    _resolve_fixup_path || fail "a child of the target mountpoint was rejected"
+    [[ $FIXUP_PATH == "$TARGET/child" ]] || fail "the fixup path was not canonicalized"
+    JOB_PATH=/
+    if _resolve_fixup_path; then fail "the replication runner accepted / for recursive fixups"; fi
+    JOB_PATH="$OUTSIDE"
+    if _resolve_fixup_path; then fail "a fixup path outside the target mountpoint was accepted"; fi
+
+    LOCK_DIR="$WORK/zr-lock"
+    JOB=job
+    _take_lock || fail "a private replication lock could not be taken"
+    [[ $(mode_of "$LOCK_DIR") == 700 ]] || fail "the replication lock directory is not 0700"
+    [[ $(mode_of "$LOCK_DIR/pve-toolbox-zfs-sync-job.lock") == 600 ]] \
+        || fail "the replication lock file is not 0600"
+    exec 9>&-
+    ln -s "$LOCK_DIR" "$WORK/zr-lock-link"
+    LOCK_DIR="$WORK/zr-lock-link"
+    lock_rc=0; _take_lock || lock_rc=$?
+    [[ $lock_rc -eq 2 ]] || fail "a symlinked replication lock directory did not fail closed"
+
+    JOB_CHOWN=1000:1000 JOB_CHMOD=""
+    _resolve_fixup_path() { FIXUP_PATH=$TARGET; return 0; }
+    chown() { return 1; }
+    if _apply_fixups >/dev/null 2>&1; then
+        fail "a failed recursive chown was reported as successful"
+    fi
+    [[ $FIXUP_PERMS == *failed* ]] || fail "the failed chown was not described"
+
+    JOBS='a-b a_b'
+    if ( _jobs_unique ) >/dev/null 2>&1; then
+        fail "the runner accepted colliding job keys from a hand-edited config"
+    fi
+) || exit 1
+pass "zfs-replication locks and fixups fail closed"
+
+# --- zfs-scrub --------------------------------------------------------------
+
+(
+    export TOOLBOX_BIN_DIR="$WORK/zs-bin" TOOLBOX_LIB_DIR="$WORK/zs-lib"
+    export TOOLBOX_CONF_DIR="$WORK/zs-conf" TOOLBOX_STATE_DIR="$WORK/zs-state"
+    export TOOLBOX_SYSTEMD_DIR="$WORK/zs-systemd"
+    mkdir -p "$TOOLBOX_BIN_DIR" "$TOOLBOX_LIB_DIR" "$TOOLBOX_CONF_DIR" \
+             "$TOOLBOX_STATE_DIR" "$TOOLBOX_SYSTEMD_DIR"
+    # shellcheck source=lib/common.sh
+    source "$ROOT/lib/common.sh"
+    # shellcheck source=modules/zfs-scrub/module.sh
+    source "$ROOT/modules/zfs-scrub/module.sh"
+
+    if _zs_pools_unique tank-a tank_a; then
+        fail "colliding scrub schedule variables were accepted"
+    fi
+    _zs_pools_unique tank-a tank-b \
+        || fail "distinct scrub schedule variables were rejected"
+
+    systemd-analyze() { [[ $1 == calendar && $2 == weekly ]]; }
+    _zs_valid_schedule weekly || fail "a valid scrub schedule was rejected"
+    if _zs_valid_schedule nonsense; then fail "an invalid scrub schedule was accepted"; fi
+    if ( _zs_write_timer tank nonsense ) >/dev/null 2>&1; then
+        fail "an invalid scrub timer was written"
+    fi
+    [[ ! -e $TOOLBOX_SYSTEMD_DIR/$ZS_UNIT@tank.timer ]] \
+        || fail "invalid scrub timer content reached disk"
+    systemctl() { return 1; }
+    if _zs_enable tank >/dev/null 2>&1; then
+        fail "scrub timer enable failure was swallowed"
+    fi
+) || exit 1
+pass "zfs-scrub rejects schedule collisions and timer failures"
+
+# --- scrutiny collector update transaction ---------------------------------
+
+(
+    export TOOLBOX_BIN_DIR="$WORK/sc-bin" TOOLBOX_LIB_DIR="$WORK/sc-lib"
+    export TOOLBOX_CONF_DIR="$WORK/sc-conf" TOOLBOX_STATE_DIR="$WORK/sc-state"
+    export TOOLBOX_SYSTEMD_DIR="$WORK/sc-systemd"
+    mkdir -p "$TOOLBOX_BIN_DIR" "$TOOLBOX_LIB_DIR" "$TOOLBOX_CONF_DIR" \
+             "$TOOLBOX_STATE_DIR" "$TOOLBOX_SYSTEMD_DIR"
+    # shellcheck source=lib/common.sh
+    source "$ROOT/lib/common.sh"
+    # shellcheck source=modules/scrutiny-collectors/module.sh
+    source "$ROOT/modules/scrutiny-collectors/module.sh"
+
+    printf 'old metrics\n' > "$TOOLBOX_BIN_DIR/${SC_BIN[metrics]}"
+    printf 'old zfs\n' > "$TOOLBOX_BIN_DIR/${SC_BIN[zfs]}"
+    chmod 0755 "$TOOLBOX_BIN_DIR/${SC_BIN[metrics]}" "$TOOLBOX_BIN_DIR/${SC_BIN[zfs]}"
+
+    require_root() { :; }
+    pkg_ensure() { :; }
+    detect_arch() { printf 'amd64'; }
+    _sc_installed() { SC_PRESENT=(metrics zfs); }
+    _sc_version() { printf 'v1.0.0'; }
+    gh_release() { GH_TAG=v2.0.0; }
+    _sc_compare() { printf 'upgrade'; }
+    confirm() { return 0; }
+    gh_fetch_checksums() { CHECKSUM_FILE=""; }
+    wait_for_idle() { :; }
+    state_set() { :; }
+    run_unit() { return 0; }
+
+    : > "$WORK/sc-stage-systemctl"
+    if (
+        systemctl() { printf '%s\n' "$*" >> "$WORK/sc-stage-systemctl"; return 0; }
+        _sc_stage_binary() {
+            [[ $1 == collector-zfs ]] && return 1
+            printf 'new metrics\n' > "$3"
+        }
+        module_update
+    ) >/dev/null 2>&1; then
+        fail "a collector update with a missing staged asset succeeded"
+    fi
+    grep -q '^stop ' "$WORK/sc-stage-systemctl" \
+        && fail "collector timers stopped before every asset was staged"
+    [[ $(<"$TOOLBOX_BIN_DIR/${SC_BIN[metrics]}") == 'old metrics' ]] \
+        || fail "staging failure replaced an installed collector"
+
+    : > "$WORK/sc-install-systemctl"
+    if (
+        systemctl() { printf '%s\n' "$*" >> "$WORK/sc-install-systemctl"; return 0; }
+        _sc_stage_binary() { printf 'new %s\n' "$1" > "$3"; }
+        _sc_install_staged() {
+            [[ $2 == "${SC_BIN[zfs]}" ]] && return 1
+            cp -a "$TOOLBOX_BIN_DIR/$2" "$TOOLBOX_BIN_DIR/$2.prev"
+            command install -m 0755 "$1" "$TOOLBOX_BIN_DIR/$2"
+        }
+        module_update
+    ) >/dev/null 2>&1; then
+        fail "a partial collector replacement succeeded"
+    fi
+    [[ $(<"$TOOLBOX_BIN_DIR/${SC_BIN[metrics]}") == 'old metrics' ]] \
+        || fail "a partial replacement did not roll back the first collector"
+    grep -q "^start $UNIT_PREFIX-metrics.timer" "$WORK/sc-install-systemctl" \
+        || fail "metrics timer was not restored after update failure"
+    grep -q "^start $UNIT_PREFIX-zfs.timer" "$WORK/sc-install-systemctl" \
+        || fail "zfs timer was not restored after update failure"
+
+    printf 'old metrics\n' > "$TOOLBOX_BIN_DIR/${SC_BIN[metrics]}"
+    printf 'old zfs\n' > "$TOOLBOX_BIN_DIR/${SC_BIN[zfs]}"
+    : > "$WORK/sc-smoke-systemctl"
+    : > "$WORK/sc-state-writes"
+    (
+        systemctl() { printf '%s\n' "$*" >> "$WORK/sc-smoke-systemctl"; return 0; }
+        _sc_stage_binary() { printf 'new %s\n' "$1" > "$3"; }
+        run_unit() { [[ $1 != "$UNIT_PREFIX-zfs" ]]; }
+        state_set() { printf '%s %s %s\n' "$1" "$2" "$3" >> "$WORK/sc-state-writes"; }
+        module_update
+    ) >/dev/null 2>&1 || fail "a smoke-test rollback did not complete"
+    [[ $(<"$TOOLBOX_BIN_DIR/${SC_BIN[metrics]}") == 'old metrics' ]] \
+        || fail "a failed release left metrics on the new version"
+    [[ $(<"$TOOLBOX_BIN_DIR/${SC_BIN[zfs]}") == 'old zfs' ]] \
+        || fail "a failed release left zfs on the new version"
+    if grep -q ' VERSION ' "$WORK/sc-state-writes"; then
+        fail "a rolled-back release was recorded as current"
+    fi
+) || exit 1
+pass "scrutiny updates stage first and restore timers on failure"


### PR DESCRIPTION
## What

Hardens config-backup, ZFS replication/scrub, and Scrutiny collector
operations found during the repository-wide review.

## Why

Several configured paths and normalized names could cause destructive
or silently incorrect behavior. Scheduled module failures could also
appear healthy or leave monitoring stopped.

Closes #13

## How

- Validate destructive paths at every mutation boundary.
- Use private non-truncating replication locks and bounded fixup paths.
- Reject normalized name collisions and invalid systemd calendars.
- Stage complete collector releases before pausing timers and roll back
  the full release on failure.
- Add behavior-level regression coverage for all affected modules.

## Testing

- `make test`
- `make lint` with ShellCheck 0.10.0
- `mkdocs build --strict`
- Debian 13 container suite with required TUI, Zsh, and Git-backend tests
- `git diff --check`

## Notes

Systemd timer validation and failure behavior change intentionally. Existing
invalid schedules or colliding normalized names now fail closed and require
operator correction. No migrations or secret-format changes.
