### PR TITLE
feat(certificate-watch): monitor TLS and ACME health

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ test: syntax
 	@./tests/backup-audit.sh
 	@./tests/native-notifications.sh
 	@./tests/storage-hygiene.sh
+	@./tests/certificate-watch.sh
 	@./tests/discord.sh
 	@./tests/config-backup.sh
 	@./tests/hardening.sh

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ pve-toolbox/
 ├── modules/
 │   ├── _template/           # copy this to start a new module (underscore = hidden)
 │   ├── backup-audit/        # read-only guest backup protection and freshness audit
+│   ├── certificate-watch/   # read-only cluster TLS and ACME health audit
 │   ├── config-backup/       # snapshots /etc/pve and host config, reported to Discord
 │   ├── native-notifications/ # owned native PVE targets, matchers, and shared sender
 │   ├── scrutiny-collectors/ # SMART/ZFS/MDADM collectors for a remote Scrutiny
@@ -99,6 +100,7 @@ without regenerating anything. See
 | Module | What it does |
 | --- | --- |
 | [backup-audit](https://quwisky.github.io/pve-toolbox/modules/backup-audit/) | Finds uncovered guests, stale or failed backups, excluded volumes, weak retention, and unhealthy backup storage |
+| [certificate-watch](https://quwisky.github.io/pve-toolbox/modules/certificate-watch/) | Checks cluster TLS expiry, hostname coverage, chains, reachability, and ACME task history |
 | [config-backup](https://quwisky.github.io/pve-toolbox/modules/config-backup/) | Snapshots `/etc/pve` and host config into verified tar.gz archives on a timer |
 | [native-notifications](https://quwisky.github.io/pve-toolbox/modules/native-notifications/) | Provisions owned PVE notification targets and matchers with protected credentials and rollback |
 | [storage-hygiene](https://quwisky.github.io/pve-toolbox/modules/storage-hygiene/) | Audits old snapshots, unreferenced-looking storage, stale content, and capacity pressure without cleanup |

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,7 @@
 pve-toolbox (0.4.0) unstable; urgency=medium
 
+  * Add read-only cluster certificate expiry, hostname, and chain checks.
+  * Report node reachability and failed or stale native ACME tasks.
   * Add read-only storage hygiene checks for snapshots, content, definitions,
     ZFS objects, capacity, inodes, and LVM thin pools.
   * Distinguish orphan candidates from volumes with ambiguous ownership.

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -35,6 +35,9 @@ The [native-notifications module](modules/native-notifications.md) checks that
 its owned target, matcher, helper, and templates remain enabled and intact.
 The [storage-hygiene module](modules/storage-hygiene.md) adds snapshot age,
 volume ownership evidence, stale content, and backend pressure checks.
+The [certificate-watch module](modules/certificate-watch.md) checks every
+cluster node's active TLS certificate, trust chain, hostname coverage,
+reachability, and native ACME task history.
 
 ## Result states and exit status
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ pve-toolbox/
 ├── modules/
 │   ├── _template/           # copy this to start a new module
 │   ├── backup-audit/
+│   ├── certificate-watch/
 │   ├── config-backup/
 │   ├── native-notifications/
 │   ├── scrutiny-collectors/
@@ -35,6 +36,7 @@ pve-toolbox/
 | Module | What it does |
 | --- | --- |
 | [backup-audit](modules/backup-audit.md) | Read-only guest backup coverage, freshness, retention, and storage audit |
+| [certificate-watch](modules/certificate-watch.md) | Read-only cluster certificate, chain, hostname, and ACME health audit |
 | [config-backup](modules/config-backup.md) | Timestamped snapshots of `/etc/pve` and host config, reported to Discord |
 | [native-notifications](modules/native-notifications.md) | Owned native PVE targets and matchers with protected secrets and tested delivery |
 | [storage-hygiene](modules/storage-hygiene.md) | Read-only snapshots, content ownership, storage definitions, and capacity audit |

--- a/docs/modules/certificate-watch.md
+++ b/docs/modules/certificate-watch.md
@@ -1,0 +1,74 @@
+# certificate-watch
+
+`certificate-watch` adds a read-only cluster TLS and native ACME audit to
+`pve-toolbox doctor`. It never orders, renews, installs, or replaces a
+certificate.
+
+```text
+Module      certificate-watch
+Config      /etc/pve-toolbox/certificate-watch.conf (0600)
+State       /var/lib/pve-toolbox/certificate-watch.state (0644)
+Mutations   module configuration only
+```
+
+## Configure
+
+```bash
+pve-toolbox install certificate-watch
+pve-toolbox doctor
+```
+
+The module inspects each node returned by the cluster API. It prefers the
+custom proxy bundle `pveproxy-ssl.pem` and otherwise checks the internal
+`pve-ssl.pem`. An unavailable node is reported without preventing checks of
+the replicated certificate files or the other nodes.
+
+For each active certificate, the report includes:
+
+- expiry against configurable UTC thresholds;
+- DNS hostname coverage from the leaf certificate;
+- issuer, subject, and subject alternative names;
+- chain verification against the system trust store for custom certificates,
+  or the cluster root CA for internal certificates.
+
+Thresholds are inclusive: an already-expired certificate fails, a certificate
+at or below the failure boundary fails, and one at or below the warning
+boundary warns. Defaults are 7 and 30 days.
+
+```ini title="/etc/pve-toolbox/certificate-watch.conf"
+CW_WARN_DAYS=30
+CW_FAIL_DAYS=7
+CW_ACME_STALE_DAYS=45
+```
+
+When ACME is configured, `acmerenew` and `acmenewcert` task history is checked.
+The latest failure is a failure when it is newer than the latest success; an
+absent or stale success is a warning. Task inspection does not trigger renewal.
+
+## Monitoring
+
+JSON output and the shared native notification helper can be combined in a
+timer or external monitoring job:
+
+```bash
+report=$(mktemp)
+trap 'rm -f -- "$report"' EXIT
+rc=0
+pve-toolbox doctor --json >"$report" || rc=$?
+if jq -e '.results[] | select(.id | startswith("module.certificate-watch."))
+  | select(.state == "warn" or .state == "fail")' "$report" >/dev/null; then
+  pve-toolbox-native-notify warning certificate-watch \
+    "certificate watch requires attention (doctor exit $rc)"
+fi
+```
+
+The helper is installed by `native-notifications`. Sending remains an explicit
+monitoring action; running doctor alone never sends anything.
+
+## Limitations
+
+- Chain validation reflects the local node's current trust store.
+- ACME health is inferred from the most recent 200 cluster tasks, so older
+  history may be unavailable.
+- The audit complements certificate and ACME checks in Proxmox; it does not
+  replace renewal monitoring or official operational guidance.

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -6,6 +6,7 @@ launcher discovers them at runtime; directories starting with `_` are skipped.
 | Module | Tags | Host only | Helper installed |
 | --- | --- | --- | --- |
 | [backup-audit](backup-audit.md) | `backup audit monitoring` | yes | none; contributes doctor checks |
+| [certificate-watch](certificate-watch.md) | `monitoring tls certificate acme notify` | yes | none; contributes doctor checks |
 | [config-backup](config-backup.md) | `backup config notify` | yes | `pve-config-backup` |
 | [native-notifications](native-notifications.md) | `monitoring notify webhook smtp gotify` | yes | `pve-toolbox-native-notify` |
 | [storage-hygiene](storage-hygiene.md) | `storage audit monitoring zfs lvm` | yes | none; contributes doctor checks |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
   - Modules:
       - Overview: modules/index.md
       - backup-audit: modules/backup-audit.md
+      - certificate-watch: modules/certificate-watch.md
       - config-backup: modules/config-backup.md
       - native-notifications: modules/native-notifications.md
       - storage-hygiene: modules/storage-hygiene.md

--- a/modules/certificate-watch/module.sh
+++ b/modules/certificate-watch/module.sh
@@ -125,7 +125,7 @@ _cw_verify_chain() { # _cw_verify_chain <source> <workdir>
 
 _cw_check_certificate() { # _cw_check_certificate <node>
     local node=$1 resolved path source work leaf end_text expiry now state days
-    local issuer subject sans chain_rc
+    local issuer subject sans chain_rc host_check
     if ! resolved=$(_cw_cert_path "$node"); then
         doctor_result fail "node.$(_cw_id "$node").certificate" \
             "active PVE certificate file is missing" "node=$node"
@@ -169,7 +169,12 @@ _cw_check_certificate() { # _cw_check_certificate <node>
                 "certificate expires in $days day(s)" "node=$node expiry_epoch=$expiry UTC" ;;
         esac
     fi
-    if openssl x509 -in "$leaf" -noout -checkhost "$node" >/dev/null 2>&1; then
+    # Some OpenSSL builds return success when -checkhost parsed the certificate
+    # even though its result text says the hostname does not match. Require the
+    # unambiguous positive result rather than trusting that inconsistent status.
+    host_check=$(openssl x509 -in "$leaf" -noout -checkhost "$node" 2>&1 || true)
+    if [[ $host_check == *"does match certificate"* \
+        && $host_check != *"does NOT match certificate"* ]]; then
         doctor_result pass "node.$(_cw_id "$node").hostname" \
             "certificate covers node hostname" "node=$node SAN=$sans"
     else

--- a/modules/certificate-watch/module.sh
+++ b/modules/certificate-watch/module.sh
@@ -1,0 +1,332 @@
+# shellcheck shell=bash
+#
+# Read-only PVE web/API certificate and ACME task health.
+# shellcheck disable=SC2034
+MODULE_NAME="certificate-watch"
+MODULE_TITLE="Certificate watch"
+MODULE_DESC="read-only cluster TLS expiry, hostname, chain, and ACME renewal health"
+MODULE_TAGS="monitoring tls certificate acme notify"
+MODULE_HOST_ONLY=1
+
+CW_CONF_KEYS=(CW_WARN_DAYS CW_FAIL_DAYS CW_ACME_STALE_DAYS)
+CW_JSON=""
+CW_ERROR=""
+
+_cw_defaults() {
+    : "${CW_WARN_DAYS:=30}"
+    : "${CW_FAIL_DAYS:=7}"
+    : "${CW_ACME_STALE_DAYS:=45}"
+}
+
+_cw_validate() {
+    CW_ERROR=""
+    [[ $CW_WARN_DAYS =~ ^[1-9][0-9]*$ && $CW_FAIL_DAYS =~ ^[1-9][0-9]*$ \
+        && $CW_FAIL_DAYS -lt $CW_WARN_DAYS ]] \
+        || { CW_ERROR="expiry thresholds must satisfy 0 < failure < warning days"; return 1; }
+    [[ $CW_ACME_STALE_DAYS =~ ^[1-9][0-9]*$ ]] \
+        || { CW_ERROR="ACME stale age must be a positive number of days"; return 1; }
+}
+
+_cw_load() {
+    _cw_defaults
+    if conf_exists "$MODULE_NAME"; then conf_load "$MODULE_NAME"; fi
+    _cw_validate
+}
+
+_cw_pve_dir() { printf '%s' "${CW_PVE_DIR:-/etc/pve}"; }
+_cw_ca_bundle() { printf '%s' "${CW_CA_BUNDLE:-/etc/ssl/certs/ca-certificates.crt}"; }
+
+_cw_id() {
+    tr '[:upper:]' '[:lower:]' <<<"$1" \
+        | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//'
+}
+
+_cw_array() { # _cw_array <description> <endpoint> [options...]
+    local description=$1 endpoint=$2 output
+    shift 2
+    CW_JSON=""
+    if ! output=$(pvesh get "$endpoint" "$@" --output-format json 2>&1); then
+        doctor_result warn "api.$(_cw_id "$description")" "could not read $description" "$output"
+        return 1
+    fi
+    if ! jq -e 'type == "array"' <<<"$output" >/dev/null 2>&1; then
+        doctor_result warn "api.$(_cw_id "$description")" "$description response was not a JSON array"
+        return 1
+    fi
+    CW_JSON=$output
+}
+
+_cw_object() { # _cw_object <description> <endpoint>
+    local description=$1 endpoint=$2 output
+    CW_JSON=""
+    if ! output=$(pvesh get "$endpoint" --output-format json 2>&1); then
+        doctor_result warn "api.$(_cw_id "$description")" "could not read $description" "$output"
+        return 1
+    fi
+    if ! jq -e 'type == "object"' <<<"$output" >/dev/null 2>&1; then
+        doctor_result warn "api.$(_cw_id "$description")" "$description response was not a JSON object"
+        return 1
+    fi
+    CW_JSON=$output
+}
+
+_cw_cert_path() { # _cw_cert_path <node> -> path and source separated by tab
+    local base node=$1
+    base="$(_cw_pve_dir)/nodes/$node"
+    if [[ -r $base/pveproxy-ssl.pem ]]; then
+        printf '%s\tcustom' "$base/pveproxy-ssl.pem"
+    elif [[ -r $base/pve-ssl.pem ]]; then
+        printf '%s\tinternal' "$base/pve-ssl.pem"
+    else
+        return 1
+    fi
+}
+
+_cw_split_bundle() { # _cw_split_bundle <bundle> <directory>
+    awk -v dir="$2" '
+        /-----BEGIN CERTIFICATE-----/ { n++; file=sprintf("%s/cert.%03d.pem", dir, n) }
+        n > 0 { print > file }
+        END { if (n == 0) exit 1 }
+    ' "$1"
+}
+
+_cw_expiry_state() { # _cw_expiry_state <not-after-epoch> <now>
+    local expiry=$1 now=$2
+    if [[ $expiry -le $now ]]; then
+        printf 'expired'
+    elif [[ $expiry -le $((now + CW_FAIL_DAYS * 86400)) ]]; then
+        printf 'fail'
+    elif [[ $expiry -le $((now + CW_WARN_DAYS * 86400)) ]]; then
+        printf 'warn'
+    else
+        printf 'pass'
+    fi
+}
+
+_cw_verify_chain() { # _cw_verify_chain <source> <workdir>
+    local source=$1 work=$2 ca untrusted=""
+    if find "$work" -maxdepth 1 -name 'cert.*.pem' | grep -q 'cert.002.pem'; then
+        untrusted="$work/intermediates.pem"
+        find "$work" -maxdepth 1 -name 'cert.*.pem' ! -name 'cert.001.pem' -print0 \
+            | sort -z | xargs -0 cat > "$untrusted"
+    fi
+    if [[ $source == internal ]]; then
+        ca="$(_cw_pve_dir)/pve-root-ca.pem"
+    else
+        ca=$(_cw_ca_bundle)
+    fi
+    [[ -r $ca ]] || return 64
+    if [[ -n $untrusted ]]; then
+        openssl verify -CAfile "$ca" -untrusted "$untrusted" "$work/cert.001.pem" >/dev/null 2>&1
+    else
+        openssl verify -CAfile "$ca" "$work/cert.001.pem" >/dev/null 2>&1
+    fi
+}
+
+_cw_check_certificate() { # _cw_check_certificate <node>
+    local node=$1 resolved path source work leaf end_text expiry now state days
+    local issuer subject sans chain_rc
+    if ! resolved=$(_cw_cert_path "$node"); then
+        doctor_result fail "node.$(_cw_id "$node").certificate" \
+            "active PVE certificate file is missing" "node=$node"
+        return 0
+    fi
+    IFS=$'\t' read -r path source <<<"$resolved"
+    work=$(mktemp -d)
+    if ! _cw_split_bundle "$path" "$work"; then
+        rm -rf -- "$work"
+        doctor_result fail "node.$(_cw_id "$node").certificate" \
+            "certificate bundle contains no PEM certificate" "node=$node path=$path"
+        return 0
+    fi
+    leaf="$work/cert.001.pem"
+    if ! end_text=$(openssl x509 -in "$leaf" -noout -enddate 2>/dev/null); then
+        rm -rf -- "$work"
+        doctor_result fail "node.$(_cw_id "$node").certificate" \
+            "active certificate could not be parsed" "node=$node path=$path"
+        return 0
+    fi
+    expiry=$(date -u -d "${end_text#notAfter=}" +%s 2>/dev/null || printf 0)
+    now=${CW_NOW_EPOCH:-$(date -u +%s)}
+    issuer=$(openssl x509 -in "$leaf" -noout -issuer 2>/dev/null | sed 's/^issuer=//')
+    subject=$(openssl x509 -in "$leaf" -noout -subject 2>/dev/null | sed 's/^subject=//')
+    sans=$(openssl x509 -in "$leaf" -noout -ext subjectAltName 2>/dev/null \
+        | tail -n +2 | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//' || true)
+    if [[ $expiry -le 0 ]]; then
+        doctor_result fail "node.$(_cw_id "$node").expiry" \
+            "certificate expiry could not be parsed" "node=$node notAfter=${end_text#notAfter=}"
+    else
+        state=$(_cw_expiry_state "$expiry" "$now")
+        days=$(((expiry - now) / 86400))
+        case $state in
+            expired) doctor_result fail "node.$(_cw_id "$node").expiry" \
+                "certificate expired $((-days)) day(s) ago" "node=$node expiry_epoch=$expiry UTC" ;;
+            fail) doctor_result fail "node.$(_cw_id "$node").expiry" \
+                "certificate expires in $days day(s)" "node=$node expiry_epoch=$expiry UTC fail_at=${CW_FAIL_DAYS}d" ;;
+            warn) doctor_result warn "node.$(_cw_id "$node").expiry" \
+                "certificate expires in $days day(s)" "node=$node expiry_epoch=$expiry UTC warn_at=${CW_WARN_DAYS}d" ;;
+            pass) doctor_result pass "node.$(_cw_id "$node").expiry" \
+                "certificate expires in $days day(s)" "node=$node expiry_epoch=$expiry UTC" ;;
+        esac
+    fi
+    if openssl x509 -in "$leaf" -noout -checkhost "$node" >/dev/null 2>&1; then
+        doctor_result pass "node.$(_cw_id "$node").hostname" \
+            "certificate covers node hostname" "node=$node SAN=$sans"
+    else
+        doctor_result fail "node.$(_cw_id "$node").hostname" \
+            "certificate does not cover node hostname" "node=$node SAN=$sans"
+    fi
+    chain_rc=0
+    _cw_verify_chain "$source" "$work" || chain_rc=$?
+    case $chain_rc in
+        0) doctor_result pass "node.$(_cw_id "$node").chain" \
+            "certificate chain validates" "node=$node source=$source issuer=$issuer subject=$subject" ;;
+        64) doctor_result unsupported "node.$(_cw_id "$node").chain" \
+            "certificate trust anchor is unavailable" "node=$node source=$source" ;;
+        *) doctor_result fail "node.$(_cw_id "$node").chain" \
+            "certificate chain validation failed" "node=$node source=$source issuer=$issuer subject=$subject" ;;
+    esac
+    rm -rf -- "$work"
+}
+
+_cw_acme_configured() { # _cw_acme_configured <node-config-json>
+    jq -e '((.acme // "") | tostring | length) > 0
+        or any(to_entries[]; (.key | startswith("acmedomain")) and ((.value | tostring | length) > 0))' \
+        <<<"$1" >/dev/null
+}
+
+_cw_check_acme() { # _cw_check_acme <node> <node-config-json> <tasks-json-or-empty>
+    local node=$1 config=$2 tasks=$3 stats now cutoff latest_success latest_failure age
+    if ! _cw_acme_configured "$config"; then
+        doctor_result skipped "node.$(_cw_id "$node").acme" "ACME is not configured for node"
+        return 0
+    fi
+    if [[ -z $tasks ]]; then
+        doctor_result warn "node.$(_cw_id "$node").acme" \
+            "ACME task history is unavailable" "node=$node"
+        return 0
+    fi
+    now=${CW_NOW_EPOCH:-$(date -u +%s)}
+    cutoff=$((now - CW_ACME_STALE_DAYS * 86400))
+    stats=$(jq -cn --argjson tasks "$tasks" --arg node "$node" '
+        [ $tasks[] | select(.node == $node and (.type == "acmerenew" or .type == "acmenewcert")) ] as $all
+        | {
+            latest_success: ([ $all[] | select(.status == "OK") | (.endtime // .starttime // 0) ] | max // 0),
+            latest_failure: ([ $all[] | select((.status // "") != "" and .status != "OK")
+                               | (.endtime // .starttime // 0) ] | max // 0)
+          }
+    ')
+    latest_success=$(jq -r '.latest_success' <<<"$stats")
+    latest_failure=$(jq -r '.latest_failure' <<<"$stats")
+    if [[ $latest_failure -gt $latest_success ]]; then
+        doctor_result fail "node.$(_cw_id "$node").acme" \
+            "latest ACME certificate task failed" \
+            "node=$node failure_epoch=$latest_failure last_success_epoch=$latest_success"
+    elif [[ $latest_success -le 0 ]]; then
+        doctor_result warn "node.$(_cw_id "$node").acme" \
+            "ACME is configured but no successful certificate task was found" "node=$node"
+    elif [[ $latest_success -lt $cutoff ]]; then
+        age=$(((now - latest_success) / 86400))
+        doctor_result warn "node.$(_cw_id "$node").acme" \
+            "last successful ACME task is ${age} days old" \
+            "node=$node success_epoch=$latest_success stale_at=${CW_ACME_STALE_DAYS}d"
+    else
+        age=$(((now - latest_success) / 86400))
+        doctor_result pass "node.$(_cw_id "$node").acme" \
+            "last successful ACME task is ${age} days old" "node=$node success_epoch=$latest_success"
+    fi
+}
+
+_cw_audit() {
+    local nodes tasks="" node config
+    if ! command -v pvesh >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1 \
+        || ! command -v openssl >/dev/null 2>&1; then
+        doctor_result unsupported prerequisites "pvesh, jq, and openssl are required"
+        return 0
+    fi
+    if ! _cw_load; then
+        doctor_result fail configuration "certificate watch thresholds are invalid" "$CW_ERROR"
+        return 0
+    fi
+    _cw_array "cluster node inventory" /nodes || return 0
+    nodes=$CW_JSON
+    if _cw_array "ACME task history" /cluster/tasks --limit 200; then tasks=$CW_JSON; fi
+    while IFS= read -r node; do
+        if _cw_object "node $node reachability" "/nodes/$node/status"; then
+            doctor_result pass "node.$(_cw_id "$node").reachability" "node API is reachable"
+        else
+            doctor_result warn "node.$(_cw_id "$node").reachability" \
+                "node API is unreachable; inspecting replicated certificate files" "node=$node"
+        fi
+        _cw_check_certificate "$node"
+        if _cw_object "node $node ACME config" "/nodes/$node/config"; then
+            config=$CW_JSON
+            _cw_check_acme "$node" "$config" "$tasks"
+        else
+            doctor_result warn "node.$(_cw_id "$node").acme" \
+                "ACME configuration could not be inspected" "node=$node"
+        fi
+    done < <(jq -r '.[].node' <<<"$nodes")
+    if command -v pve-toolbox-native-notify >/dev/null 2>&1; then
+        doctor_result pass notification "native notification helper is available for certificate alerts"
+    else
+        doctor_result skipped notification "native notification helper is not installed"
+    fi
+}
+
+module_install() {
+    require_root
+    require_pve
+    _cw_defaults
+    if conf_exists "$MODULE_NAME"; then conf_load "$MODULE_NAME"; fi
+    pkg_ensure jq:jq openssl:openssl
+    ask CW_WARN_DAYS "certificate warning threshold (days)" "$CW_WARN_DAYS"
+    ask CW_FAIL_DAYS "certificate failure threshold (days)" "$CW_FAIL_DAYS"
+    ask CW_ACME_STALE_DAYS "ACME task stale threshold (days)" "$CW_ACME_STALE_DAYS"
+    _cw_validate || die "$CW_ERROR"
+    local key
+    for key in "${CW_CONF_KEYS[@]}"; do conf_set "$MODULE_NAME" "$key" "${!key}"; done
+    state_set "$MODULE_NAME" INSTALLED_AT "$(date -Is)"
+    ok "configured read-only certificate watch"
+}
+
+module_update() {
+    local check_only=0 key missing=()
+    [[ ${1:-} == --check ]] && check_only=1
+    conf_exists "$MODULE_NAME" || die "not installed"
+    _cw_defaults
+    for key in "${CW_CONF_KEYS[@]}"; do
+        [[ -n $(conf_get "$MODULE_NAME" "$key") ]] || missing+=("$key")
+    done
+    if [[ ${#missing[@]} -eq 0 ]]; then ok "certificate watch configuration is up to date"; return 0; fi
+    if [[ $check_only -eq 1 ]]; then warn "update available: missing settings ${missing[*]}"; return 0; fi
+    for key in "${missing[@]}"; do conf_set "$MODULE_NAME" "$key" "${!key}"; done
+    ok "added missing certificate watch settings"
+}
+
+module_status() {
+    conf_exists "$MODULE_NAME" || { printf 'not installed'; return 1; }
+    printf 'configured, read-only'
+}
+
+module_status_long() {
+    module_status || return 1
+    printf '\n'
+    if _cw_load; then
+        printf '  expiry  warn %sd, fail %sd\n' "$CW_WARN_DAYS" "$CW_FAIL_DAYS"
+        printf '  ACME    stale after %sd\n' "$CW_ACME_STALE_DAYS"
+        printf '  renewal never triggered\n'
+    else
+        printf '  configuration invalid\n'
+        return 1
+    fi
+}
+
+module_doctor() { _cw_audit; }
+
+module_uninstall() {
+    require_root
+    conf_clear "$MODULE_NAME"
+    state_clear "$MODULE_NAME"
+    ok "removed certificate watch configuration; no certificate was changed"
+}

--- a/tests/certificate-watch.sh
+++ b/tests/certificate-watch.sh
@@ -35,10 +35,11 @@ openssl x509 -req -in "$WORK/intermediate.csr" -CA "$WORK/root.crt" \
     -CAkey "$WORK/root.key" -CAcreateserial -days 180 \
     -extfile "$WORK/intermediate.ext" -out "$WORK/intermediate.crt" >/dev/null 2>&1
 
-make_leaf() { # make_leaf <node> <san-host> <days> <include-intermediate>
-    local node=$1 san=$2 days=$3 include_intermediate=$4 dir="$WORK/pve/nodes/$1"
+make_leaf() { # make_leaf <node> <san-host> <days> <include-intermediate> [common-name]
+    local node=$1 san=$2 days=$3 include_intermediate=$4 common_name=${5:-$1}
+    local dir="$WORK/pve/nodes/$1"
     mkdir -p "$dir"
-    openssl req -newkey rsa:2048 -nodes -subj "/CN=$node" \
+    openssl req -newkey rsa:2048 -nodes -subj "/CN=$common_name" \
         -keyout "$WORK/$node.key" -out "$WORK/$node.csr" >/dev/null 2>&1
     printf '%s\n' "subjectAltName=DNS:$san" 'extendedKeyUsage=serverAuth' > "$WORK/$node.ext"
     openssl x509 -req -in "$WORK/$node.csr" -CA "$WORK/intermediate.crt" \
@@ -52,7 +53,7 @@ make_leaf() { # make_leaf <node> <san-host> <days> <include-intermediate>
 }
 
 make_leaf pve1 pve1 60 yes
-make_leaf pve2 other.example 60 yes
+make_leaf pve2 other.example 60 yes other.example
 make_leaf pve3 pve3 60 no
 make_leaf pve4 pve4 1 yes
 CW_CA_BUNDLE="$WORK/root.crt"

--- a/tests/certificate-watch.sh
+++ b/tests/certificate-watch.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Generated certificate and cluster fixtures for the read-only certificate audit.
+set -euo pipefail
+
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
+ROOT=$PWD
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/conf" "$WORK/state" "$WORK/pve/nodes"
+
+pass() { printf 'ok  %s\n' "$1"; }
+fail() { printf 'FAIL %s\n' "$1" >&2; exit 1; }
+
+TOOLBOX_CONF_DIR="$WORK/conf"
+TOOLBOX_STATE_DIR="$WORK/state"
+CW_PVE_DIR="$WORK/pve"
+export TOOLBOX_CONF_DIR TOOLBOX_STATE_DIR CW_PVE_DIR
+
+# shellcheck source=lib/common.sh
+source "$ROOT/lib/common.sh"
+# shellcheck source=lib/report.sh
+source "$ROOT/lib/report.sh"
+# shellcheck source=lib/doctor.sh
+source "$ROOT/lib/doctor.sh"
+# shellcheck source=modules/certificate-watch/module.sh
+source "$ROOT/modules/certificate-watch/module.sh"
+
+openssl req -x509 -newkey rsa:2048 -nodes -days 365 -subj /CN=Test-Root \
+    -keyout "$WORK/root.key" -out "$WORK/root.crt" >/dev/null 2>&1
+openssl req -newkey rsa:2048 -nodes -subj /CN=Test-Intermediate \
+    -keyout "$WORK/intermediate.key" -out "$WORK/intermediate.csr" >/dev/null 2>&1
+printf '%s\n' 'basicConstraints=critical,CA:TRUE' \
+    'keyUsage=critical,keyCertSign,cRLSign' > "$WORK/intermediate.ext"
+openssl x509 -req -in "$WORK/intermediate.csr" -CA "$WORK/root.crt" \
+    -CAkey "$WORK/root.key" -CAcreateserial -days 180 \
+    -extfile "$WORK/intermediate.ext" -out "$WORK/intermediate.crt" >/dev/null 2>&1
+
+make_leaf() { # make_leaf <node> <san-host> <days> <include-intermediate>
+    local node=$1 san=$2 days=$3 include_intermediate=$4 dir="$WORK/pve/nodes/$1"
+    mkdir -p "$dir"
+    openssl req -newkey rsa:2048 -nodes -subj "/CN=$node" \
+        -keyout "$WORK/$node.key" -out "$WORK/$node.csr" >/dev/null 2>&1
+    printf '%s\n' "subjectAltName=DNS:$san" 'extendedKeyUsage=serverAuth' > "$WORK/$node.ext"
+    openssl x509 -req -in "$WORK/$node.csr" -CA "$WORK/intermediate.crt" \
+        -CAkey "$WORK/intermediate.key" -CAcreateserial -days "$days" \
+        -extfile "$WORK/$node.ext" -out "$WORK/$node.crt" >/dev/null 2>&1
+    if [[ $include_intermediate == yes ]]; then
+        awk '1' "$WORK/$node.crt" "$WORK/intermediate.crt" > "$dir/pveproxy-ssl.pem"
+    else
+        cp -- "$WORK/$node.crt" "$dir/pveproxy-ssl.pem"
+    fi
+}
+
+make_leaf pve1 pve1 60 yes
+make_leaf pve2 other.example 60 yes
+make_leaf pve3 pve3 60 no
+make_leaf pve4 pve4 1 yes
+CW_CA_BUNDLE="$WORK/root.crt"
+CW_NOW_EPOCH=$(( $(date -u -d "$(openssl x509 -in "$WORK/pve4.crt" -noout -enddate | cut -d= -f2-)" +%s) + 1 ))
+export CW_CA_BUNDLE CW_NOW_EPOCH
+
+pvesh() {
+    [[ ${1:-} == get ]] || fail "certificate audit attempted a mutating PVE call: $*"
+    case ${2:-} in
+        /nodes) printf '%s\n' '[{"node":"pve1"},{"node":"pve2"},{"node":"pve3"},{"node":"pve4"}]' ;;
+        /cluster/tasks)
+            jq -n --argjson now "$CW_NOW_EPOCH" '[
+              {node:"pve1",type:"acmerenew",status:"OK",endtime:($now-86400)},
+              {node:"pve3",type:"acmenewcert",status:"OK",endtime:($now-172800)},
+              {node:"pve3",type:"acmerenew",status:"certificate order failed",endtime:($now-3600)}
+            ]' ;;
+        /nodes/pve2/status) return 1 ;;
+        /nodes/*/status) printf '%s\n' '{"status":"online"}' ;;
+        /nodes/pve1/config|/nodes/pve3/config) printf '%s\n' '{"acme":"account=default","acmedomain0":"domain=example.test"}' ;;
+        /nodes/pve2/config|/nodes/pve4/config) printf '%s\n' '{}' ;;
+        *) fail "unexpected PVE fixture endpoint: ${2:-}" ;;
+    esac
+}
+
+result_state() {
+    local wanted=$1 i
+    for ((i = 0; i < ${#REPORT_IDS[@]}; i++)); do
+        [[ ${REPORT_IDS[$i]} == "$wanted" ]] && { printf '%s' "${REPORT_STATES[$i]}"; return 0; }
+    done
+    return 1
+}
+
+conf_set certificate-watch CW_WARN_DAYS 30
+conf_set certificate-watch CW_FAIL_DAYS 7
+conf_set certificate-watch CW_ACME_STALE_DAYS 45
+doctor_reset
+module_doctor
+[[ $(report_exit_code) == 1 ]] || fail "critical certificate fixture did not fail"
+[[ $(result_state node.pve1.expiry) == pass ]] || fail "valid certificate expiry failed"
+[[ $(result_state node.pve1.hostname) == pass ]] || fail "valid hostname failed"
+[[ $(result_state node.pve1.chain) == pass ]] || fail "complete chain failed"
+[[ $(result_state node.pve1.acme) == pass ]] || fail "recent ACME success failed"
+[[ $(result_state node.pve2.reachability) == warn ]] || fail "unreachable node was not warned"
+[[ $(result_state node.pve2.hostname) == fail ]] || fail "hostname mismatch was not failed"
+[[ $(result_state node.pve3.chain) == fail ]] || fail "incomplete chain was not failed"
+[[ $(result_state node.pve3.acme) == fail ]] || fail "latest failed ACME task was not failed"
+[[ $(result_state node.pve4.expiry) == fail ]] || fail "expired generated certificate was not failed"
+pass "valid, expired, mismatched, incomplete-chain, and unreachable fixtures"
+
+CW_FAIL_DAYS=7 CW_WARN_DAYS=30
+now=1000000
+[[ $(_cw_expiry_state "$now" "$now") == expired ]] || fail "expiry instant boundary"
+[[ $(_cw_expiry_state $((now + 7 * 86400)) "$now") == fail ]] || fail "failure boundary"
+[[ $(_cw_expiry_state $((now + 30 * 86400)) "$now") == warn ]] || fail "warning boundary"
+[[ $(_cw_expiry_state $((now + 30 * 86400 + 1)) "$now") == pass ]] || fail "healthy boundary"
+pass "UTC expiry boundaries are inclusive and predictable"
+
+CW_FAIL_DAYS=30 CW_WARN_DAYS=7 CW_ACME_STALE_DAYS=45
+_cw_validate && fail "reversed expiry thresholds were accepted"
+CW_FAIL_DAYS=7 CW_WARN_DAYS=30 CW_ACME_STALE_DAYS=0
+_cw_validate && fail "zero ACME stale threshold was accepted"
+pass "certificate thresholds fail closed"

--- a/tests/package.sh
+++ b/tests/package.sh
@@ -48,6 +48,7 @@ for path in \
     ./usr/lib/pve-toolbox/modules/native-notifications/module.sh \
     ./usr/lib/pve-toolbox/modules/native-notifications/pve-toolbox-native-notify \
     ./usr/lib/pve-toolbox/modules/storage-hygiene/module.sh \
+    ./usr/lib/pve-toolbox/modules/certificate-watch/module.sh \
     ./usr/share/man/man1/pve-toolbox.1.gz \
     ./usr/share/bash-completion/completions/pve-toolbox \
     ./usr/share/zsh/vendor-completions/_pve-toolbox


### PR DESCRIPTION
## What

Adds read-only cluster certificate expiry, hostname, chain, reachability, and native ACME task checks.

## Why

Reports TLS and renewal risks before certificates become operational failures. Closes #23.

## Testing

Added generated valid, expired, mismatched, incomplete-chain, unreachable-node, ACME, and UTC-boundary fixtures.

make lint

TUI_TEST_REQUIRED=1 ZSH_TEST_REQUIRED=1 CB_GATE_TESTS_REQUIRED=1 PACKAGING_TEST_REQUIRED=1 PACKAGING_INSTALL_TEST_REQUIRED=1 REPOSITORY_TEST_REQUIRED=1 make test

mkdocs build --strict

## Notes

The module never orders, renews, installs, or replaces certificates.