### PR TITLE
feat(upgrade-readiness): audit nodes before upgrades

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ test: syntax
 	@./tests/native-notifications.sh
 	@./tests/storage-hygiene.sh
 	@./tests/certificate-watch.sh
+	@./tests/upgrade-readiness.sh
 	@./tests/discord.sh
 	@./tests/config-backup.sh
 	@./tests/hardening.sh

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ pve-toolbox/
 │   ├── native-notifications/ # owned native PVE targets, matchers, and shared sender
 │   ├── scrutiny-collectors/ # SMART/ZFS/MDADM collectors for a remote Scrutiny
 │   ├── storage-hygiene/     # read-only snapshot, content, and capacity audit
+│   ├── upgrade-readiness/   # read-only, policy-driven upgrade preflight
 │   ├── zfs-scrub/           # scheduled scrub per pool, reported to Discord
 │   └── zfs-replication/     # syncoid jobs on a timer, reported to Discord
 ├── completions/             # bash + zsh completion, installed by `link`
@@ -104,6 +105,7 @@ without regenerating anything. See
 | [config-backup](https://quwisky.github.io/pve-toolbox/modules/config-backup/) | Snapshots `/etc/pve` and host config into verified tar.gz archives on a timer |
 | [native-notifications](https://quwisky.github.io/pve-toolbox/modules/native-notifications/) | Provisions owned PVE notification targets and matchers with protected credentials and rollback |
 | [storage-hygiene](https://quwisky.github.io/pve-toolbox/modules/storage-hygiene/) | Audits old snapshots, unreferenced-looking storage, stale content, and capacity pressure without cleanup |
+| [upgrade-readiness](https://quwisky.github.io/pve-toolbox/modules/upgrade-readiness/) | Reports repository, package, space, cluster, service, storage, and backup blockers before upgrades |
 | [zfs-scrub](https://quwisky.github.io/pve-toolbox/modules/zfs-scrub/) | Scrubs each pool on its own timer, reports start and result to Discord |
 | [zfs-replication](https://quwisky.github.io/pve-toolbox/modules/zfs-replication/) | Runs `syncoid` jobs on timers, reports duration and size to Discord |
 | [scrutiny-collectors](https://quwisky.github.io/pve-toolbox/modules/scrutiny-collectors/) | SMART / ZFS / MDADM collectors feeding a remote Scrutiny instance |

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,8 @@
 pve-toolbox (0.4.0) unstable; urgency=medium
 
+  * Add a read-only, policy-driven PVE 9 upgrade readiness preflight.
+  * Report repository, package, reboot, space, cluster, storage, service, and
+    recent-backup blockers with remediation context.
   * Add read-only cluster certificate expiry, hostname, and chain checks.
   * Report node reachability and failed or stale native ACME tasks.
   * Add read-only storage hygiene checks for snapshots, content, definitions,

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -38,6 +38,9 @@ volume ownership evidence, stale content, and backend pressure checks.
 The [certificate-watch module](modules/certificate-watch.md) checks every
 cluster node's active TLS certificate, trust chain, hostname coverage,
 reachability, and native ACME task history.
+The [upgrade-readiness module](modules/upgrade-readiness.md) applies a
+release-specific preflight policy to repositories, packages, filesystems,
+cluster nodes, services, storage, and recent backups.
 
 ## Result states and exit status
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ pve-toolbox/
 │   ├── native-notifications/
 │   ├── scrutiny-collectors/
 │   ├── storage-hygiene/
+│   ├── upgrade-readiness/
 │   ├── zfs-scrub/
 │   └── zfs-replication/
 ├── completions/             # bash + zsh, installed by `link`
@@ -40,6 +41,7 @@ pve-toolbox/
 | [config-backup](modules/config-backup.md) | Timestamped snapshots of `/etc/pve` and host config, reported to Discord |
 | [native-notifications](modules/native-notifications.md) | Owned native PVE targets and matchers with protected secrets and tested delivery |
 | [storage-hygiene](modules/storage-hygiene.md) | Read-only snapshots, content ownership, storage definitions, and capacity audit |
+| [upgrade-readiness](modules/upgrade-readiness.md) | Policy-driven, read-only PVE upgrade blocker and risk preflight |
 | [zfs-scrub](modules/zfs-scrub.md) | Scrubs each pool on its own timer, reports start and result to Discord |
 | [zfs-replication](modules/zfs-replication.md) | Runs `syncoid` jobs on timers, reports duration and size to Discord |
 | [scrutiny-collectors](modules/scrutiny-collectors.md) | SMART / ZFS / MDADM collectors feeding a remote Scrutiny instance |

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -10,6 +10,7 @@ launcher discovers them at runtime; directories starting with `_` are skipped.
 | [config-backup](config-backup.md) | `backup config notify` | yes | `pve-config-backup` |
 | [native-notifications](native-notifications.md) | `monitoring notify webhook smtp gotify` | yes | `pve-toolbox-native-notify` |
 | [storage-hygiene](storage-hygiene.md) | `storage audit monitoring zfs lvm` | yes | none; contributes doctor checks |
+| [upgrade-readiness](upgrade-readiness.md) | `upgrade audit monitoring backup apt` | yes | none; contributes doctor checks |
 | [zfs-scrub](zfs-scrub.md) | `storage zfs monitoring notify` | yes | `pve-toolbox-zfs-scrub` |
 | [zfs-replication](zfs-replication.md) | `storage zfs backup replication notify` | yes | `pve-toolbox-zfs-sync` |
 | [scrutiny-collectors](scrutiny-collectors.md) | `storage monitoring smart zfs` | yes | four collector binaries |

--- a/docs/modules/upgrade-readiness.md
+++ b/docs/modules/upgrade-readiness.md
@@ -1,0 +1,63 @@
+# upgrade-readiness
+
+`upgrade-readiness` is a read-only preflight for routine Proxmox VE upgrades.
+The first shipped policy targets PVE 9 on Debian 13 (`trixie`). It reports
+blockers and operator-review risks; it does not edit repositories, install or
+remove packages, reboot nodes, or start backups.
+
+```bash
+pve-toolbox install upgrade-readiness
+pve-toolbox doctor
+```
+
+## Checks
+
+The module checks:
+
+- official Debian and Proxmox repository suites;
+- unknown third-party repositories, which always produce a warning for human
+  compatibility review;
+- held packages and a pending-reboot marker;
+- free space on the policy's critical filesystems;
+- every cluster node's reachability and PVE major version;
+- failed services and inactive enabled storage on reachable nodes;
+- successful guest backups against an explicit freshness policy.
+
+Failures contribute the standard doctor exit status `1`, so a failed preflight
+cannot appear healthy to automation. Warnings produce status `2` when no check
+fails.
+
+```ini title="/etc/pve-toolbox/upgrade-readiness.conf"
+UR_POLICY=pve-9
+UR_BACKUP_HOURS=48
+UR_MIN_FREE_MB=2048
+```
+
+The backup age is deliberately operator-controlled. Set it to the recovery
+policy your environment actually requires; the default is 48 hours. The
+preflight can coexist with `backup-audit`, but it independently verifies this
+upgrade prerequisite so an uninstalled module cannot silently skip it.
+
+## Release policies
+
+Release-specific facts live under `modules/upgrade-readiness/policies/`.
+The `pve-9` policy declares the expected major, supported suite, known official
+repository hosts, and critical filesystems. A missing, mismatched, symlinked,
+or malformed policy fails closed.
+
+## Before upgrading
+
+Resolve every failure and review every warning, then rerun doctor until the
+result matches your maintenance policy. Keep the JSON report with the change
+record when useful:
+
+```bash
+pve-toolbox doctor --json >preflight.json
+```
+
+!!! warning
+
+    This report complements, but does not replace, the official Proxmox
+    release notes and upgrade guidance. Read those documents in full for the
+    exact versions and upgrade path you are using. Repository recognition also
+    does not prove subscription status or third-party compatibility.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
       - config-backup: modules/config-backup.md
       - native-notifications: modules/native-notifications.md
       - storage-hygiene: modules/storage-hygiene.md
+      - upgrade-readiness: modules/upgrade-readiness.md
       - zfs-scrub: modules/zfs-scrub.md
       - zfs-replication: modules/zfs-replication.md
       - scrutiny-collectors: modules/scrutiny-collectors.md

--- a/modules/upgrade-readiness/module.sh
+++ b/modules/upgrade-readiness/module.sh
@@ -1,0 +1,269 @@
+# shellcheck shell=bash
+# Read-only, policy-driven preflight for routine PVE upgrades.
+# shellcheck disable=SC2034
+MODULE_NAME="upgrade-readiness"
+MODULE_TITLE="Upgrade readiness"
+MODULE_DESC="read-only PVE upgrade blocker and risk preflight"
+MODULE_TAGS="upgrade audit monitoring backup apt"
+MODULE_HOST_ONLY=1
+
+UR_CONF_KEYS=(UR_POLICY UR_BACKUP_HOURS UR_MIN_FREE_MB)
+UR_JSON=""
+UR_ERROR=""
+
+_ur_defaults() {
+    : "${UR_POLICY:=pve-9}"
+    : "${UR_BACKUP_HOURS:=48}"
+    : "${UR_MIN_FREE_MB:=2048}"
+}
+
+_ur_module_dir() { cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P; }
+_ur_policy_path() { printf '%s/policies/%s.conf' "$(_ur_module_dir)" "$UR_POLICY"; }
+
+_ur_load() {
+    local policy
+    _ur_defaults
+    if conf_exists "$MODULE_NAME"; then conf_load "$MODULE_NAME"; fi
+    UR_ERROR=""
+    [[ $UR_POLICY =~ ^[a-z0-9][a-z0-9.-]*$ ]] \
+        || { UR_ERROR="policy name contains unsupported characters"; return 1; }
+    [[ $UR_BACKUP_HOURS =~ ^[1-9][0-9]*$ && $UR_MIN_FREE_MB =~ ^[1-9][0-9]*$ ]] \
+        || { UR_ERROR="backup age and free-space threshold must be positive integers"; return 1; }
+    policy=$(_ur_policy_path)
+    [[ -r $policy && ! -L $policy ]] \
+        || { UR_ERROR="release policy is missing or unsafe: $UR_POLICY"; return 1; }
+    # Policy files ship with the module and contain only declarative values.
+    # shellcheck disable=SC1090
+    source "$policy"
+    [[ ${UR_POLICY_ID:-} == "$UR_POLICY" && ${UR_EXPECTED_PVE_MAJOR:-} =~ ^[0-9]+$ \
+        && -n ${UR_SUPPORTED_SUITES:-} && -n ${UR_OFFICIAL_REPO_HOSTS:-} \
+        && -n ${UR_CRITICAL_PATHS:-} ]] \
+        || { UR_ERROR="release policy is incomplete or mismatched"; return 1; }
+}
+
+_ur_id() { tr '[:upper:]' '[:lower:]' <<<"$1" | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//'; }
+
+_ur_array() {
+    local description=$1 endpoint=$2 output
+    shift 2
+    UR_JSON=""
+    if ! output=$(pvesh get "$endpoint" "$@" --output-format json 2>&1); then
+        doctor_result fail "api.$(_ur_id "$description")" "could not read $description" "$output"
+        return 1
+    fi
+    jq -e 'type == "array"' <<<"$output" >/dev/null 2>&1 \
+        || { doctor_result fail "api.$(_ur_id "$description")" "$description was not a JSON array"; return 1; }
+    UR_JSON=$output
+}
+
+_ur_object() {
+    local description=$1 endpoint=$2 output
+    UR_JSON=""
+    if ! output=$(pvesh get "$endpoint" --output-format json 2>&1); then
+        doctor_result fail "api.$(_ur_id "$description")" "could not read $description" "$output"
+        return 1
+    fi
+    jq -e 'type == "object"' <<<"$output" >/dev/null 2>&1 \
+        || { doctor_result fail "api.$(_ur_id "$description")" "$description was not a JSON object"; return 1; }
+    UR_JSON=$output
+}
+
+_ur_suite_supported() { [[ " $UR_SUPPORTED_SUITES " == *" $1 "* ]]; }
+_ur_host_official() { [[ " $UR_OFFICIAL_REPO_HOSTS " == *" $1 "* ]]; }
+
+_ur_repo_rows() {
+    local root=${UR_APT_DIR:-/etc/apt} file line uri suite host
+    while IFS= read -r -d '' file; do
+        while IFS= read -r line; do
+            line=${line%%#*}
+            [[ $line =~ ^[[:space:]]*deb(-src)?[[:space:]]+(\[[^]]+\][[:space:]]+)?([^[:space:]]+)[[:space:]]+([^[:space:]]+) ]] || continue
+            uri=${BASH_REMATCH[3]}; suite=${BASH_REMATCH[4]}
+            host=${uri#*://}; host=${host%%/*}
+            printf '%s\t%s\t%s\n' "$file" "$host" "$suite"
+        done < "$file"
+    done < <(find "$root" -type f -name '*.list' -print0 2>/dev/null)
+    while IFS= read -r -d '' file; do
+        uri=""; suite=""
+        while IFS= read -r line || [[ -n $line ]]; do
+            case $line in
+                URIs:*) uri=${line#URIs:}; uri=${uri## } ;;
+                Suites:*) suite=${line#Suites:}; suite=${suite## } ;;
+                '')
+                    if [[ -n $uri && -n $suite ]]; then
+                        host=${uri%% *}; host=${host#*://}; host=${host%%/*}
+                        printf '%s\t%s\t%s\n' "$file" "$host" "${suite%% *}"
+                    fi
+                    uri=""; suite="" ;;
+            esac
+        done < <(awk '1; END { print "" }' "$file")
+    done < <(find "$root" -type f -name '*.sources' -print0 2>/dev/null)
+}
+
+_ur_check_repositories() {
+    local rows row file host suite count=0
+    rows=$(_ur_repo_rows)
+    while IFS=$'\t' read -r file host suite; do
+        [[ -n $host ]] || continue
+        count=$((count + 1))
+        if _ur_host_official "$host"; then
+            if _ur_suite_supported "$suite"; then
+                doctor_result pass "repository.$count" "official repository uses a supported suite" "$host $suite"
+            else
+                doctor_result fail "repository.$count" "official repository uses an unsupported suite" \
+                    "$host suite=$suite; migrate it to: $UR_SUPPORTED_SUITES"
+            fi
+        else
+            doctor_result warn "repository.$count" "unknown third-party repository needs operator review" \
+                "$host suite=$suite file=$file; confirm vendor support before upgrading"
+        fi
+    done <<<"$rows"
+    [[ $count -gt 0 ]] || doctor_result fail repositories "no enabled APT repositories were found"
+}
+
+_ur_check_holds() {
+    local holds
+    if ! holds=$(dpkg --get-selections 2>/dev/null | awk '$2 == "hold" { print $1 }'); then
+        doctor_result fail packages.holds "could not inspect held packages"
+    elif [[ -n $holds ]]; then
+        doctor_result fail packages.holds "held packages can block the upgrade" "$holds; review with apt-mark showhold"
+    else
+        doctor_result pass packages.holds "no held packages"
+    fi
+}
+
+_ur_check_reboot() {
+    if [[ -e ${UR_REBOOT_FILE:-/var/run/reboot-required} ]]; then
+        doctor_result fail reboot.pending "a reboot is pending" "reboot before starting the upgrade"
+    else
+        doctor_result pass reboot.pending "no pending reboot marker"
+    fi
+}
+
+_ur_check_space() {
+    local path row available id
+    for path in $UR_CRITICAL_PATHS; do
+        if ! row=$(df -Pm -- "$path" 2>/dev/null | awk 'NR == 2 { print $4 }'); then row=""; fi
+        id=$(_ur_id "$path"); [[ -n $id ]] || id=root
+        if [[ ! $row =~ ^[0-9]+$ ]]; then
+            doctor_result fail "space.$id" "could not determine free space" "$path"
+        else
+            available=$row
+            if [[ $available -lt $UR_MIN_FREE_MB ]]; then
+                doctor_result fail "space.$id" "critical filesystem has insufficient free space" \
+                    "$path free=${available}MiB required=${UR_MIN_FREE_MB}MiB"
+            else
+                doctor_result pass "space.$id" "critical filesystem has upgrade headroom" \
+                    "$path free=${available}MiB"
+            fi
+        fi
+    done
+}
+
+_ur_check_nodes() {
+    local nodes=$1 node version versions="" services storage stopped inactive
+    local -A seen_versions=()
+    while IFS= read -r node; do
+        if _ur_object "node $node status" "/nodes/$node/status"; then
+            doctor_result pass "node.$(_ur_id "$node").reachability" "node API is reachable"
+        else
+            doctor_result fail "node.$(_ur_id "$node").reachability" "node is unavailable; do not upgrade the cluster"
+            continue
+        fi
+        if _ur_object "node $node version" "/nodes/$node/version"; then
+            version=$(jq -r '.version // .release // "unknown"' <<<"$UR_JSON")
+            versions+="$node=$version "
+            seen_versions["$version"]=1
+            if [[ $version == "$UR_EXPECTED_PVE_MAJOR".* ]]; then
+                doctor_result pass "node.$(_ur_id "$node").version" "node runs the policy PVE major" "$version"
+            else
+                doctor_result fail "node.$(_ur_id "$node").version" "node version is outside the PVE policy" \
+                    "found=$version expected=$UR_EXPECTED_PVE_MAJOR.x"
+            fi
+        fi
+        if _ur_array "node $node failed services" "/nodes/$node/services" --state stopped; then
+            services=$UR_JSON
+            stopped=$(jq -r '[.[] | select(.state == "failed" or .status == "failed") | .name] | join(",")' <<<"$services")
+            [[ -z $stopped ]] && doctor_result pass "node.$(_ur_id "$node").services" "no failed services" \
+                || doctor_result fail "node.$(_ur_id "$node").services" "node has failed services" "$stopped"
+        fi
+        if _ur_array "node $node storage" "/nodes/$node/storage"; then
+            storage=$UR_JSON
+            inactive=$(jq -r '[.[] | select((.enabled // 1) == 1 and (.active // 0) != 1) | .storage] | join(",")' <<<"$storage")
+            [[ -z $inactive ]] && doctor_result pass "node.$(_ur_id "$node").storage" "enabled storage is active" \
+                || doctor_result fail "node.$(_ur_id "$node").storage" "enabled storage is inactive" "$inactive"
+        fi
+    done < <(jq -r '.[].node' <<<"$nodes")
+    if [[ ${#seen_versions[@]} -gt 1 ]]; then
+        doctor_result warn cluster.versions "cluster nodes have version skew" \
+            "$versions; align patch versions before upgrading when practical"
+    elif [[ -n $versions ]]; then
+        doctor_result pass cluster.versions "reachable cluster nodes run the same version" "$versions"
+    fi
+}
+
+_ur_check_backups() {
+    local guests tasks now cutoff guest vmid last age
+    _ur_array "cluster guest inventory" /cluster/resources --type vm || return 0
+    guests=$UR_JSON
+    _ur_array "cluster backup task history" /cluster/tasks --typefilter vzdump --limit 500 || return 0
+    tasks=$UR_JSON
+    now=${UR_NOW_EPOCH:-$(date +%s)}; cutoff=$((now - UR_BACKUP_HOURS * 3600))
+    while IFS= read -r guest; do
+        vmid=$(jq -r '.vmid | tostring' <<<"$guest")
+        last=$(jq -r --arg id "$vmid" '[.[] | select(.type == "vzdump" and .status == "OK"
+          and ((.id // .vmid // "") | tostring) == $id) | (.endtime // .starttime // 0)] | max // 0' <<<"$tasks")
+        if [[ $last -lt $cutoff ]]; then
+            doctor_result fail "backup.$vmid" "guest lacks a sufficiently recent successful backup" \
+                "policy=${UR_BACKUP_HOURS}h; run or verify a backup before upgrading"
+        else
+            age=$(((now - last) / 3600))
+            doctor_result pass "backup.$vmid" "guest has a recent successful backup" "age=${age}h"
+        fi
+    done < <(jq -c '.[] | select(.type == "qemu" or .type == "lxc") | select((.template // 0) != 1)' <<<"$guests")
+}
+
+_ur_audit() {
+    local nodes
+    for command in pvesh jq dpkg df; do
+        command -v "$command" >/dev/null 2>&1 \
+            || { doctor_result unsupported prerequisites "$command is required"; return 0; }
+    done
+    _ur_load || { doctor_result fail configuration "upgrade policy is invalid" "$UR_ERROR"; return 0; }
+    doctor_result pass policy "loaded release-specific upgrade policy" "$UR_POLICY"
+    _ur_check_repositories
+    _ur_check_holds
+    _ur_check_reboot
+    _ur_check_space
+    _ur_array "cluster node inventory" /nodes || return 0
+    nodes=$UR_JSON
+    _ur_check_nodes "$nodes"
+    _ur_check_backups
+}
+
+module_install() {
+    require_root; require_pve; _ur_defaults
+    if conf_exists "$MODULE_NAME"; then conf_load "$MODULE_NAME"; fi
+    pkg_ensure jq:jq
+    ask UR_POLICY "upgrade policy" "$UR_POLICY"
+    ask UR_BACKUP_HOURS "maximum backup age (hours)" "$UR_BACKUP_HOURS"
+    ask UR_MIN_FREE_MB "minimum free space (MiB)" "$UR_MIN_FREE_MB"
+    _ur_load || die "$UR_ERROR"
+    local key; for key in "${UR_CONF_KEYS[@]}"; do conf_set "$MODULE_NAME" "$key" "${!key}"; done
+    state_set "$MODULE_NAME" INSTALLED_AT "$(date -Is)"
+    ok "configured read-only $UR_POLICY upgrade preflight"
+}
+
+module_update() {
+    local check_only=0 key missing=(); [[ ${1:-} == --check ]] && check_only=1
+    conf_exists "$MODULE_NAME" || die "not installed"; _ur_defaults
+    for key in "${UR_CONF_KEYS[@]}"; do [[ -n $(conf_get "$MODULE_NAME" "$key") ]] || missing+=("$key"); done
+    [[ ${#missing[@]} -gt 0 ]] || { ok "upgrade readiness configuration is up to date"; return 0; }
+    [[ $check_only -eq 0 ]] || { warn "update available: missing settings ${missing[*]}"; return 0; }
+    for key in "${missing[@]}"; do conf_set "$MODULE_NAME" "$key" "${!key}"; done
+    ok "added missing upgrade readiness settings"
+}
+
+module_status() { conf_exists "$MODULE_NAME" || { printf 'not installed'; return 1; }; printf 'configured, read-only'; }
+module_status_long() { module_status || return 1; printf '\n'; _ur_load && printf '  policy %s; backups %sh; free space %sMiB\n' "$UR_POLICY" "$UR_BACKUP_HOURS" "$UR_MIN_FREE_MB"; }
+module_doctor() { _ur_audit; }
+module_uninstall() { require_root; conf_clear "$MODULE_NAME"; state_clear "$MODULE_NAME"; ok "removed upgrade readiness configuration; no host setting was changed"; }

--- a/modules/upgrade-readiness/policies/pve-9.conf
+++ b/modules/upgrade-readiness/policies/pve-9.conf
@@ -1,0 +1,6 @@
+# Release-specific policy for routine Proxmox VE 9 upgrades on Debian 13.
+UR_POLICY_ID=pve-9
+UR_EXPECTED_PVE_MAJOR=9
+UR_SUPPORTED_SUITES=trixie
+UR_OFFICIAL_REPO_HOSTS='download.proxmox.com enterprise.proxmox.com deb.debian.org security.debian.org ftp.debian.org'
+UR_CRITICAL_PATHS='/ /boot /var/lib/vz'

--- a/tests/package.sh
+++ b/tests/package.sh
@@ -49,6 +49,8 @@ for path in \
     ./usr/lib/pve-toolbox/modules/native-notifications/pve-toolbox-native-notify \
     ./usr/lib/pve-toolbox/modules/storage-hygiene/module.sh \
     ./usr/lib/pve-toolbox/modules/certificate-watch/module.sh \
+    ./usr/lib/pve-toolbox/modules/upgrade-readiness/module.sh \
+    ./usr/lib/pve-toolbox/modules/upgrade-readiness/policies/pve-9.conf \
     ./usr/share/man/man1/pve-toolbox.1.gz \
     ./usr/share/bash-completion/completions/pve-toolbox \
     ./usr/share/zsh/vendor-completions/_pve-toolbox

--- a/tests/upgrade-readiness.sh
+++ b/tests/upgrade-readiness.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Mixed-cluster fixtures for the read-only upgrade preflight.
+set -euo pipefail
+
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
+ROOT=$PWD
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/conf" "$WORK/state" "$WORK/apt/sources.list.d"
+printf '%s\n' \
+    'deb http://download.proxmox.com/debian/pve bookworm pve-no-subscription' \
+    'deb https://packages.example.test/tool trixie main' > "$WORK/apt/sources.list"
+: > "$WORK/reboot-required"
+
+TOOLBOX_CONF_DIR="$WORK/conf"
+TOOLBOX_STATE_DIR="$WORK/state"
+UR_APT_DIR="$WORK/apt"
+UR_REBOOT_FILE="$WORK/reboot-required"
+UR_NOW_EPOCH=2000000000
+export TOOLBOX_CONF_DIR TOOLBOX_STATE_DIR UR_APT_DIR UR_REBOOT_FILE UR_NOW_EPOCH
+
+pass() { printf 'ok  %s\n' "$1"; }
+fail() { printf 'FAIL %s\n' "$1" >&2; exit 1; }
+
+# shellcheck source=lib/common.sh
+source "$ROOT/lib/common.sh"
+# shellcheck source=lib/report.sh
+source "$ROOT/lib/report.sh"
+# shellcheck source=lib/doctor.sh
+source "$ROOT/lib/doctor.sh"
+# shellcheck source=modules/upgrade-readiness/module.sh
+source "$ROOT/modules/upgrade-readiness/module.sh"
+
+dpkg() {
+    [[ $* == '--get-selections' ]] || fail "unexpected dpkg invocation: $*"
+    printf '%s\n' $'pve-manager\tinstall' $'linux-image-amd64\thold'
+}
+
+df() {
+    [[ ${1:-} == -Pm && ${2:-} == -- ]] || fail "unexpected df invocation: $*"
+    if [[ ${3:-} == / ]]; then
+        printf '%s\n' 'Filesystem 1048576-blocks Used Available Capacity Mounted on' '/dev/root 10000 9000 1000 90% /'
+    else
+        printf '%s\n' 'Filesystem 1048576-blocks Used Available Capacity Mounted on' "/dev/test 10000 6000 4000 60% ${3:-}"
+    fi
+}
+
+pvesh() {
+    [[ ${1:-} == get ]] || fail "upgrade preflight attempted a mutating PVE call: $*"
+    case ${2:-} in
+        /nodes) printf '%s\n' '[{"node":"pve1"},{"node":"pve2"},{"node":"pve3"}]' ;;
+        /nodes/pve3/status) return 1 ;;
+        /nodes/*/status) printf '%s\n' '{"status":"online"}' ;;
+        /nodes/pve1/version) printf '%s\n' '{"version":"9.0.3"}' ;;
+        /nodes/pve2/version) printf '%s\n' '{"version":"8.4.8"}' ;;
+        /nodes/pve1/services) printf '%s\n' '[{"name":"pveproxy.service","state":"failed"}]' ;;
+        /nodes/pve2/services) printf '%s\n' '[]' ;;
+        /nodes/pve1/storage) printf '%s\n' '[{"storage":"local","enabled":1,"active":0}]' ;;
+        /nodes/pve2/storage) printf '%s\n' '[{"storage":"local","enabled":1,"active":1}]' ;;
+        /cluster/resources) printf '%s\n' '[{"vmid":100,"type":"qemu"},{"vmid":101,"type":"lxc"}]' ;;
+        /cluster/tasks)
+            jq -n --argjson now "$UR_NOW_EPOCH" '[
+              {type:"vzdump",id:100,status:"OK",endtime:($now-3600)},
+              {type:"vzdump",id:101,status:"OK",endtime:($now-259200)}
+            ]' ;;
+        *) fail "unexpected PVE fixture endpoint: ${2:-}" ;;
+    esac
+}
+
+result_state() {
+    local wanted=$1 i
+    for ((i = 0; i < ${#REPORT_IDS[@]}; i++)); do
+        [[ ${REPORT_IDS[$i]} == "$wanted" ]] && { printf '%s' "${REPORT_STATES[$i]}"; return 0; }
+    done
+    return 1
+}
+
+conf_set upgrade-readiness UR_POLICY pve-9
+conf_set upgrade-readiness UR_BACKUP_HOURS 48
+conf_set upgrade-readiness UR_MIN_FREE_MB 2048
+doctor_reset
+module_doctor
+[[ $(report_exit_code) == 1 ]] || fail "upgrade blockers did not return failure"
+[[ $(result_state repository.1) == fail ]] || fail "bad official suite was not failed"
+[[ $(result_state repository.2) == warn ]] || fail "third-party repository was not warned"
+[[ $(result_state packages.holds) == fail ]] || fail "held package was not failed"
+[[ $(result_state reboot.pending) == fail ]] || fail "pending reboot was not failed"
+[[ $(result_state space.root) == fail ]] || fail "low root space was not failed"
+[[ $(result_state node.pve2.version) == fail ]] || fail "mixed PVE major was not failed"
+[[ $(result_state cluster.versions) == warn ]] || fail "cluster version skew was not warned"
+[[ $(result_state node.pve3.reachability) == fail ]] || fail "unavailable cluster node was not failed"
+[[ $(result_state node.pve1.services) == fail ]] || fail "failed service was not failed"
+[[ $(result_state node.pve1.storage) == fail ]] || fail "inactive storage was not failed"
+[[ $(result_state backup.100) == pass ]] || fail "recent backup did not pass"
+[[ $(result_state backup.101) == fail ]] || fail "missing recent backup was not failed"
+pass "mixed versions, suites, holds, space, services, storage, and backups"
+
+conf_clear upgrade-readiness
+UR_POLICY='../escape' UR_BACKUP_HOURS=48 UR_MIN_FREE_MB=2048
+_ur_load && fail "unsafe policy name was accepted"
+UR_POLICY=pve-9 UR_BACKUP_HOURS=0 UR_MIN_FREE_MB=2048
+_ur_load && fail "zero backup policy was accepted"
+pass "upgrade policy input fails closed"


### PR DESCRIPTION
## What

Adds a read-only, policy-driven PVE 9 upgrade preflight for repositories, packages, reboots, disk space, cluster state, services, storage, and backups.

## Why

Makes upgrade blockers and operator-review risks visible to automation. Closes #24.

## Testing

Added mixed-version, bad-suite, third-party repository, held-package, low-space, unavailable-node, service, storage, backup, and policy fixtures.

make lint

TUI_TEST_REQUIRED=1 ZSH_TEST_REQUIRED=1 CB_GATE_TESTS_REQUIRED=1 PACKAGING_TEST_REQUIRED=1 PACKAGING_INSTALL_TEST_REQUIRED=1 REPOSITORY_TEST_REQUIRED=1 make test

mkdocs build --strict

## Notes

The report complements rather than replaces official Proxmox upgrade guidance.