### PR TITLE
feat(restore-drill): validate isolated backup restores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ test: syntax
 	@./tests/storage-hygiene.sh
 	@./tests/certificate-watch.sh
 	@./tests/upgrade-readiness.sh
+	@./tests/restore-drill.sh
 	@./tests/discord.sh
 	@./tests/config-backup.sh
 	@./tests/hardening.sh

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ pve-toolbox/
 │   ├── certificate-watch/   # read-only cluster TLS and ACME health audit
 │   ├── config-backup/       # snapshots /etc/pve and host config, reported to Discord
 │   ├── native-notifications/ # owned native PVE targets, matchers, and shared sender
+│   ├── restore-drill/       # guarded isolated backup restore validation
 │   ├── scrutiny-collectors/ # SMART/ZFS/MDADM collectors for a remote Scrutiny
 │   ├── storage-hygiene/     # read-only snapshot, content, and capacity audit
 │   ├── upgrade-readiness/   # read-only, policy-driven upgrade preflight
@@ -104,6 +105,7 @@ without regenerating anything. See
 | [certificate-watch](https://quwisky.github.io/pve-toolbox/modules/certificate-watch/) | Checks cluster TLS expiry, hostname coverage, chains, reachability, and ACME task history |
 | [config-backup](https://quwisky.github.io/pve-toolbox/modules/config-backup/) | Snapshots `/etc/pve` and host config into verified tar.gz archives on a timer |
 | [native-notifications](https://quwisky.github.io/pve-toolbox/modules/native-notifications/) | Provisions owned PVE notification targets and matchers with protected credentials and rollback |
+| [restore-drill](https://quwisky.github.io/pve-toolbox/modules/restore-drill/) | Plans and explicitly runs isolated, ownership-checked VM or container restore drills |
 | [storage-hygiene](https://quwisky.github.io/pve-toolbox/modules/storage-hygiene/) | Audits old snapshots, unreferenced-looking storage, stale content, and capacity pressure without cleanup |
 | [upgrade-readiness](https://quwisky.github.io/pve-toolbox/modules/upgrade-readiness/) | Reports repository, package, space, cluster, service, storage, and backup blockers before upgrades |
 | [zfs-scrub](https://quwisky.github.io/pve-toolbox/modules/zfs-scrub/) | Scrubs each pool on its own timer, reports start and result to Discord |

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,8 @@
 pve-toolbox (0.4.0) unstable; urgency=medium
 
+  * Add guarded, isolated VM and container backup restore drills.
+  * Default to a plan, require explicit mutation consent, retain recoverable
+    state, and delete only ownership-marked temporary guests.
   * Add a read-only, policy-driven PVE 9 upgrade readiness preflight.
   * Report repository, package, reboot, space, cluster, storage, service, and
     recent-backup blockers with remediation context.

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -41,6 +41,9 @@ reachability, and native ACME task history.
 The [upgrade-readiness module](modules/upgrade-readiness.md) applies a
 release-specific preflight policy to repositories, packages, filesystems,
 cluster nodes, services, storage, and recent backups.
+The [restore-drill module](modules/restore-drill.md) reports a missing helper
+or unfinished drill while leaving recovery and cleanup explicitly operator
+controlled.
 
 ## Result states and exit status
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ pve-toolbox/
 │   ├── certificate-watch/
 │   ├── config-backup/
 │   ├── native-notifications/
+│   ├── restore-drill/
 │   ├── scrutiny-collectors/
 │   ├── storage-hygiene/
 │   ├── upgrade-readiness/
@@ -40,6 +41,7 @@ pve-toolbox/
 | [certificate-watch](modules/certificate-watch.md) | Read-only cluster certificate, chain, hostname, and ACME health audit |
 | [config-backup](modules/config-backup.md) | Timestamped snapshots of `/etc/pve` and host config, reported to Discord |
 | [native-notifications](modules/native-notifications.md) | Owned native PVE targets and matchers with protected secrets and tested delivery |
+| [restore-drill](modules/restore-drill.md) | Guarded, isolated backup restore validation with recoverable cleanup |
 | [storage-hygiene](modules/storage-hygiene.md) | Read-only snapshots, content ownership, storage definitions, and capacity audit |
 | [upgrade-readiness](modules/upgrade-readiness.md) | Policy-driven, read-only PVE upgrade blocker and risk preflight |
 | [zfs-scrub](modules/zfs-scrub.md) | Scrubs each pool on its own timer, reports start and result to Discord |

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -9,6 +9,7 @@ launcher discovers them at runtime; directories starting with `_` are skipped.
 | [certificate-watch](certificate-watch.md) | `monitoring tls certificate acme notify` | yes | none; contributes doctor checks |
 | [config-backup](config-backup.md) | `backup config notify` | yes | `pve-config-backup` |
 | [native-notifications](native-notifications.md) | `monitoring notify webhook smtp gotify` | yes | `pve-toolbox-native-notify` |
+| [restore-drill](restore-drill.md) | `backup restore audit isolation notify` | yes | `pve-toolbox-restore-drill` |
 | [storage-hygiene](storage-hygiene.md) | `storage audit monitoring zfs lvm` | yes | none; contributes doctor checks |
 | [upgrade-readiness](upgrade-readiness.md) | `upgrade audit monitoring backup apt` | yes | none; contributes doctor checks |
 | [zfs-scrub](zfs-scrub.md) | `storage zfs monitoring notify` | yes | `pve-toolbox-zfs-scrub` |

--- a/docs/modules/restore-drill.md
+++ b/docs/modules/restore-drill.md
@@ -1,0 +1,96 @@
+# restore-drill
+
+`restore-drill` validates a specific VM or container backup by restoring it to
+a collision-free temporary VMID. The helper is intentionally separate from
+the normal module lifecycle because every real run consumes storage and may
+boot a guest.
+
+!!! danger "Resource and data safety"
+
+    A restore drill is a destructive-capable maintenance operation. The
+    default invocation only prints a plan. A real run can consume substantial
+    storage and compute, and its final step deletes the temporary guest and
+    restored disks. Verify the backup, target storage, VMID, capacity, and
+    maintenance window before confirming. Never use production storage unless
+    that choice is deliberate.
+
+## Configure
+
+```bash
+pve-toolbox install restore-drill
+```
+
+```ini title="/etc/pve-toolbox/restore-drill.conf"
+RD_STORAGE=local-lvm
+RD_VMID_START=900000
+RD_BOOT_PROBE=1
+RD_BOOT_TIMEOUT=60
+RD_ALLOW_UNATTENDED=0
+```
+
+The VMID range is scanned without overwriting existing guests. Set the target
+to storage intended for temporary drill data. Boot probing can be disabled,
+but configuration and isolation checks always run.
+
+## Plan first
+
+Supply the exact Proxmox backup volume or archive path:
+
+```bash
+pve-toolbox-restore-drill \
+  --backup local:backup/vzdump-qemu-100-2026_08_29-01_00_00.vma.zst
+```
+
+This prints the selected backup, node, storage, allocated VMID, isolation,
+probe, and cleanup plan. It performs no restore and writes no run state.
+
+## Execute interactively
+
+After reviewing the plan, add `--execute`:
+
+```bash
+pve-toolbox-restore-drill \
+  --backup local:backup/vzdump-qemu-100-2026_08_29-01_00_00.vma.zst \
+  --storage drill-storage \
+  --execute
+```
+
+The helper requires an exact `RESTORE <vmid>` confirmation. It restores with
+unique MAC generation, disables VM network links (or removes container network
+devices), marks restored disks out of scheduled backups, disables on-boot, and
+does not create HA or replication jobs. The optional boot probe only checks
+that the isolated guest reaches its running state.
+
+For non-interactive use, both controls are required: configure
+`RD_ALLOW_UNATTENDED=1` and pass `--unattended --execute`. The flag alone is
+not authorization.
+
+## Failure and cleanup
+
+The current operation is recorded at
+`/var/lib/pve-toolbox/restore-drill-run.state` with the exact backup, run ID,
+VMID, phase, elapsed duration, probe result, and cleanup result. A failed probe
+preserves the isolated guest for inspection. A restore or isolation failure is
+not automatically deleted because ownership may not yet be provable.
+
+Resume proven cleanup explicitly:
+
+```bash
+pve-toolbox-restore-drill --cleanup
+```
+
+Cleanup requires `DELETE <vmid>` confirmation, or the same two-part unattended
+policy. It proceeds only when the state says the guest was created and the
+guest configuration contains the matching unpredictable run marker. A VMID
+collision, missing marker, altered marker, malformed state, or failed destroy
+stops cleanup without trying another target. `--keep` preserves a successful
+drill for later inspection and explicit cleanup.
+
+After successful teardown, the evidence moves to
+`/var/lib/pve-toolbox/restore-drill-last.state`. Uninstall refuses while a live
+run record exists and retains the last report. If automatic cleanup is refused,
+inspect the run state and VMID manually; never delete a guest based only on its
+number.
+
+When `native-notifications` is installed, restore and probe outcomes are sent
+through its shared helper. Notification failure never weakens restore safety.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
       - certificate-watch: modules/certificate-watch.md
       - config-backup: modules/config-backup.md
       - native-notifications: modules/native-notifications.md
+      - restore-drill: modules/restore-drill.md
       - storage-hygiene: modules/storage-hygiene.md
       - upgrade-readiness: modules/upgrade-readiness.md
       - zfs-scrub: modules/zfs-scrub.md

--- a/modules/restore-drill/module.sh
+++ b/modules/restore-drill/module.sh
@@ -1,0 +1,124 @@
+# shellcheck shell=bash
+# Configure the explicitly invoked isolated restore-drill helper.
+# shellcheck disable=SC2034
+MODULE_NAME="restore-drill"
+MODULE_TITLE="Restore drill"
+MODULE_DESC="guarded, isolated VM and container backup restore validation"
+MODULE_TAGS="backup restore audit isolation notify"
+MODULE_HOST_ONLY=1
+
+RD_BIN="pve-toolbox-restore-drill"
+RD_CONF_KEYS=(RD_STORAGE RD_VMID_START RD_BOOT_PROBE RD_BOOT_TIMEOUT RD_ALLOW_UNATTENDED)
+RD_ERROR=""
+
+_rd_dir() { printf '%s/modules/%s' "${TOOLBOX_ROOT:-/usr/lib/pve-toolbox}" "$MODULE_NAME"; }
+_rd_src() { printf '%s/%s' "$(_rd_dir)" "$RD_BIN"; }
+_rd_run_state() { printf '%s/restore-drill-run.state' "$TOOLBOX_STATE_DIR"; }
+_rd_last_report() { printf '%s/restore-drill-last.state' "$TOOLBOX_STATE_DIR"; }
+
+_rd_defaults() {
+    : "${RD_STORAGE:=local-lvm}"
+    : "${RD_VMID_START:=900000}"
+    : "${RD_BOOT_PROBE:=1}"
+    : "${RD_BOOT_TIMEOUT:=60}"
+    : "${RD_ALLOW_UNATTENDED:=0}"
+}
+
+_rd_validate() {
+    RD_ERROR=""
+    [[ $RD_STORAGE =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] \
+        || { RD_ERROR="target storage name is invalid"; return 1; }
+    [[ $RD_VMID_START =~ ^[1-9][0-9]*$ && $RD_VMID_START -le 999999999 ]] \
+        || { RD_ERROR="VMID start must be between 1 and 999999999"; return 1; }
+    [[ $RD_BOOT_PROBE =~ ^[01]$ && $RD_BOOT_TIMEOUT =~ ^[1-9][0-9]*$ \
+        && $RD_ALLOW_UNATTENDED =~ ^[01]$ ]] \
+        || { RD_ERROR="probe and unattended settings are invalid"; return 1; }
+}
+
+_rd_load() {
+    _rd_defaults
+    if conf_exists "$MODULE_NAME"; then conf_load "$MODULE_NAME"; fi
+    _rd_validate
+}
+
+_rd_install_helper() {
+    mkdir -p "$TOOLBOX_BIN_DIR"
+    install -m 0755 "$(_rd_src)" "$TOOLBOX_BIN_DIR/$RD_BIN"
+}
+
+module_install() {
+    require_root; require_pve; _rd_defaults
+    if conf_exists "$MODULE_NAME"; then conf_load "$MODULE_NAME"; fi
+    pkg_ensure flock:util-linux
+    ask RD_STORAGE "isolated restore target storage" "$RD_STORAGE"
+    ask RD_VMID_START "temporary VMID range start" "$RD_VMID_START"
+    ask RD_BOOT_PROBE "boot probe (1 enabled, 0 disabled)" "$RD_BOOT_PROBE"
+    ask RD_BOOT_TIMEOUT "boot probe timeout (seconds)" "$RD_BOOT_TIMEOUT"
+    ask RD_ALLOW_UNATTENDED "allow explicit --unattended runs (1/0)" "$RD_ALLOW_UNATTENDED"
+    _rd_validate || die "$RD_ERROR"
+    local key; for key in "${RD_CONF_KEYS[@]}"; do conf_set "$MODULE_NAME" "$key" "${!key}"; done
+    _rd_install_helper
+    state_set "$MODULE_NAME" INSTALLED_AT "$(date -Is)"
+    ok "installed guarded restore drill helper"
+    dim "  default invocation only prints a plan"
+}
+
+module_update() {
+    local check_only=0 key missing=() changed=0
+    [[ ${1:-} == --check ]] && check_only=1
+    conf_exists "$MODULE_NAME" || die "not installed"; _rd_defaults
+    for key in "${RD_CONF_KEYS[@]}"; do [[ -n $(conf_get "$MODULE_NAME" "$key") ]] || missing+=("$key"); done
+    [[ -x $TOOLBOX_BIN_DIR/$RD_BIN ]] || changed=1
+    cmp -s "$(_rd_src)" "$TOOLBOX_BIN_DIR/$RD_BIN" || changed=1
+    if [[ ${#missing[@]} -eq 0 && $changed -eq 0 ]]; then ok "restore drill is up to date"; return 0; fi
+    if [[ $check_only -eq 1 ]]; then warn "restore drill update available"; return 0; fi
+    for key in "${missing[@]}"; do conf_set "$MODULE_NAME" "$key" "${!key}"; done
+    _rd_install_helper
+    ok "updated restore drill"
+}
+
+module_status() {
+    conf_exists "$MODULE_NAME" && [[ -x $TOOLBOX_BIN_DIR/$RD_BIN ]] \
+        || { printf 'not installed'; return 1; }
+    if [[ -f $(_rd_run_state) ]]; then printf 'attention: unfinished drill'; else printf 'ready, dry-run by default'; fi
+}
+
+module_status_long() {
+    module_status || return 1; printf '\n'
+    if _rd_load; then
+        printf '  storage       %s\n' "$RD_STORAGE"
+        printf '  VMID start    %s\n' "$RD_VMID_START"
+        printf '  boot probe    %s (%ss)\n' "$RD_BOOT_PROBE" "$RD_BOOT_TIMEOUT"
+        printf '  unattended    %s (still requires --unattended)\n' "$RD_ALLOW_UNATTENDED"
+        [[ ! -f $(_rd_last_report) ]] || printf '  last report   %s\n' "$(_rd_last_report)"
+    fi
+}
+
+module_doctor() {
+    if [[ ! -x $TOOLBOX_BIN_DIR/$RD_BIN ]]; then
+        doctor_result fail helper "restore drill helper is missing"
+    else
+        doctor_result pass helper "restore drill helper is installed"
+    fi
+    if [[ -f $(_rd_run_state) ]]; then
+        local phase
+        phase=$(awk -F= '$1 == "PHASE" { print $2; exit }' "$(_rd_run_state)")
+        case $phase in
+            probe-failed) doctor_result warn active-run "failed drill is preserved for inspection" \
+                "cleanup explicitly with $RD_BIN --cleanup" ;;
+            *) doctor_result fail active-run "unfinished restore drill needs operator attention" \
+                "phase=${phase:-unknown}; inspect state before explicit cleanup" ;;
+        esac
+    else
+        doctor_result pass active-run "no unfinished restore drill"
+    fi
+}
+
+module_uninstall() {
+    require_root
+    [[ ! -e $(_rd_run_state) ]] \
+        || die "unfinished drill state exists; inspect or clean it before uninstalling"
+    rm -f -- "$TOOLBOX_BIN_DIR/$RD_BIN"
+    conf_clear "$MODULE_NAME"; state_clear "$MODULE_NAME"
+    ok "removed restore drill helper and configuration; retained the last drill report"
+}

--- a/modules/restore-drill/pve-toolbox-restore-drill
+++ b/modules/restore-drill/pve-toolbox-restore-drill
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+# Isolated, ownership-checked restore drill runner.
+set -euo pipefail
+
+RD_CONF=${RD_CONF:-/etc/pve-toolbox/restore-drill.conf}
+RD_RUN_STATE=${RD_RUN_STATE:-/var/lib/pve-toolbox/restore-drill-run.state}
+RD_LAST_REPORT=${RD_LAST_REPORT:-/var/lib/pve-toolbox/restore-drill-last.state}
+RD_LOCK=${RD_LOCK:-/var/lib/pve-toolbox/restore-drill.lock}
+: "${RD_STORAGE:=local-lvm}"
+: "${RD_VMID_START:=900000}"
+: "${RD_BOOT_PROBE:=1}"
+: "${RD_BOOT_TIMEOUT:=60}"
+: "${RD_ALLOW_UNATTENDED:=0}"
+
+usage() {
+    cat <<'EOF'
+usage: pve-toolbox-restore-drill --backup <volume> [options]
+       pve-toolbox-restore-drill --cleanup [--unattended]
+
+Options:
+  --backup <volume>    exact vzdump backup volume or path
+  --storage <name>     isolated restore target storage
+  --vmid <id>          temporary VMID (otherwise allocate from configured range)
+  --execute            perform the displayed restore plan
+  --unattended         use the separately enabled unattended policy
+  --keep               preserve a successful drill for inspection
+  --cleanup            resume safe cleanup from the recorded state
+EOF
+}
+
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+note() { printf '%s\n' "$*"; }
+
+load_conf() {
+    if [[ -r $RD_CONF ]]; then
+        # The module writes this root-only file with shell-safe quoted values.
+        # shellcheck disable=SC1090
+        source "$RD_CONF"
+    fi
+    [[ $RD_STORAGE =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || die "invalid configured storage"
+    [[ $RD_VMID_START =~ ^[1-9][0-9]*$ && $RD_VMID_START -le 999999999 ]] || die "invalid VMID start"
+    [[ $RD_BOOT_PROBE =~ ^[01]$ && $RD_BOOT_TIMEOUT =~ ^[1-9][0-9]*$ ]] || die "invalid probe policy"
+    [[ $RD_ALLOW_UNATTENDED =~ ^[01]$ ]] || die "invalid unattended policy"
+}
+
+state_get() { awk -F= -v key="$1" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' "$RD_RUN_STATE"; }
+
+write_state() { # phase created cleanup probe duration
+    local phase=$1 created=$2 cleanup=$3 probe=$4 duration=$5 tmp
+    mkdir -p -- "$(dirname -- "$RD_RUN_STATE")"
+    tmp=$(mktemp "${RD_RUN_STATE}.tmp.XXXXXX")
+    chmod 0600 "$tmp"
+    printf '%s\n' \
+        "RUN_ID=$run_id" "PHASE=$phase" "VMID=$vmid" "KIND=$kind" \
+        "BACKUP=$backup" "STORAGE=$storage" "NODE=$node" \
+        "START_EPOCH=$started" "DURATION_SECONDS=$duration" \
+        "CREATED=$created" "PROBE=$probe" "CLEANUP=$cleanup" > "$tmp"
+    mv -f -- "$tmp" "$RD_RUN_STATE"
+}
+
+load_state() {
+    [[ -f $RD_RUN_STATE && ! -L $RD_RUN_STATE ]] || die "no recoverable drill state exists"
+    run_id=$(state_get RUN_ID); phase=$(state_get PHASE); vmid=$(state_get VMID)
+    kind=$(state_get KIND); backup=$(state_get BACKUP); storage=$(state_get STORAGE)
+    node=$(state_get NODE); started=$(state_get START_EPOCH); created=$(state_get CREATED)
+    duration=$(state_get DURATION_SECONDS); probe=$(state_get PROBE)
+    [[ $run_id =~ ^[A-Za-z0-9._-]+$ && $phase =~ ^[a-z-]+$ \
+        && $vmid =~ ^[1-9][0-9]*$ && $kind =~ ^(qemu|lxc)$ \
+        && $backup =~ ^[A-Za-z0-9/][A-Za-z0-9._:/+-]+$ && $storage =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ \
+        && $node =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ && $started =~ ^[0-9]+$ \
+        && $created =~ ^[01]$ && $duration =~ ^[0-9]+$ \
+        && $probe =~ ^(not-run|pending|passed|failed|unknown)$ ]] \
+        || die "drill state is malformed; refusing automatic cleanup"
+}
+
+guest_exists() {
+    qm status "$1" >/dev/null 2>&1 || pct status "$1" >/dev/null 2>&1
+}
+
+allocate_vmid() {
+    local candidate=$RD_VMID_START limit=$((RD_VMID_START + 9999))
+    while [[ $candidate -le $limit ]]; do
+        if ! guest_exists "$candidate"; then printf '%s' "$candidate"; return 0; fi
+        candidate=$((candidate + 1))
+    done
+    return 1
+}
+
+confirm_action() { # exact phrase
+    local phrase=$1 reply
+    if [[ $unattended -eq 1 ]]; then
+        [[ $RD_ALLOW_UNATTENDED -eq 1 ]] \
+            || die "--unattended requires RD_ALLOW_UNATTENDED=1 in the module configuration"
+        return 0
+    fi
+    [[ -t 0 ]] || die "confirmation requires a terminal; configure unattended policy explicitly for automation"
+    printf 'Type %s to continue: ' "$phrase" >&2
+    IFS= read -r reply
+    [[ $reply == "$phrase" ]] || die "confirmation did not match"
+}
+
+marker() { printf 'pve-toolbox restore-drill run=%s' "$run_id"; }
+
+mark_guest() {
+    local config
+    if [[ $kind == qemu ]]; then
+        qm set "$vmid" --description "$(marker)" --onboot 0 >/dev/null || return 1
+        local key value
+        config=$(qm config "$vmid") || return 1
+        while IFS=: read -r key value; do
+            value=${value# }
+            if [[ $key =~ ^net[0-9]+$ ]]; then
+                [[ $value == *,link_down=1* ]] || value+=",link_down=1"
+                qm set "$vmid" --"$key" "$value" >/dev/null || return 1
+            elif [[ $key =~ ^(ide|sata|scsi|virtio|efidisk|tpmstate)[0-9]+$ ]]; then
+                if [[ $value =~ (^|,)backup=[01]($|,) ]]; then
+                    value=$(sed -E 's/(^|,)backup=[01]($|,)/\1backup=0\2/' <<<"$value")
+                else
+                    value+=",backup=0"
+                fi
+                qm set "$vmid" --"$key" "$value" >/dev/null || return 1
+            fi
+        done <<<"$config"
+    else
+        pct set "$vmid" --description "$(marker)" --onboot 0 >/dev/null || return 1
+        local key value
+        config=$(pct config "$vmid") || return 1
+        while IFS=: read -r key value; do
+            value=${value# }
+            if [[ $key =~ ^net[0-9]+$ ]]; then
+                pct set "$vmid" --delete "$key" >/dev/null || return 1
+            elif [[ $key == rootfs || $key =~ ^mp[0-9]+$ ]]; then
+                if [[ $value =~ (^|,)backup=[01]($|,) ]]; then
+                    value=$(sed -E 's/(^|,)backup=[01]($|,)/\1backup=0\2/' <<<"$value")
+                else
+                    value+=",backup=0"
+                fi
+                pct set "$vmid" --"$key" "$value" >/dev/null || return 1
+            fi
+        done <<<"$config"
+    fi
+}
+
+owned_guest() {
+    local config
+    if [[ $kind == qemu ]]; then config=$(qm config "$vmid" 2>/dev/null) || return 1
+    else config=$(pct config "$vmid" 2>/dev/null) || return 1
+    fi
+    grep -Fqx "description: $(marker)" <<<"$config"
+}
+
+restore_guest() {
+    if [[ $kind == qemu ]]; then
+        qmrestore "$backup" "$vmid" --storage "$storage" --unique 1
+    else
+        pct restore "$vmid" "$backup" --storage "$storage" --unprivileged 1
+    fi
+}
+
+probe_guest() {
+    [[ $RD_BOOT_PROBE -eq 1 ]] || { note "boot probe disabled by policy"; return 0; }
+    local deadline status
+    if [[ $kind == qemu ]]; then qm start "$vmid" >/dev/null; else pct start "$vmid" >/dev/null; fi
+    deadline=$(( $(date +%s) + RD_BOOT_TIMEOUT ))
+    while [[ $(date +%s) -le $deadline ]]; do
+        if [[ $kind == qemu ]]; then status=$(qm status "$vmid" 2>/dev/null || true)
+        else status=$(pct status "$vmid" 2>/dev/null || true)
+        fi
+        [[ $status == *'status: running'* ]] && return 0
+        sleep 1
+    done
+    return 1
+}
+
+stop_owned_guest() {
+    if [[ $kind == qemu ]]; then qm stop "$vmid" --timeout 30 >/dev/null 2>&1 || true
+    else pct stop "$vmid" --timeout 30 >/dev/null 2>&1 || true
+    fi
+}
+
+finish_report() {
+    local cleanup=$1 probe=$2 duration=$3
+    write_state completed 1 "$cleanup" "$probe" "$duration"
+    mkdir -p -- "$(dirname -- "$RD_LAST_REPORT")"
+    cp -- "$RD_RUN_STATE" "$RD_LAST_REPORT"
+    chmod 0600 "$RD_LAST_REPORT"
+    rm -f -- "$RD_RUN_STATE"
+}
+
+cleanup_guest() {
+    local duration=${1:-0} probe=${2:-unknown}
+    [[ $created -eq 1 ]] || die "state cannot prove the guest was marked as created by this drill; inspect VMID $vmid manually"
+    guest_exists "$vmid" || die "recorded temporary guest $vmid is missing; refusing to infer cleanup"
+    owned_guest || die "guest $vmid does not carry run marker $(marker); refusing deletion"
+    stop_owned_guest
+    if [[ $kind == qemu ]]; then
+        if ! qm destroy "$vmid" --purge 1 --destroy-unreferenced-disks 1; then
+            write_state cleanup-failed 1 failed "$probe" "$duration"
+            die "cleanup failed; retry: pve-toolbox-restore-drill --cleanup"
+        fi
+    elif ! pct destroy "$vmid" --purge 1; then
+        write_state cleanup-failed 1 failed "$probe" "$duration"
+        die "cleanup failed; retry: pve-toolbox-restore-drill --cleanup"
+    fi
+    finish_report success "$probe" "$duration"
+    note "restore drill cleanup completed for VMID $vmid"
+}
+
+notify_result() {
+    local severity=$1 message=$2
+    command -v pve-toolbox-native-notify >/dev/null 2>&1 || return 0
+    pve-toolbox-native-notify "$severity" "restore drill" "$message" >/dev/null 2>&1 || true
+}
+
+manual_recovery() {
+    local command
+    [[ $kind == qemu ]] && command=qm || command=pct
+    note "Inspect the partial guest: $command config $vmid" >&2
+    note "The helper will not delete it without its run marker. If you independently prove" >&2
+    note "that VMID $vmid is only this partial restore, remove it manually with:" >&2
+    if [[ $kind == qemu ]]; then
+        note "  qm destroy $vmid --purge 1 --destroy-unreferenced-disks 1" >&2
+    else
+        note "  pct destroy $vmid --purge 1" >&2
+    fi
+}
+
+backup=""; storage=""; vmid=""; execute=0; unattended=0; keep=0; cleanup=0
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --backup) [[ $# -ge 2 ]] || die "--backup needs a value"; backup=$2; shift 2 ;;
+        --storage) [[ $# -ge 2 ]] || die "--storage needs a value"; storage=$2; shift 2 ;;
+        --vmid) [[ $# -ge 2 ]] || die "--vmid needs a value"; vmid=$2; shift 2 ;;
+        --execute) execute=1; shift ;;
+        --unattended) unattended=1; shift ;;
+        --keep) keep=1; shift ;;
+        --cleanup) cleanup=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) usage >&2; die "unknown option: $1" ;;
+    esac
+done
+
+load_conf
+[[ $EUID -eq 0 ]] || die "restore drills must run as root"
+mkdir -p -- "$(dirname -- "$RD_LOCK")"
+exec 9>"$RD_LOCK"
+flock -n 9 || die "another restore drill is active"
+
+if [[ $cleanup -eq 1 ]]; then
+    [[ -z $backup && -z $vmid && $execute -eq 0 && $keep -eq 0 ]] || die "--cleanup cannot be combined with restore options"
+    load_state
+    confirm_action "DELETE $vmid"
+    cleanup_guest "$duration" "$probe"
+    exit 0
+fi
+
+[[ -n $backup && $backup =~ ^[A-Za-z0-9/][A-Za-z0-9._:/+-]+$ ]] \
+    || die "an exact, safe --backup value is required"
+storage=${storage:-$RD_STORAGE}
+[[ $storage =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || die "invalid target storage"
+case $backup in
+    *vzdump-qemu-*) kind=qemu ;;
+    *vzdump-lxc-*) kind=lxc ;;
+    *) die "backup name must identify a vzdump qemu or lxc archive" ;;
+esac
+node=${RD_NODE:-$(hostname -s)}
+[[ $node =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || die "invalid node name"
+if [[ -n $vmid ]]; then
+    [[ $vmid =~ ^[1-9][0-9]*$ && $vmid -le 999999999 ]] || die "invalid VMID"
+    guest_exists "$vmid" && die "VMID $vmid already exists; refusing collision"
+else
+    vmid=$(allocate_vmid) || die "no free temporary VMID in the configured range"
+fi
+
+note "Restore drill plan"
+note "  backup: $backup"
+note "  target: node=$node storage=$storage VMID=$vmid type=$kind"
+note "  isolation: networking and disk backup disabled, onboot disabled, no HA/replication enrollment"
+note "  probe: boot=$RD_BOOT_PROBE timeout=${RD_BOOT_TIMEOUT}s"
+note "  cleanup: delete only the ownership-marked temporary guest"
+[[ $execute -eq 1 ]] || { note "Dry run only. Add --execute to perform this plan."; exit 0; }
+[[ ! -e $RD_RUN_STATE ]] || die "an unfinished drill exists; inspect it or run --cleanup"
+confirm_action "RESTORE $vmid"
+
+run_id="$(date -u +%Y%m%dT%H%M%SZ)-$$-$RANDOM"
+started=$(date +%s)
+write_state restore-started 0 pending not-run 0
+if ! restore_guest; then
+    write_state restore-failed 0 manual not-run "$(( $(date +%s) - started ))"
+    notify_result error "restore failed for $backup at VMID $vmid; manual inspection required"
+    manual_recovery
+    die "restore failed; state retained at $RD_RUN_STATE and automatic deletion is disabled"
+fi
+if ! mark_guest; then
+    write_state isolation-failed 0 manual not-run "$(( $(date +%s) - started ))"
+    notify_result error "isolation failed for VMID $vmid; manual inspection required"
+    manual_recovery
+    die "could not prove isolation/ownership; do not start VMID $vmid; inspect it manually"
+fi
+created=1
+write_state restored 1 pending pending "$(( $(date +%s) - started ))"
+if ! probe_guest; then
+    write_state probe-failed 1 preserved failed "$(( $(date +%s) - started ))"
+    notify_result error "isolated restore probe failed for VMID $vmid; drill preserved"
+    die "probe failed; VMID $vmid was preserved for inspection; cleanup with pve-toolbox-restore-drill --cleanup"
+fi
+duration=$(( $(date +%s) - started ))
+write_state probe-passed 1 pending passed "$duration"
+notify_result notice "isolated restore probe passed for $backup in ${duration}s"
+if [[ $keep -eq 1 ]]; then
+    note "probe passed; VMID $vmid preserved by --keep"
+    note "cleanup later: pve-toolbox-restore-drill --cleanup"
+    exit 0
+fi
+cleanup_guest "$duration" passed

--- a/tests/fixtures/restore-drill-mock.sh
+++ b/tests/fixtures/restore-drill-mock.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tool=${0##*/}
+printf '%s %s\n' "$tool" "$*" >> "$MOCK_LOG"
+exists() { [[ -f $MOCK_STATE/$1.exists ]]; }
+
+case $tool in
+    qm|pct)
+        action=${1:-}; id=${2:-}
+        case $action in
+            status)
+                exists "$id" || exit 2
+                printf 'status: %s\n' "$(<"$MOCK_STATE/$id.status")" ;;
+            config)
+                exists "$id" || exit 2
+                [[ ${MOCK_CONFIG_FAIL:-0} != 1 ]] || exit 1
+                [[ ! -f $MOCK_STATE/$id.marker ]] \
+                    || printf 'description: %s\n' "$(<"$MOCK_STATE/$id.marker")"
+                if [[ $tool == qm ]]; then
+                    printf 'net0: virtio=02:00:00:00:00:01,bridge=vmbr0\n'
+                    printf 'scsi0: test-store:vm-%s-disk-0,size=8G\n' "$id"
+                else
+                    printf 'net0: name=eth0,bridge=vmbr0\n'
+                    printf 'rootfs: test-store:subvol-%s-disk-0,size=8G\n' "$id"
+                fi ;;
+            set)
+                exists "$id" || exit 2
+                shift 2
+                while [[ $# -gt 0 ]]; do
+                    case $1 in
+                        --description) printf '%s' "$2" > "$MOCK_STATE/$id.marker"; shift 2 ;;
+                        --delete|--onboot|--net[0-9]*|--scsi[0-9]*|--rootfs|--mp[0-9]*) shift 2 ;;
+                        *) shift ;;
+                    esac
+                done ;;
+            start)
+                exists "$id" || exit 2
+                [[ ${MOCK_PROBE_FAIL:-0} == 1 ]] \
+                    || printf 'running' > "$MOCK_STATE/$id.status" ;;
+            stop)
+                exists "$id" || exit 2
+                printf 'stopped' > "$MOCK_STATE/$id.status" ;;
+            restore)
+                [[ $tool == pct && ${MOCK_RESTORE_FAIL:-0} != 1 ]] || exit 1
+                : > "$MOCK_STATE/$id.exists"
+                printf 'stopped' > "$MOCK_STATE/$id.status" ;;
+            destroy)
+                [[ ${MOCK_DESTROY_FAIL:-0} != 1 ]] || exit 1
+                exists "$id" || exit 2
+                rm -f -- "$MOCK_STATE/$id.exists" "$MOCK_STATE/$id.status" "$MOCK_STATE/$id.marker" ;;
+            *) exit 64 ;;
+        esac ;;
+    qmrestore)
+        backup=${1:-}; id=${2:-}
+        [[ ${MOCK_RESTORE_FAIL:-0} != 1 ]] || exit 1
+        [[ -n $backup && $id =~ ^[0-9]+$ ]] || exit 64
+        : > "$MOCK_STATE/$id.exists"
+        printf 'stopped' > "$MOCK_STATE/$id.status" ;;
+    *) exit 64 ;;
+esac

--- a/tests/package.sh
+++ b/tests/package.sh
@@ -51,6 +51,8 @@ for path in \
     ./usr/lib/pve-toolbox/modules/certificate-watch/module.sh \
     ./usr/lib/pve-toolbox/modules/upgrade-readiness/module.sh \
     ./usr/lib/pve-toolbox/modules/upgrade-readiness/policies/pve-9.conf \
+    ./usr/lib/pve-toolbox/modules/restore-drill/module.sh \
+    ./usr/lib/pve-toolbox/modules/restore-drill/pve-toolbox-restore-drill \
     ./usr/share/man/man1/pve-toolbox.1.gz \
     ./usr/share/bash-completion/completions/pve-toolbox \
     ./usr/share/zsh/vendor-completions/_pve-toolbox

--- a/tests/restore-drill.sh
+++ b/tests/restore-drill.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Destructive-boundary fixtures for the isolated restore drill helper.
+set -euo pipefail
+
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
+ROOT=$PWD
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/bin" "$WORK/mock" "$WORK/state" "$WORK/conf" "$WORK/lock"
+cp -- "$ROOT/tests/fixtures/restore-drill-mock.sh" "$WORK/bin/mock"
+chmod 0755 "$WORK/bin/mock"
+for name in qm pct qmrestore; do ln -s mock "$WORK/bin/$name"; done
+
+pass() { printf 'ok  %s\n' "$1"; }
+fail() { printf 'FAIL %s\n' "$1" >&2; exit 1; }
+
+HELPER="$ROOT/modules/restore-drill/pve-toolbox-restore-drill"
+MOCK_STATE="$WORK/mock"
+MOCK_LOG="$WORK/mock.log"
+RD_CONF="$WORK/conf/restore-drill.conf"
+RD_RUN_STATE="$WORK/state/run.state"
+RD_LAST_REPORT="$WORK/state/last.state"
+RD_LOCK="$WORK/lock/drill.lock"
+RD_NODE=pve1
+PATH="$WORK/bin:$PATH"
+export MOCK_STATE MOCK_LOG RD_CONF RD_RUN_STATE RD_LAST_REPORT RD_LOCK RD_NODE PATH
+printf '%s\n' "RD_STORAGE='test-store'" "RD_VMID_START='900000'" \
+    "RD_BOOT_PROBE='1'" "RD_BOOT_TIMEOUT='1'" "RD_ALLOW_UNATTENDED='1'" > "$RD_CONF"
+
+backup='local:backup/vzdump-qemu-100-2026_08_29-01_00_00.vma.zst'
+: > "$MOCK_LOG"
+: > "$MOCK_STATE/900000.exists"
+printf 'stopped' > "$MOCK_STATE/900000.status"
+output=$($HELPER --backup "$backup")
+[[ $output == *'VMID=900001'* && $output == *'Dry run only'* ]] \
+    || fail "default invocation did not show the collision-free plan"
+[[ ! -e $RD_RUN_STATE && $(<"$MOCK_LOG") != *qmrestore* ]] \
+    || fail "dry run changed restore state"
+pass "default invocation is a collision-aware dry run"
+
+if $HELPER --backup "$backup" --vmid 900000 --execute --unattended >/dev/null 2>&1; then
+    fail "explicit VMID collision was accepted"
+fi
+pass "existing guest VMIDs cannot be overwritten"
+
+: > "$MOCK_LOG"
+export MOCK_RESTORE_FAIL=1
+if $HELPER --backup "$backup" --vmid 900002 --execute --unattended >/dev/null 2>&1; then
+    fail "restore failure returned success"
+fi
+unset MOCK_RESTORE_FAIL
+grep -q '^PHASE=restore-failed$' "$RD_RUN_STATE" || fail "restore failure state was not retained"
+[[ $(<"$MOCK_LOG") != *'qm destroy 900002'* ]] || fail "failed restore triggered deletion"
+rm -f -- "$RD_RUN_STATE"
+pass "restore failures preserve recoverable state without inferred deletion"
+
+: > "$MOCK_LOG"
+export MOCK_CONFIG_FAIL=1
+if $HELPER --backup "$backup" --vmid 900002 --execute --unattended >/dev/null 2>&1; then
+    fail "failed isolation inspection returned success"
+fi
+unset MOCK_CONFIG_FAIL
+grep -q '^PHASE=isolation-failed$' "$RD_RUN_STATE" || fail "isolation failure state was not retained"
+[[ -f $MOCK_STATE/900002.exists && $(<"$MOCK_LOG") != *'qm destroy 900002'* ]] \
+    || fail "unproven partial restore was deleted"
+rm -f -- "$RD_RUN_STATE" "$MOCK_STATE/900002.exists" "$MOCK_STATE/900002.status" \
+    "$MOCK_STATE/900002.marker"
+pass "configuration inspection failures stop before ownership is asserted"
+
+: > "$MOCK_LOG"
+export MOCK_PROBE_FAIL=1
+if $HELPER --backup "$backup" --vmid 900003 --execute --unattended >/dev/null 2>&1; then
+    fail "failed boot probe returned success"
+fi
+unset MOCK_PROBE_FAIL
+grep -q '^PHASE=probe-failed$' "$RD_RUN_STATE" || fail "probe failure state was not retained"
+[[ -f $MOCK_STATE/900003.exists && $(<"$MOCK_LOG") != *'qm destroy 900003'* ]] \
+    || fail "failed probe was not preserved"
+grep -Eq '^qm set 900003 --net0 .*link_down=1' "$MOCK_LOG" \
+    || fail "restored VM networking was not disabled"
+grep -Eq '^qm set 900003 --scsi0 .*backup=0' "$MOCK_LOG" \
+    || fail "restored VM disks were not excluded from scheduled backups"
+grep -q '^qmrestore .* 900003 --storage test-store --unique 1$' "$MOCK_LOG" \
+    || fail "restore did not use collision-safe unique mode and target storage"
+pass "failed probes preserve an isolated, ownership-marked guest"
+
+export MOCK_DESTROY_FAIL=1
+if $HELPER --cleanup --unattended >/dev/null 2>&1; then fail "failed cleanup returned success"; fi
+unset MOCK_DESTROY_FAIL
+grep -q '^PHASE=cleanup-failed$' "$RD_RUN_STATE" || fail "interrupted cleanup state was not recoverable"
+$HELPER --cleanup --unattended >/dev/null
+[[ ! -e $RD_RUN_STATE && ! -e $MOCK_STATE/900003.exists ]] \
+    || fail "cleanup retry did not safely complete"
+grep -q '^CLEANUP=success$' "$RD_LAST_REPORT" || fail "cleanup result was not recorded"
+pass "interrupted cleanup resumes only for the marked drill guest"
+
+: > "$MOCK_LOG"
+$HELPER --backup "$backup" --vmid 900004 --execute --unattended >/dev/null
+[[ ! -e $RD_RUN_STATE && ! -e $MOCK_STATE/900004.exists ]] \
+    || fail "successful drill did not tear down"
+grep -q "^BACKUP=$backup$" "$RD_LAST_REPORT" || fail "exact backup was not recorded"
+grep -q '^PROBE=passed$' "$RD_LAST_REPORT" || fail "probe result was not recorded"
+grep -Eq '^DURATION_SECONDS=[0-9]+$' "$RD_LAST_REPORT" || fail "duration was not recorded"
+grep -q '^qm destroy 900004 --purge 1 --destroy-unreferenced-disks 1$' "$MOCK_LOG" \
+    || fail "successful teardown did not use the guarded destroy path"
+pass "successful drill records evidence and tears down the temporary guest"
+
+: > "$MOCK_LOG"
+ct_backup='local:backup/vzdump-lxc-101-2026_08_29-01_00_00.tar.zst'
+$HELPER --backup "$ct_backup" --vmid 900005 --execute --unattended >/dev/null
+grep -q '^pct set 900005 --delete net0$' "$MOCK_LOG" \
+    || fail "restored container networking was not removed"
+grep -Eq '^pct set 900005 --rootfs .*backup=0' "$MOCK_LOG" \
+    || fail "restored container rootfs was not excluded from scheduled backups"
+grep -q '^pct destroy 900005 --purge 1$' "$MOCK_LOG" \
+    || fail "container teardown did not use the guarded destroy path"
+pass "container drills apply the same isolation and teardown boundary"
+
+# A valid state with a different marker must never authorize deletion.
+sed 's/^VMID=.*/VMID=900000/; s/^RUN_ID=.*/RUN_ID=foreign-run/; s/^PHASE=.*/PHASE=probe-passed/' \
+    "$RD_LAST_REPORT" > "$RD_RUN_STATE"
+if $HELPER --cleanup --unattended >/dev/null 2>&1; then fail "foreign guest marker was accepted"; fi
+[[ -f $MOCK_STATE/900000.exists ]] || fail "foreign guest was deleted"
+pass "cleanup fails closed when ownership proof does not match"

--- a/tests/restore-drill.sh
+++ b/tests/restore-drill.sh
@@ -27,25 +27,45 @@ export MOCK_STATE MOCK_LOG RD_CONF RD_RUN_STATE RD_LAST_REPORT RD_LOCK RD_NODE P
 printf '%s\n' "RD_STORAGE='test-store'" "RD_VMID_START='900000'" \
     "RD_BOOT_PROBE='1'" "RD_BOOT_TIMEOUT='1'" "RD_ALLOW_UNATTENDED='1'" > "$RD_CONF"
 
+run_helper() {
+    if [[ $EUID -eq 0 ]]; then
+        "$HELPER" "$@"
+    else
+        local rc=0
+        command -v sudo >/dev/null 2>&1 || fail "sudo is required to test the root-only helper"
+        sudo env \
+            "MOCK_STATE=$MOCK_STATE" "MOCK_LOG=$MOCK_LOG" \
+            "MOCK_RESTORE_FAIL=${MOCK_RESTORE_FAIL:-}" \
+            "MOCK_CONFIG_FAIL=${MOCK_CONFIG_FAIL:-}" \
+            "MOCK_PROBE_FAIL=${MOCK_PROBE_FAIL:-}" \
+            "MOCK_DESTROY_FAIL=${MOCK_DESTROY_FAIL:-}" \
+            "RD_CONF=$RD_CONF" "RD_RUN_STATE=$RD_RUN_STATE" \
+            "RD_LAST_REPORT=$RD_LAST_REPORT" "RD_LOCK=$RD_LOCK" \
+            "RD_NODE=$RD_NODE" "PATH=$PATH" "$HELPER" "$@" || rc=$?
+        sudo chown -R "$(id -u):$(id -g)" "$WORK"
+        return "$rc"
+    fi
+}
+
 backup='local:backup/vzdump-qemu-100-2026_08_29-01_00_00.vma.zst'
 : > "$MOCK_LOG"
 : > "$MOCK_STATE/900000.exists"
 printf 'stopped' > "$MOCK_STATE/900000.status"
-output=$($HELPER --backup "$backup")
+output=$(run_helper --backup "$backup")
 [[ $output == *'VMID=900001'* && $output == *'Dry run only'* ]] \
     || fail "default invocation did not show the collision-free plan"
 [[ ! -e $RD_RUN_STATE && $(<"$MOCK_LOG") != *qmrestore* ]] \
     || fail "dry run changed restore state"
 pass "default invocation is a collision-aware dry run"
 
-if $HELPER --backup "$backup" --vmid 900000 --execute --unattended >/dev/null 2>&1; then
+if run_helper --backup "$backup" --vmid 900000 --execute --unattended >/dev/null 2>&1; then
     fail "explicit VMID collision was accepted"
 fi
 pass "existing guest VMIDs cannot be overwritten"
 
 : > "$MOCK_LOG"
 export MOCK_RESTORE_FAIL=1
-if $HELPER --backup "$backup" --vmid 900002 --execute --unattended >/dev/null 2>&1; then
+if run_helper --backup "$backup" --vmid 900002 --execute --unattended >/dev/null 2>&1; then
     fail "restore failure returned success"
 fi
 unset MOCK_RESTORE_FAIL
@@ -56,7 +76,7 @@ pass "restore failures preserve recoverable state without inferred deletion"
 
 : > "$MOCK_LOG"
 export MOCK_CONFIG_FAIL=1
-if $HELPER --backup "$backup" --vmid 900002 --execute --unattended >/dev/null 2>&1; then
+if run_helper --backup "$backup" --vmid 900002 --execute --unattended >/dev/null 2>&1; then
     fail "failed isolation inspection returned success"
 fi
 unset MOCK_CONFIG_FAIL
@@ -69,7 +89,7 @@ pass "configuration inspection failures stop before ownership is asserted"
 
 : > "$MOCK_LOG"
 export MOCK_PROBE_FAIL=1
-if $HELPER --backup "$backup" --vmid 900003 --execute --unattended >/dev/null 2>&1; then
+if run_helper --backup "$backup" --vmid 900003 --execute --unattended >/dev/null 2>&1; then
     fail "failed boot probe returned success"
 fi
 unset MOCK_PROBE_FAIL
@@ -85,17 +105,17 @@ grep -q '^qmrestore .* 900003 --storage test-store --unique 1$' "$MOCK_LOG" \
 pass "failed probes preserve an isolated, ownership-marked guest"
 
 export MOCK_DESTROY_FAIL=1
-if $HELPER --cleanup --unattended >/dev/null 2>&1; then fail "failed cleanup returned success"; fi
+if run_helper --cleanup --unattended >/dev/null 2>&1; then fail "failed cleanup returned success"; fi
 unset MOCK_DESTROY_FAIL
 grep -q '^PHASE=cleanup-failed$' "$RD_RUN_STATE" || fail "interrupted cleanup state was not recoverable"
-$HELPER --cleanup --unattended >/dev/null
+run_helper --cleanup --unattended >/dev/null
 [[ ! -e $RD_RUN_STATE && ! -e $MOCK_STATE/900003.exists ]] \
     || fail "cleanup retry did not safely complete"
 grep -q '^CLEANUP=success$' "$RD_LAST_REPORT" || fail "cleanup result was not recorded"
 pass "interrupted cleanup resumes only for the marked drill guest"
 
 : > "$MOCK_LOG"
-$HELPER --backup "$backup" --vmid 900004 --execute --unattended >/dev/null
+run_helper --backup "$backup" --vmid 900004 --execute --unattended >/dev/null
 [[ ! -e $RD_RUN_STATE && ! -e $MOCK_STATE/900004.exists ]] \
     || fail "successful drill did not tear down"
 grep -q "^BACKUP=$backup$" "$RD_LAST_REPORT" || fail "exact backup was not recorded"
@@ -107,7 +127,7 @@ pass "successful drill records evidence and tears down the temporary guest"
 
 : > "$MOCK_LOG"
 ct_backup='local:backup/vzdump-lxc-101-2026_08_29-01_00_00.tar.zst'
-$HELPER --backup "$ct_backup" --vmid 900005 --execute --unattended >/dev/null
+run_helper --backup "$ct_backup" --vmid 900005 --execute --unattended >/dev/null
 grep -q '^pct set 900005 --delete net0$' "$MOCK_LOG" \
     || fail "restored container networking was not removed"
 grep -Eq '^pct set 900005 --rootfs .*backup=0' "$MOCK_LOG" \
@@ -119,6 +139,6 @@ pass "container drills apply the same isolation and teardown boundary"
 # A valid state with a different marker must never authorize deletion.
 sed 's/^VMID=.*/VMID=900000/; s/^RUN_ID=.*/RUN_ID=foreign-run/; s/^PHASE=.*/PHASE=probe-passed/' \
     "$RD_LAST_REPORT" > "$RD_RUN_STATE"
-if $HELPER --cleanup --unattended >/dev/null 2>&1; then fail "foreign guest marker was accepted"; fi
+if run_helper --cleanup --unattended >/dev/null 2>&1; then fail "foreign guest marker was accepted"; fi
 [[ -f $MOCK_STATE/900000.exists ]] || fail "foreign guest was deleted"
 pass "cleanup fails closed when ownership proof does not match"


### PR DESCRIPTION
## What

Adds explicitly invoked, isolated VM and container backup restore drills with recoverable state and ownership-checked cleanup.

## Why

Validates that backups can be restored without overwriting existing guests or enrolling temporary workloads in networking, HA, replication, or scheduled backups. Closes #25.

## How

Plans by default, requires exact interactive confirmation or a two-part unattended policy, applies isolation before boot, and deletes only a guest carrying the current run marker.

## Testing

Added collision, restore failure, isolation failure, probe failure, interrupted cleanup, VM teardown, container teardown, and foreign-marker fixtures.

make lint

TUI_TEST_REQUIRED=1 ZSH_TEST_REQUIRED=1 CB_GATE_TESTS_REQUIRED=1 PACKAGING_TEST_REQUIRED=1 PACKAGING_INSTALL_TEST_REQUIRED=1 REPOSITORY_TEST_REQUIRED=1 make test

mkdocs build --strict

## Notes

This is a destructive-capable workflow. The current boot probe verifies running state only; service-level guest probes are a follow-up configuration surface.