### PR TITLE
docs(agents): configure engineering skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,3 +100,20 @@ make test
   known gaps, and migration steps.
 - Before handoff, run `git diff --check`, confirm the working tree contains no
   unrelated files or secrets, and verify required pull-request checks pass.
+
+## Agent skills
+
+### Issue tracker
+
+Issues and specifications are tracked in GitHub Issues for
+`quwisky/pve-toolbox`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Use the default five-role triage vocabulary. See
+`docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This repository uses a single-context domain-documentation layout. See
+`docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,35 @@
+# Domain Docs
+
+How engineering skills should consume this repository’s domain documentation.
+
+## Layout
+
+This is a single-context repository:
+
+- `CONTEXT.md` contains the project glossary and domain model.
+- `docs/adr/` contains architecture decision records.
+
+These files are created lazily when terminology or architectural decisions
+need to be recorded.
+
+## Before exploring
+
+Read `CONTEXT.md` and any ADRs relevant to the area being changed. If they do
+not exist, proceed silently; do not require them before beginning ordinary
+work.
+
+## Use the glossary’s vocabulary
+
+When output names a domain concept—in an issue title, proposal, hypothesis, or
+test—use the term defined in `CONTEXT.md`. Do not drift to synonyms the glossary
+explicitly avoids.
+
+If a required concept is absent, reconsider whether the term belongs to the
+project or note the gap for the domain-modeling skill.
+
+## Flag ADR conflicts
+
+If proposed work contradicts an existing ADR, surface it explicitly rather
+than silently overriding it:
+
+> _Contradicts ADR-0007, but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,65 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all
+operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a
+  heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by
+  `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json
+  number,title,body,labels,comments --jq '[.[] | {number, title, body, labels:
+  [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label`
+  and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` /
+  `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v`; `gh` does this automatically when run
+inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external
+PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using
+the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for
+  the diff.
+- **List external PRs for triage**: `gh pr list --state open --json
+  number,title,body,labels,author,authorAssociation,comments` then keep only
+  `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE`.
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label` /
+  `--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so resolve a bare `#42`
+with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says “publish to the issue tracker”
+
+Create a GitHub issue.
+
+## When a skill says “fetch the relevant ticket”
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The map is a single issue with child issues as tickets.
+
+- **Map**: an issue labelled `wayfinder:map`, holding Notes,
+  Decisions-so-far, and Fog.
+- **Child ticket**: a GitHub sub-issue linked to the map. Where sub-issues are
+  unavailable, use a map task list and put `Part of #<map>` in the child.
+- **Blocking**: use GitHub’s native issue dependencies. Where unavailable, put
+  `Blocked by: #<n>` at the top of the child.
+- **Frontier query**: select the first unassigned open child without an open
+  blocker.
+- **Claim**: `gh issue edit <n> --add-assignee @me`.
+- **Resolve**: comment with the answer, close the ticket, and append its context
+  pointer to the map.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,16 @@
+# Triage Labels
+
+The engineering skills use five canonical triage roles. This file maps those
+roles to this repository’s GitHub labels.
+
+| Canonical role    | GitHub label       | Meaning                                  |
+| ----------------- | ------------------ | ---------------------------------------- |
+| `needs-triage`    | `needs-triage`     | Maintainer needs to evaluate this issue  |
+| `needs-info`      | `needs-info`       | Waiting on reporter for more information |
+| `ready-for-agent` | `ready-for-agent`  | Fully specified, ready for an AFK agent  |
+| `ready-for-human` | `ready-for-human`  | Requires human implementation            |
+| `wontfix`         | `wontfix`          | Will not be actioned                     |
+
+When a skill mentions a canonical role, use the corresponding GitHub label
+from this table. Edit the right-hand column if the repository’s label
+vocabulary changes.


### PR DESCRIPTION
## What

Configure the repository conventions used by the engineering skills:
GitHub Issues, the default triage-label mapping, and a single-context domain
documentation layout.

## Why

Repository-aware skills need a shared source of truth for tracker operations,
triage states, terminology, and architecture decisions.

## Testing

- `mkdocs build --strict`
- `git diff --check`

## Notes

- No runtime, package, release, or public API behavior changes.
- `CONTEXT.md` and ADRs remain lazy artifacts created when needed.
