### PR TITLE
feat(storage-hygiene): audit snapshots and orphaned storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ test: syntax
 	@./tests/doctor.sh
 	@./tests/backup-audit.sh
 	@./tests/native-notifications.sh
+	@./tests/storage-hygiene.sh
 	@./tests/discord.sh
 	@./tests/config-backup.sh
 	@./tests/hardening.sh

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ pve-toolbox/
 │   ├── config-backup/       # snapshots /etc/pve and host config, reported to Discord
 │   ├── native-notifications/ # owned native PVE targets, matchers, and shared sender
 │   ├── scrutiny-collectors/ # SMART/ZFS/MDADM collectors for a remote Scrutiny
+│   ├── storage-hygiene/     # read-only snapshot, content, and capacity audit
 │   ├── zfs-scrub/           # scheduled scrub per pool, reported to Discord
 │   └── zfs-replication/     # syncoid jobs on a timer, reported to Discord
 ├── completions/             # bash + zsh completion, installed by `link`
@@ -100,6 +101,7 @@ without regenerating anything. See
 | [backup-audit](https://quwisky.github.io/pve-toolbox/modules/backup-audit/) | Finds uncovered guests, stale or failed backups, excluded volumes, weak retention, and unhealthy backup storage |
 | [config-backup](https://quwisky.github.io/pve-toolbox/modules/config-backup/) | Snapshots `/etc/pve` and host config into verified tar.gz archives on a timer |
 | [native-notifications](https://quwisky.github.io/pve-toolbox/modules/native-notifications/) | Provisions owned PVE notification targets and matchers with protected credentials and rollback |
+| [storage-hygiene](https://quwisky.github.io/pve-toolbox/modules/storage-hygiene/) | Audits old snapshots, unreferenced-looking storage, stale content, and capacity pressure without cleanup |
 | [zfs-scrub](https://quwisky.github.io/pve-toolbox/modules/zfs-scrub/) | Scrubs each pool on its own timer, reports start and result to Discord |
 | [zfs-replication](https://quwisky.github.io/pve-toolbox/modules/zfs-replication/) | Runs `syncoid` jobs on timers, reports duration and size to Discord |
 | [scrutiny-collectors](https://quwisky.github.io/pve-toolbox/modules/scrutiny-collectors/) | SMART / ZFS / MDADM collectors feeding a remote Scrutiny instance |

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,8 @@
 pve-toolbox (0.4.0) unstable; urgency=medium
 
+  * Add read-only storage hygiene checks for snapshots, content, definitions,
+    ZFS objects, capacity, inodes, and LVM thin pools.
+  * Distinguish orphan candidates from volumes with ambiguous ownership.
   * Add idempotent native PVE webhook, Discord, Gotify, and SMTP targets.
   * Provision owned matchers with delivery tests, protected credentials, and
     rollback on failure.

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -33,6 +33,8 @@ guest coverage, backup freshness, failure history, retention, excluded-volume,
 and per-node backup-storage results after it is configured.
 The [native-notifications module](modules/native-notifications.md) checks that
 its owned target, matcher, helper, and templates remain enabled and intact.
+The [storage-hygiene module](modules/storage-hygiene.md) adds snapshot age,
+volume ownership evidence, stale content, and backend pressure checks.
 
 ## Result states and exit status
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ pve-toolbox/
 │   ├── config-backup/
 │   ├── native-notifications/
 │   ├── scrutiny-collectors/
+│   ├── storage-hygiene/
 │   ├── zfs-scrub/
 │   └── zfs-replication/
 ├── completions/             # bash + zsh, installed by `link`
@@ -36,6 +37,7 @@ pve-toolbox/
 | [backup-audit](modules/backup-audit.md) | Read-only guest backup coverage, freshness, retention, and storage audit |
 | [config-backup](modules/config-backup.md) | Timestamped snapshots of `/etc/pve` and host config, reported to Discord |
 | [native-notifications](modules/native-notifications.md) | Owned native PVE targets and matchers with protected secrets and tested delivery |
+| [storage-hygiene](modules/storage-hygiene.md) | Read-only snapshots, content ownership, storage definitions, and capacity audit |
 | [zfs-scrub](modules/zfs-scrub.md) | Scrubs each pool on its own timer, reports start and result to Discord |
 | [zfs-replication](modules/zfs-replication.md) | Runs `syncoid` jobs on timers, reports duration and size to Discord |
 | [scrutiny-collectors](modules/scrutiny-collectors.md) | SMART / ZFS / MDADM collectors feeding a remote Scrutiny instance |

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -8,6 +8,7 @@ launcher discovers them at runtime; directories starting with `_` are skipped.
 | [backup-audit](backup-audit.md) | `backup audit monitoring` | yes | none; contributes doctor checks |
 | [config-backup](config-backup.md) | `backup config notify` | yes | `pve-config-backup` |
 | [native-notifications](native-notifications.md) | `monitoring notify webhook smtp gotify` | yes | `pve-toolbox-native-notify` |
+| [storage-hygiene](storage-hygiene.md) | `storage audit monitoring zfs lvm` | yes | none; contributes doctor checks |
 | [zfs-scrub](zfs-scrub.md) | `storage zfs monitoring notify` | yes | `pve-toolbox-zfs-scrub` |
 | [zfs-replication](zfs-replication.md) | `storage zfs backup replication notify` | yes | `pve-toolbox-zfs-sync` |
 | [scrutiny-collectors](scrutiny-collectors.md) | `storage monitoring smart zfs` | yes | four collector binaries |

--- a/docs/modules/storage-hygiene.md
+++ b/docs/modules/storage-hygiene.md
@@ -1,0 +1,135 @@
+# storage-hygiene
+
+Adds a read-only storage hygiene pass to `pve-toolbox doctor`. It inventories
+guest snapshots, configured storage content, PVE storage definitions, directory
+inodes, ZFS objects, and LVM thin pools without offering a delete command.
+
+```text
+Module      storage-hygiene
+Config      /etc/pve-toolbox/storage-hygiene.conf (0600)
+State       /var/lib/pve-toolbox/storage-hygiene.state (0644)
+Mutations   none during an audit
+```
+
+```bash
+pve-toolbox install storage-hygiene
+pve-toolbox doctor
+pve-toolbox doctor --json
+```
+
+## Checks
+
+### Snapshots
+
+Every non-template VM and container is queried through its PVE snapshot API.
+A snapshot older than `SH_SNAPSHOT_DAYS` warns with the VMID, node, snapshot
+name, creation epoch, and calculated age. The synthetic `current` entry is
+ignored. A snapshot without a usable timestamp is reported with unknown age.
+
+### Guest volumes and storage content
+
+Active guest disk and mount-point volume IDs form the reference set. PVE
+storage content of type `images` or `rootdir` is compared with it:
+
+- a volume listed in a guest's `unusedN` config entry warns as explicitly
+  unused, with that config entry as its evidence;
+- a volume naming a VMID absent from the cluster inventory is an **orphan
+  candidate**;
+- a volume naming a live VMID but absent from its active config is
+  **ownership unknown**, not orphaned.
+
+The last category matters. Snapshots, replication, import workflows, storage
+plugins, or external tools may still own a volume that does not appear in the
+active guest config. The audit never assumes absence from one inventory is
+permission to remove data.
+
+ISO and `vztmpl` entries with a PVE content creation time older than
+`SH_CONTENT_DAYS` warn as stale. Age is evidence of review need, not evidence
+that content is unused.
+
+### Definitions and availability
+
+Disabled storage definitions warn. Enabled definitions with identical backend
+signatures—type plus path, pool, volume group, thin pool, server, share, and
+portal—warn as suspicious duplicates. They may be intentional aliases.
+
+Runtime storage status is checked on every cluster node. Disabled or inactive
+storage fails. Capacity warns and fails at the configured thresholds. Content
+queries respect a definition's PVE node restriction.
+
+For local `dir` storage whose path exists on the audit node, `df -Pi` adds inode
+pressure using the same capacity thresholds. Remote-node inode use is not
+inferred from the local filesystem.
+
+### ZFS and LVM thin pools
+
+When `zfs` is available, datasets and volumes with conventional
+`vm-<id>-...` or `subvol-<id>-...` names are compared with the PVE reference
+set. Missing owner VMIDs produce orphan candidates; live owner VMIDs produce
+unknown-ownership warnings. Unconventional dataset names remain unclassified
+instead of being guessed at.
+
+When `lvs` is available, thin-pool data and metadata percentages are reported.
+The higher pressure value determines warning or failure. Ordinary logical
+volumes are not classified as orphaned from LVM names alone; PVE's content
+inventory is the evidence source for those candidates.
+
+## Thresholds
+
+```ini title="/etc/pve-toolbox/storage-hygiene.conf"
+SH_SNAPSHOT_DAYS='30'
+SH_CONTENT_DAYS='180'
+SH_CAPACITY_WARN='85'
+SH_CAPACITY_FAIL='95'
+SH_THIN_WARN='80'
+SH_THIN_FAIL='95'
+```
+
+Age values must be positive integers. Percentage pairs must satisfy
+`0 <= warning < failure <= 100`. Invalid settings fail the module doctor check.
+
+Unattended configuration:
+
+```bash
+SH_SNAPSHOT_DAYS=45 \
+SH_CONTENT_DAYS=365 \
+SH_CAPACITY_WARN=80 \
+SH_CAPACITY_FAIL=90 \
+SH_THIN_WARN=75 \
+SH_THIN_FAIL=90 \
+  pve-toolbox -y install storage-hygiene
+```
+
+## Manual verification
+
+Treat every result as an investigation starting point. Before considering a
+cleanup outside this tool:
+
+1. Re-run the audit and preserve its JSON evidence.
+2. Inspect the guest config, including `unusedN` entries and snapshots.
+3. Inspect storage content with `pvesm list <storage>` on the owning node.
+4. Check backup, replication, import, HA, and external automation records.
+5. For ZFS, inspect snapshots, clones, origins, holds, and dependent datasets.
+6. For LVM thin pools, inspect logical-volume attributes and open devices.
+7. Take and verify a backup before any manual removal.
+
+There is intentionally no force flag, cleanup helper, prune action, or deletion
+API in this release. Cleanup requires a separate proposal and review.
+
+## Result ID families
+
+| Pattern | Evidence |
+| --- | --- |
+| `guest.<vmid>.snapshot.<name>` | Snapshot name, node, timestamp, and age |
+| `volume.<volid>.unused-config` | Matching guest `unusedN` reference |
+| `volume.<volid>.orphan-candidate` | Parsed owner VMID is absent |
+| `volume.<volid>.ownership-unknown` | Live owner exists but active config lacks the ID |
+| `content.<volid>.stale` | Content type, node, storage, and creation time |
+| `definition.*` | Disabled definition or duplicate backend signature |
+| `storage.<node>.<id>.*` | Availability and byte capacity |
+| `inode.<id>` | Local directory path and inode counts |
+| `zfs.*` | Dataset name, type, byte figures, and owner evidence |
+| `lvm-thin.*` | Volume group, pool, data use, and metadata use |
+
+All IDs are automatically prefixed with `module.storage-hygiene.` in doctor
+and JSON output.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
       - backup-audit: modules/backup-audit.md
       - config-backup: modules/config-backup.md
       - native-notifications: modules/native-notifications.md
+      - storage-hygiene: modules/storage-hygiene.md
       - zfs-scrub: modules/zfs-scrub.md
       - zfs-replication: modules/zfs-replication.md
       - scrutiny-collectors: modules/scrutiny-collectors.md

--- a/modules/storage-hygiene/module.sh
+++ b/modules/storage-hygiene/module.sh
@@ -1,0 +1,406 @@
+# shellcheck shell=bash
+#
+# Read-only snapshot, volume ownership, content age, and capacity audit.
+# shellcheck disable=SC2034
+MODULE_NAME="storage-hygiene"
+MODULE_TITLE="Storage hygiene"
+MODULE_DESC="read-only snapshots, unreferenced volumes, stale content, and capacity audit"
+MODULE_TAGS="storage audit monitoring zfs lvm"
+MODULE_HOST_ONLY=1
+
+SH_CONF_KEYS=(
+    SH_SNAPSHOT_DAYS SH_CONTENT_DAYS SH_CAPACITY_WARN SH_CAPACITY_FAIL
+    SH_THIN_WARN SH_THIN_FAIL
+)
+SH_JSON=""
+SH_ERROR=""
+
+_sh_defaults() {
+    : "${SH_SNAPSHOT_DAYS:=30}"
+    : "${SH_CONTENT_DAYS:=180}"
+    : "${SH_CAPACITY_WARN:=85}"
+    : "${SH_CAPACITY_FAIL:=95}"
+    : "${SH_THIN_WARN:=80}"
+    : "${SH_THIN_FAIL:=95}"
+}
+
+_sh_validate() {
+    SH_ERROR=""
+    [[ $SH_SNAPSHOT_DAYS =~ ^[1-9][0-9]*$ ]] \
+        || { SH_ERROR="snapshot age must be a positive number of days"; return 1; }
+    [[ $SH_CONTENT_DAYS =~ ^[1-9][0-9]*$ ]] \
+        || { SH_ERROR="content age must be a positive number of days"; return 1; }
+    [[ $SH_CAPACITY_WARN =~ ^[0-9]+$ && $SH_CAPACITY_FAIL =~ ^[0-9]+$ \
+        && $SH_CAPACITY_WARN -lt $SH_CAPACITY_FAIL && $SH_CAPACITY_FAIL -le 100 ]] \
+        || { SH_ERROR="capacity thresholds must satisfy 0 <= warning < failure <= 100"; return 1; }
+    [[ $SH_THIN_WARN =~ ^[0-9]+$ && $SH_THIN_FAIL =~ ^[0-9]+$ \
+        && $SH_THIN_WARN -lt $SH_THIN_FAIL && $SH_THIN_FAIL -le 100 ]] \
+        || { SH_ERROR="thin-pool thresholds must satisfy 0 <= warning < failure <= 100"; return 1; }
+}
+
+_sh_load() {
+    _sh_defaults
+    if conf_exists "$MODULE_NAME"; then conf_load "$MODULE_NAME"; fi
+    _sh_validate
+}
+
+_sh_id() {
+    tr '[:upper:]' '[:lower:]' <<<"$1" \
+        | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//'
+}
+
+_sh_array() { # _sh_array <description> <endpoint> [options...]
+    local description=$1 endpoint=$2 output
+    shift 2
+    SH_JSON=""
+    if ! output=$(pvesh get "$endpoint" "$@" --output-format json 2>&1); then
+        doctor_result fail "api.$(_sh_id "$description")" "could not read $description" "$output"
+        return 1
+    fi
+    if ! jq -e 'type == "array"' <<<"$output" >/dev/null 2>&1; then
+        doctor_result fail "api.$(_sh_id "$description")" "$description response was not a JSON array"
+        return 1
+    fi
+    SH_JSON=$output
+}
+
+_sh_object() { # _sh_object <description> <endpoint>
+    local description=$1 endpoint=$2 output
+    SH_JSON=""
+    if ! output=$(pvesh get "$endpoint" --output-format json 2>&1); then
+        doctor_result warn "api.$(_sh_id "$description")" "could not inspect $description" "$output"
+        return 1
+    fi
+    if ! jq -e 'type == "object"' <<<"$output" >/dev/null 2>&1; then
+        doctor_result warn "api.$(_sh_id "$description")" "$description response was not a JSON object"
+        return 1
+    fi
+    SH_JSON=$output
+}
+
+_sh_percent_result() { # _sh_percent_result <id> <label> <percent> <evidence>
+    local id=$1 label=$2 percent=$3 evidence=$4
+    if [[ $percent -ge $SH_CAPACITY_FAIL ]]; then
+        doctor_result fail "$id" "$label is ${percent}% used" "$evidence"
+    elif [[ $percent -ge $SH_CAPACITY_WARN ]]; then
+        doctor_result warn "$id" "$label is ${percent}% used" "$evidence"
+    else
+        doctor_result pass "$id" "$label is ${percent}% used" "$evidence"
+    fi
+}
+
+_sh_guest_inventory() { # sets SH_GUESTS SH_REFS SH_UNUSED SH_NODES
+    local guest vmid node type endpoint config snapshots snap name stamp age key value
+    local now snapshot_cutoff
+    SH_GUESTS=$1
+    SH_REFS='[]'
+    SH_UNUSED='[]'
+    SH_NODES=$2
+    now=${SH_NOW_EPOCH:-$(date +%s)}
+    snapshot_cutoff=$((now - SH_SNAPSHOT_DAYS * 86400))
+
+    while IFS= read -r guest; do
+        vmid=$(jq -r '.vmid | tostring' <<<"$guest")
+        node=$(jq -r '.node // "unknown"' <<<"$guest")
+        type=$(jq -r '.type' <<<"$guest")
+        SH_NODES=$(jq -cn --argjson nodes "$SH_NODES" --arg node "$node" '$nodes + [$node] | unique')
+        case $type in qemu|lxc) ;; *) continue ;; esac
+        endpoint="/nodes/$node/$type/$vmid"
+        if _sh_object "guest $vmid config" "$endpoint/config"; then
+            config=$SH_JSON
+            while IFS=$'\t' read -r key value; do
+                [[ -n $value ]] || continue
+                if [[ $key == unused* ]]; then
+                    SH_UNUSED=$(jq -cn --argjson refs "$SH_UNUSED" --arg value "$value" '$refs + [$value] | unique')
+                else
+                    SH_REFS=$(jq -cn --argjson refs "$SH_REFS" --arg value "$value" '$refs + [$value] | unique')
+                fi
+            done < <(jq -r '
+                to_entries[]
+                | select(.key | test("^(ide|sata|scsi|virtio|efidisk|tpmstate|unused|mp|rootfs)[0-9]*$"))
+                | [.key, ((.value | tostring) | split(",")[0])] | @tsv
+            ' <<<"$config")
+        fi
+        if ! _sh_array "guest $vmid snapshots" "$endpoint/snapshot"; then
+            continue
+        fi
+        snapshots=$SH_JSON
+        while IFS= read -r snap; do
+            name=$(jq -r '.name // "unnamed"' <<<"$snap")
+            [[ $name != current ]] || continue
+            stamp=$(jq -r '(.snaptime // 0) | tonumber? // 0 | floor' <<<"$snap")
+            if [[ $stamp -le 0 ]]; then
+                doctor_result warn "guest.$vmid.snapshot.$(_sh_id "$name")" \
+                    "snapshot age is unknown" "node=$node snapshot=$name missing snaptime"
+            elif [[ $stamp -lt $snapshot_cutoff ]]; then
+                age=$(((now - stamp) / 86400))
+                doctor_result warn "guest.$vmid.snapshot.$(_sh_id "$name")" \
+                    "snapshot is ${age} days old" "node=$node snapshot=$name created=$stamp"
+            fi
+        done < <(jq -c '.[]' <<<"$snapshots")
+    done < <(jq -c '.[] | select((.type == "qemu" or .type == "lxc") and ((.template // 0) | tostring) != "1")' <<<"$1")
+}
+
+_sh_storage_definitions() { # _sh_storage_definitions <json>
+    local duplicates group signature ids
+    duplicates=$(jq -c '
+        map(select(((.disable // 0) | tostring) != "1")
+            | . + {signature: ([.type // "", .path // "", .pool // "", .vgname // "",
+                                .thinpool // "", .server // "", .share // "", .portal // ""]
+                               | map(tostring) | join("|"))})
+        | sort_by(.signature) | group_by(.signature) | map(select(length > 1))
+    ' <<<"$1")
+    while IFS= read -r group; do
+        signature=$(jq -r '.[0].signature' <<<"$group")
+        ids=$(jq -r 'map(.storage) | join(",")' <<<"$group")
+        doctor_result warn "definition.duplicate.$(_sh_id "$ids")" \
+            "storage definitions have the same backend signature" "ids=$ids signature=$signature"
+    done < <(jq -c '.[]' <<<"$duplicates")
+    while IFS= read -r group; do
+        ids=$(jq -r '.storage' <<<"$group")
+        if [[ $(jq -r '(.disable // 0) | tostring' <<<"$group") == 1 ]]; then
+            doctor_result warn "definition.$(_sh_id "$ids").disabled" \
+                "storage definition is disabled" "storage=$ids type=$(jq -r '.type // "unknown"' <<<"$group")"
+        fi
+    done < <(jq -c '.[]' <<<"$1")
+}
+
+_sh_storage_status() { # _sh_storage_status <nodes-json>
+    local node row id enabled active total used percent
+    while IFS= read -r node; do
+        if ! _sh_array "storage status on $node" "/nodes/$node/storage"; then continue; fi
+        while IFS= read -r row; do
+            id=$(jq -r '.storage // "unknown"' <<<"$row")
+            enabled=$(jq -r '(.enabled // 1) | tostring' <<<"$row")
+            active=$(jq -r '(.active // 0) | tostring' <<<"$row")
+            if [[ $enabled == 0 || $active != 1 ]]; then
+                doctor_result fail "storage.$(_sh_id "$node.$id").availability" \
+                    "storage is unavailable" "node=$node storage=$id enabled=$enabled active=$active"
+                continue
+            fi
+            total=$(jq -r '(.total // 0) | tonumber? // 0 | floor' <<<"$row")
+            used=$(jq -r '(.used // 0) | tonumber? // 0 | floor' <<<"$row")
+            if [[ $total -gt 0 ]]; then
+                percent=$((used * 100 / total))
+                _sh_percent_result "storage.$(_sh_id "$node.$id").capacity" \
+                    "storage $node:$id" "$percent" "used=$used total=$total"
+            else
+                doctor_result warn "storage.$(_sh_id "$node.$id").capacity" \
+                    "storage capacity is unknown" "node=$node storage=$id total=$total"
+            fi
+        done < <(jq -c '.[]' <<<"$SH_JSON")
+    done < <(jq -r '.[]' <<<"$1")
+}
+
+_sh_content() { # _sh_content <definitions-json> <nodes-json>
+    local definition storage allowed node content row volid kind ctime age now vmid evidence
+    now=${SH_NOW_EPOCH:-$(date +%s)}
+    while IFS= read -r definition; do
+        storage=$(jq -r '.storage' <<<"$definition")
+        allowed=$(jq -r '.nodes // ""' <<<"$definition")
+        [[ $(jq -r '(.disable // 0) | tostring' <<<"$definition") != 1 ]] || continue
+        while IFS= read -r node; do
+            if [[ -n $allowed && ",$allowed," != *",$node,"* ]]; then continue; fi
+            if ! _sh_array "content $node $storage" "/nodes/$node/storage/$storage/content"; then
+                doctor_result warn "content.$(_sh_id "$node.$storage").unknown" \
+                    "storage content ownership is unknown" "node=$node storage=$storage listing failed"
+                continue
+            fi
+            content=$SH_JSON
+            while IFS= read -r row; do
+                volid=$(jq -r '.volid // "unknown"' <<<"$row")
+                kind=$(jq -r '.content // "unknown"' <<<"$row")
+                case $kind in
+                    images|rootdir)
+                        jq -e --arg volid "$volid" 'index($volid) != null' <<<"$SH_REFS" >/dev/null && continue
+                        if jq -e --arg volid "$volid" 'index($volid) != null' <<<"$SH_UNUSED" >/dev/null; then
+                            doctor_result warn "volume.$(_sh_id "$volid").unused-config" \
+                                "volume is listed as unused in a guest config" \
+                                "node=$node storage=$storage volid=$volid verify guest unused-disk entries"
+                            continue
+                        fi
+                        vmid=$(jq -r '(.vmid // 0) | tostring' <<<"$row")
+                        if [[ $vmid == 0 && $volid =~ (vm|subvol)-([0-9]+)- ]]; then vmid=${BASH_REMATCH[2]}; fi
+                        evidence="node=$node storage=$storage volid=$volid not referenced by inventoried guest configs"
+                        if [[ $vmid != 0 ]] && ! jq -e --arg vmid "$vmid" \
+                            'any(.[]; (.vmid | tostring) == $vmid)' <<<"$SH_GUESTS" >/dev/null; then
+                            doctor_result warn "volume.$(_sh_id "$volid").orphan-candidate" \
+                                "volume owner VMID does not exist" "$evidence owner-vmid=$vmid"
+                        else
+                            doctor_result warn "volume.$(_sh_id "$volid").ownership-unknown" \
+                                "volume is not referenced by an active config; ownership is unknown" \
+                                "$evidence snapshots, replication, or external tooling may own it"
+                        fi
+                        ;;
+                    iso|vztmpl)
+                        ctime=$(jq -r '(.ctime // 0) | tonumber? // 0 | floor' <<<"$row")
+                        [[ $ctime -gt 0 ]] || continue
+                        age=$(((now - ctime) / 86400))
+                        if [[ $age -ge $SH_CONTENT_DAYS ]]; then
+                            doctor_result warn "content.$(_sh_id "$volid").stale" \
+                                "$kind content is ${age} days old" \
+                                "node=$node storage=$storage volid=$volid ctime=$ctime"
+                        fi
+                        ;;
+                esac
+            done < <(jq -c '.[]' <<<"$content")
+        done < <(jq -r '.[]' <<<"$2")
+    done < <(jq -c '.[]' <<<"$1")
+}
+
+_sh_inode_usage() { # _sh_inode_usage <definitions-json>
+    local definition storage path line total used percent
+    command -v df >/dev/null 2>&1 || return 0
+    while IFS= read -r definition; do
+        storage=$(jq -r '.storage' <<<"$definition")
+        path=$(jq -r '.path // empty' <<<"$definition")
+        [[ -n $path && -d $path ]] || continue
+        line=$(df -Pi -- "$path" 2>/dev/null | tail -n1) || continue
+        read -r _ total used _ _ _ <<<"$line"
+        [[ $total =~ ^[0-9]+$ && $total -gt 0 ]] || continue
+        percent=$((used * 100 / total))
+        _sh_percent_result "inode.$(_sh_id "$storage")" "inode use for $storage" \
+            "$percent" "path=$path used=$used total=$total"
+    done < <(jq -c '.[] | select(.type == "dir")' <<<"$1")
+}
+
+_sh_zfs() {
+    local output row name type used available leaf vmid evidence
+    command -v zfs >/dev/null 2>&1 || { doctor_result skipped zfs "ZFS inventory is not available"; return 0; }
+    if ! output=$(zfs list -Hp -o name,type,used,available 2>&1); then
+        doctor_result warn zfs "could not read ZFS dataset inventory" "$output"
+        return 0
+    fi
+    while IFS=$'\t' read -r name type used available; do
+        leaf=${name##*/}
+        [[ $leaf =~ ^(vm|subvol)-([0-9]+)- ]] || continue
+        vmid=${BASH_REMATCH[2]}
+        evidence="dataset=$name type=$type used=$used available=$available no matching PVE volume reference"
+        if jq -e --arg leaf "$leaf" 'any(.[]; endswith(":" + $leaf))' <<<"$SH_REFS" >/dev/null; then
+            continue
+        elif jq -e --arg vmid "$vmid" 'any(.[]; (.vmid | tostring) == $vmid)' <<<"$SH_GUESTS" >/dev/null; then
+            doctor_result warn "zfs.$(_sh_id "$name").ownership-unknown" \
+                "ZFS object is unreferenced; ownership is unknown" "$evidence owner VMID exists"
+        else
+            doctor_result warn "zfs.$(_sh_id "$name").orphan-candidate" \
+                "ZFS object owner VMID does not exist" "$evidence owner-vmid=$vmid"
+        fi
+    done <<<"$output"
+}
+
+_sh_lvm() {
+    local output row vg pool data meta max value evidence
+    command -v lvs >/dev/null 2>&1 || { doctor_result skipped lvm-thin "LVM inventory is not available"; return 0; }
+    if ! output=$(lvs --reportformat json --units b --nosuffix \
+        -o vg_name,lv_name,lv_attr,data_percent,metadata_percent 2>&1); then
+        doctor_result warn lvm-thin "could not read LVM thin-pool inventory" "$output"
+        return 0
+    fi
+    if ! jq -e '.report | type == "array"' <<<"$output" >/dev/null 2>&1; then
+        doctor_result warn lvm-thin "LVM inventory was not valid JSON"
+        return 0
+    fi
+    while IFS= read -r row; do
+        vg=$(jq -r '.vg_name | gsub("^[[:space:]]+|[[:space:]]+$"; "")' <<<"$row")
+        pool=$(jq -r '.lv_name | gsub("^[[:space:]]+|[[:space:]]+$"; "")' <<<"$row")
+        data=$(jq -r '(.data_percent // "0") | tonumber? // 0 | floor' <<<"$row")
+        meta=$(jq -r '(.metadata_percent // "0") | tonumber? // 0 | floor' <<<"$row")
+        max=$data; [[ $meta -le $max ]] || max=$meta
+        value=pass
+        [[ $max -lt $SH_THIN_WARN ]] || value=warn
+        [[ $max -lt $SH_THIN_FAIL ]] || value=fail
+        evidence="vg=$vg pool=$pool data=${data}% metadata=${meta}%"
+        doctor_result "$value" "lvm-thin.$(_sh_id "$vg.$pool")" \
+            "thin pool data=${data}% metadata=${meta}%" "$evidence"
+    done < <(jq -c '.report[].lv[] | select((.lv_attr // "") | startswith("t"))' <<<"$output")
+}
+
+_sh_audit() {
+    local guests definitions node_records nodes
+    if ! command -v pvesh >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+        doctor_result unsupported prerequisites "pvesh and jq are required"
+        return 0
+    fi
+    if ! _sh_load; then
+        doctor_result fail configuration "storage hygiene thresholds are invalid" "$SH_ERROR"
+        return 0
+    fi
+    _sh_array "cluster guest inventory" /cluster/resources --type vm || return 0
+    guests=$SH_JSON
+    _sh_array "cluster node inventory" /nodes || return 0
+    node_records=$SH_JSON
+    nodes=$(jq -c '[.[].node // empty] | unique' <<<"$node_records")
+    _sh_array "storage definitions" /storage || return 0
+    definitions=$SH_JSON
+    _sh_guest_inventory "$guests" "$nodes"
+    doctor_result pass inventory \
+        "inventoried $(jq 'length' <<<"$guests") guest records and $(jq 'length' <<<"$definitions") storage definitions"
+    _sh_storage_definitions "$definitions"
+    _sh_storage_status "$SH_NODES"
+    _sh_content "$definitions" "$SH_NODES"
+    _sh_inode_usage "$definitions"
+    _sh_zfs
+    _sh_lvm
+}
+
+module_install() {
+    require_root
+    require_pve
+    _sh_defaults
+    if conf_exists "$MODULE_NAME"; then conf_load "$MODULE_NAME"; fi
+    pkg_ensure jq:jq
+    ask SH_SNAPSHOT_DAYS "snapshot warning age (days)" "$SH_SNAPSHOT_DAYS"
+    ask SH_CONTENT_DAYS "ISO/template warning age (days)" "$SH_CONTENT_DAYS"
+    ask SH_CAPACITY_WARN "capacity warning threshold" "$SH_CAPACITY_WARN"
+    ask SH_CAPACITY_FAIL "capacity failure threshold" "$SH_CAPACITY_FAIL"
+    ask SH_THIN_WARN "thin-pool warning threshold" "$SH_THIN_WARN"
+    ask SH_THIN_FAIL "thin-pool failure threshold" "$SH_THIN_FAIL"
+    _sh_validate || die "$SH_ERROR"
+    local key
+    for key in "${SH_CONF_KEYS[@]}"; do conf_set "$MODULE_NAME" "$key" "${!key}"; done
+    state_set "$MODULE_NAME" INSTALLED_AT "$(date -Is)"
+    ok "configured read-only storage hygiene audit"
+}
+
+module_update() {
+    local check_only=0 key missing=()
+    [[ ${1:-} == --check ]] && check_only=1
+    conf_exists "$MODULE_NAME" || die "not installed"
+    _sh_defaults
+    for key in "${SH_CONF_KEYS[@]}"; do
+        [[ -n $(conf_get "$MODULE_NAME" "$key") ]] || missing+=("$key")
+    done
+    if [[ ${#missing[@]} -eq 0 ]]; then ok "storage hygiene configuration is up to date"; return 0; fi
+    if [[ $check_only -eq 1 ]]; then warn "update available: missing settings ${missing[*]}"; return 0; fi
+    for key in "${missing[@]}"; do conf_set "$MODULE_NAME" "$key" "${!key}"; done
+    ok "added missing storage hygiene settings"
+}
+
+module_status() {
+    conf_exists "$MODULE_NAME" || { printf 'not installed'; return 1; }
+    printf 'configured, read-only'
+}
+
+module_status_long() {
+    module_status || return 1
+    printf '\n'
+    if _sh_load; then
+        printf '  snapshots  warn after %sd\n' "$SH_SNAPSHOT_DAYS"
+        printf '  content    warn after %sd\n' "$SH_CONTENT_DAYS"
+        printf '  capacity   warn %s%%, fail %s%%\n' "$SH_CAPACITY_WARN" "$SH_CAPACITY_FAIL"
+        printf '  thin pool  warn %s%%, fail %s%%\n' "$SH_THIN_WARN" "$SH_THIN_FAIL"
+        printf '  cleanup    never automatic\n'
+    else
+        printf '  configuration invalid\n'
+        return 1
+    fi
+}
+
+module_doctor() { _sh_audit; }
+
+module_uninstall() {
+    require_root
+    conf_clear "$MODULE_NAME"
+    state_clear "$MODULE_NAME"
+    ok "removed storage hygiene audit configuration; no storage was changed"
+}

--- a/tests/package.sh
+++ b/tests/package.sh
@@ -47,6 +47,7 @@ for path in \
     ./usr/lib/pve-toolbox/modules/config-backup/module.sh \
     ./usr/lib/pve-toolbox/modules/native-notifications/module.sh \
     ./usr/lib/pve-toolbox/modules/native-notifications/pve-toolbox-native-notify \
+    ./usr/lib/pve-toolbox/modules/storage-hygiene/module.sh \
     ./usr/share/man/man1/pve-toolbox.1.gz \
     ./usr/share/bash-completion/completions/pve-toolbox \
     ./usr/share/zsh/vendor-completions/_pve-toolbox

--- a/tests/storage-hygiene.sh
+++ b/tests/storage-hygiene.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Directory, ZFS, and LVM-thin fixtures for the read-only hygiene audit.
+set -euo pipefail
+
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
+ROOT=$PWD
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/dir" "$WORK/conf" "$WORK/state"
+
+pass() { printf 'ok  %s\n' "$1"; }
+fail() { printf 'FAIL %s\n' "$1" >&2; exit 1; }
+
+TOOLBOX_CONF_DIR="$WORK/conf"
+TOOLBOX_STATE_DIR="$WORK/state"
+export TOOLBOX_CONF_DIR TOOLBOX_STATE_DIR
+
+# shellcheck source=lib/common.sh
+source "$ROOT/lib/common.sh"
+# shellcheck source=lib/report.sh
+source "$ROOT/lib/report.sh"
+# shellcheck source=lib/doctor.sh
+source "$ROOT/lib/doctor.sh"
+# shellcheck source=modules/storage-hygiene/module.sh
+source "$ROOT/modules/storage-hygiene/module.sh"
+
+SH_NOW_EPOCH=2000000000
+export SH_NOW_EPOCH
+
+pvesh() {
+    [[ ${1:-} == get ]] || fail "storage audit attempted a mutating PVE call: $*"
+    local endpoint=${2:-}
+    case $endpoint in
+        /cluster/resources)
+            printf '%s\n' '[
+              {"vmid":100,"node":"pve1","type":"qemu"},
+              {"vmid":101,"node":"pve1","type":"lxc"}
+            ]' ;;
+        /nodes)
+            printf '%s\n' '[{"node":"pve1"}]' ;;
+        /storage)
+            jq -n --arg path "$WORK/dir" '[
+              {storage:"local",type:"dir",path:$path,nodes:"pve1"},
+              {storage:"local-copy",type:"dir",path:$path,nodes:"pve1"},
+              {storage:"zfs-store",type:"zfspool",pool:"tank/data",nodes:"pve1"},
+              {storage:"local-lvm",type:"lvmthin",vgname:"pve",thinpool:"data",nodes:"pve1"},
+              {storage:"disabled",type:"dir",path:"/offline",disable:1,nodes:"pve1"}
+            ]' ;;
+        /nodes/pve1/qemu/100/config)
+            printf '%s\n' '{
+              "scsi0":"local:vm-100-disk-0,size=8G",
+              "scsi1":"zfs-store:vm-100-disk-0,size=8G",
+              "unused0":"local:vm-100-disk-9"
+            }' ;;
+        /nodes/pve1/lxc/101/config)
+            printf '%s\n' '{"rootfs":"local:subvol-101-disk-0,size=8G"}' ;;
+        /nodes/pve1/qemu/100/snapshot)
+            printf '%s\n' '[
+              {"name":"current"},
+              {"name":"before-upgrade","snaptime":1991360000}
+            ]' ;;
+        /nodes/pve1/lxc/101/snapshot)
+            printf '%s\n' '[]' ;;
+        /nodes/pve1/storage)
+            printf '%s\n' '[
+              {"storage":"local","enabled":1,"active":1,"total":100,"used":90},
+              {"storage":"local-copy","enabled":1,"active":1,"total":100,"used":10},
+              {"storage":"zfs-store","enabled":1,"active":1,"total":100,"used":20},
+              {"storage":"local-lvm","enabled":1,"active":1,"total":100,"used":97},
+              {"storage":"disabled","enabled":0,"active":0,"total":100,"used":0}
+            ]' ;;
+        /nodes/pve1/storage/local/content)
+            printf '%s\n' '[
+              {"volid":"local:vm-100-disk-0","content":"images","vmid":100},
+              {"volid":"local:vm-100-disk-9","content":"images","vmid":100},
+              {"volid":"local:vm-100-disk-2","content":"images","vmid":100},
+              {"volid":"local:vm-999-disk-0","content":"images","vmid":999},
+              {"volid":"local:iso/old.iso","content":"iso","ctime":1980000000},
+              {"volid":"local:vztmpl/fresh.tar.zst","content":"vztmpl","ctime":1999990000}
+            ]' ;;
+        /nodes/pve1/storage/local-copy/content|/nodes/pve1/storage/zfs-store/content|/nodes/pve1/storage/local-lvm/content)
+            printf '%s\n' '[]' ;;
+        *) fail "unexpected PVE fixture endpoint: $endpoint" ;;
+    esac
+}
+
+df() {
+    [[ ${1:-} == -Pi && ${2:-} == -- ]] || fail "unexpected df invocation: $*"
+    printf '%s\n' \
+        'Filesystem Inodes IUsed IFree IUse% Mounted on' \
+        '/dev/test 100 88 12 88% /fixture'
+}
+
+zfs() {
+    [[ $* == 'list -Hp -o name,type,used,available' ]] || fail "unexpected zfs invocation: $*"
+    printf '%s\n' \
+        $'tank/data/vm-100-disk-0\tvolume\t100\t900' \
+        $'tank/data/vm-100-disk-8\tvolume\t100\t900' \
+        $'tank/data/subvol-998-disk-0\tfilesystem\t100\t900'
+}
+
+lvs() {
+    [[ $* == '--reportformat json --units b --nosuffix -o vg_name,lv_name,lv_attr,data_percent,metadata_percent' ]] \
+        || fail "unexpected lvs invocation: $*"
+    printf '%s\n' '{"report":[{"lv":[
+      {"vg_name":"pve","lv_name":"data","lv_attr":"twi-aotz--","data_percent":"96.2","metadata_percent":"81.0"},
+      {"vg_name":"pve","lv_name":"vm-100-disk-0","lv_attr":"Vwi-a-tz--","data_percent":"","metadata_percent":""}
+    ]}]}'
+}
+
+result_state() {
+    local wanted=$1 i
+    for ((i = 0; i < ${#REPORT_IDS[@]}; i++)); do
+        if [[ ${REPORT_IDS[$i]} == "$wanted" ]]; then
+            printf '%s' "${REPORT_STATES[$i]}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+conf_set storage-hygiene SH_SNAPSHOT_DAYS 30
+conf_set storage-hygiene SH_CONTENT_DAYS 180
+conf_set storage-hygiene SH_CAPACITY_WARN 85
+conf_set storage-hygiene SH_CAPACITY_FAIL 95
+conf_set storage-hygiene SH_THIN_WARN 80
+conf_set storage-hygiene SH_THIN_FAIL 95
+
+doctor_reset
+module_doctor
+[[ $(report_exit_code) == 1 ]] || fail "critical storage fixture did not fail"
+[[ $(result_state guest.100.snapshot.before-upgrade) == warn ]] \
+    || fail "old guest snapshot was not warned"
+[[ $(result_state definition.duplicate.local-local-copy) == warn ]] \
+    || fail "duplicate directory definitions were not detected"
+[[ $(result_state definition.disabled.disabled) == warn ]] \
+    || fail "disabled storage definition was not reported"
+[[ $(result_state storage.pve1.local.capacity) == warn ]] \
+    || fail "directory capacity warning was not applied"
+[[ $(result_state storage.pve1.local-lvm.capacity) == fail ]] \
+    || fail "storage capacity failure was not applied"
+[[ $(result_state inode.local) == warn ]] || fail "directory inode pressure was not reported"
+[[ $(result_state volume.local-vm-100-disk-9.unused-config) == warn ]] \
+    || fail "guest unused-disk evidence was not reported"
+[[ $(result_state volume.local-vm-100-disk-2.ownership-unknown) == warn ]] \
+    || fail "ambiguous live-guest volume was not marked unknown"
+[[ $(result_state volume.local-vm-999-disk-0.orphan-candidate) == warn ]] \
+    || fail "missing-owner volume was not reported as a candidate"
+[[ $(result_state content.local-iso-old.iso.stale) == warn ]] \
+    || fail "stale ISO was not reported"
+[[ $(result_state zfs.tank-data-vm-100-disk-8.ownership-unknown) == warn ]] \
+    || fail "ambiguous ZFS volume was not marked unknown"
+[[ $(result_state zfs.tank-data-subvol-998-disk-0.orphan-candidate) == warn ]] \
+    || fail "missing-owner ZFS dataset was not reported"
+[[ $(result_state lvm-thin.pve.data) == fail ]] \
+    || fail "LVM thin-pool pressure was not failed"
+pass "directory, ZFS, and LVM-thin evidence is reported"
+
+detail=$(jq -rn --argjson ids "$(printf '%s\n' "${REPORT_IDS[@]}" | jq -R . | jq -s .)" '$ids | join(" ")')
+[[ $detail != *delete* && $detail != *prune* ]] || fail "audit emitted a cleanup action"
+pass "audit remains read-only and proposes no automatic cleanup"
+
+SH_SNAPSHOT_DAYS=0 SH_CONTENT_DAYS=180 SH_CAPACITY_WARN=85 SH_CAPACITY_FAIL=95 \
+    SH_THIN_WARN=80 SH_THIN_FAIL=95
+_sh_validate && fail "zero snapshot threshold was accepted"
+SH_SNAPSHOT_DAYS=30 SH_CAPACITY_WARN=95 SH_CAPACITY_FAIL=85
+_sh_validate && fail "reversed capacity thresholds were accepted"
+SH_CAPACITY_WARN=85 SH_CAPACITY_FAIL=95 SH_THIN_WARN=95 SH_THIN_FAIL=80
+_sh_validate && fail "reversed thin-pool thresholds were accepted"
+pass "storage hygiene thresholds fail closed"


### PR DESCRIPTION
## What

Adds read-only checks for old snapshots, stale content, duplicate definitions, capacity, inodes, ZFS objects, and LVM-thin pressure.

## Why

Provides evidence for storage cleanup decisions without deleting or pruning anything. Closes #22.

## Testing

Added directory, ZFS, LVM-thin, ownership-ambiguity, threshold, and no-cleanup fixtures.

make lint

TUI_TEST_REQUIRED=1 ZSH_TEST_REQUIRED=1 CB_GATE_TESTS_REQUIRED=1 PACKAGING_TEST_REQUIRED=1 PACKAGING_INSTALL_TEST_REQUIRED=1 REPOSITORY_TEST_REQUIRED=1 make test

mkdocs build --strict