### PR TITLE
ci(release): harden package validation pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '04:00'
+      timezone: Europe/Budapest
+    groups:
+      github-actions:
+        patterns:
+          - '*'
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,9 @@ jobs:
           retention-days: 14
 
   required:
-    name: Required
+    # Preserve the protected-branch context while making it aggregate every
+    # authoritative validation job.
+    name: shellcheck + smoke test
     if: ${{ always() }}
     needs: [portable, docs, debian]
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,57 +5,155 @@ on:
     branches: [master]
   pull_request:
   workflow_dispatch:
+  workflow_call:
+    outputs:
+      package-artifact:
+        description: Name of the tested Debian package artifact
+        value: ${{ jobs.debian.outputs.artifact-name }}
+      package-sha256:
+        description: SHA-256 digest of the tested Debian package
+        value: ${{ jobs.debian.outputs.package-sha256 }}
 
 permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
-  lint:
-    name: shellcheck + smoke test
-    runs-on: ubuntu-latest
+  portable:
+    name: Portable lint and tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Install shellcheck
+      - name: Set up Go for actionlint
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.25.x'
+          cache: false
+
+      - name: Install lint tools
         run: |
-          command -v shellcheck >/dev/null || {
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends shellcheck
-          }
-          shellcheck --version
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends shellcheck
+          install -d "$RUNNER_TEMP/actionlint"
+          GOBIN="$RUNNER_TEMP/actionlint" \
+            go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+          printf '%s\n' "$RUNNER_TEMP/actionlint" >> "$GITHUB_PATH"
 
-      - run: make lint
+      - name: Lint
+        run: make lint
 
-      - run: make test
+      - name: Run portable tests
+        run: make test
+
+  docs:
+    name: Strict documentation
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
+
+      - name: Install documentation dependencies
+        run: pip install -r docs/requirements.txt
+
+      - name: Build documentation
+        run: mkdocs build --strict
 
   debian:
-    name: smoke test on debian 13 (pve target)
-    runs-on: ubuntu-latest
-    container: debian:13
+    name: Debian 13 package and repository
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    container: debian:13@sha256:6788062a1b42ac281f053ac876170b79a3eaed5d61383b8ed7eaca6c6965f3b1
+    outputs:
+      artifact-name: ${{ steps.package.outputs.artifact-name }}
+      package-sha256: ${{ steps.package.outputs.sha256 }}
     steps:
-      - name: Install build deps
+      - name: Install test and build dependencies
         run: |
           apt-get update
           apt-get install -y --no-install-recommends \
-            make git ca-certificates whiptail expect zsh curl jq rsync tar gzip \
-            build-essential debhelper devscripts gnupg reprepro
+            build-essential ca-certificates curl debhelper devscripts expect \
+            git gnupg jq make reprepro rsync shellcheck tar gzip whiptail zsh
 
-      - uses: actions/checkout@v4
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # TUI_TEST_REQUIRED turns a missing whiptail or expect into a failure
-      # rather than a skip. This is the job that has them, so the ui test has
-      # to run here; make test picks it up without a second pass.
-      - run: make test
+      - name: Build the Debian package once
+        id: package
+        run: |
+          version=$(<VERSION)
+          test "$version" = "$(dpkg-parsechangelog -S Version)"
+          dpkg-buildpackage --build=binary --no-sign
+
+          source_package="../pve-toolbox_${version}_all.deb"
+          test -f "$source_package"
+          install -d dist
+          package="$GITHUB_WORKSPACE/dist/pve-toolbox_${version}_all.deb"
+          install -m 0644 "$source_package" "$package"
+          sha256=$(sha256sum "$package" | awk '{print $1}')
+          printf '%s  %s\n' "$sha256" "${package##*/}" > dist/SHA256SUMS
+
+          {
+            printf 'artifact-name=pve-toolbox-deb-%s\n' "$GITHUB_SHA"
+            printf 'path=%s\n' "$package"
+            printf 'sha256=%s\n' "$sha256"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Test the exact Debian package
         env:
-          TUI_TEST_REQUIRED: "1"
-          ZSH_TEST_REQUIRED: "1"
-          # This job installs every runner dependency, so a skipped gate test
-          # here means a broken environment, not an absent one.
-          CB_GATE_TESTS_REQUIRED: "1"
-          PACKAGING_TEST_REQUIRED: "1"
-          PACKAGING_INSTALL_TEST_REQUIRED: "1"
-          REPOSITORY_TEST_REQUIRED: "1"
+          TUI_TEST_REQUIRED: '1'
+          ZSH_TEST_REQUIRED: '1'
+          CB_GATE_TESTS_REQUIRED: '1'
+          PACKAGING_TEST_REQUIRED: '1'
+          PACKAGING_INSTALL_TEST_REQUIRED: '1'
+          REPOSITORY_TEST_REQUIRED: '1'
+          PACKAGE_DEB: ${{ steps.package.outputs.path }}
+          PACKAGE_DEB_SHA256: ${{ steps.package.outputs.sha256 }}
+        run: make test
+
+      - name: Verify package digest after tests
+        run: (cd dist && sha256sum --check SHA256SUMS)
+
+      - name: Upload the tested Debian package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.package.outputs.artifact-name }}
+          path: |
+            dist/*.deb
+            dist/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 14
+
+  required:
+    name: Required
+    if: ${{ always() }}
+    needs: [portable, docs, debian]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require every validation job
+        env:
+          PORTABLE_RESULT: ${{ needs.portable.result }}
+          DOCS_RESULT: ${{ needs.docs.result }}
+          DEBIAN_RESULT: ${{ needs.debian.result }}
+        run: |
+          for result in "$PORTABLE_RESULT" "$DOCS_RESULT" "$DEBIAN_RESULT"; do
+            test "$result" = success
+          done

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,55 +1,71 @@
 name: Docs
 
 on:
-  push:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
     branches: [master]
-  pull_request:
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.ref == 'refs/heads/master' && 'pages' || format('docs-{0}', github.ref) }}
+  group: pages
   cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   build:
-    name: mkdocs build --strict
-    runs-on: ubuntu-latest
+    name: Build published site
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' ||
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/master'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
+      - name: Check out validated source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          python-version: '3.x'
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.13'
           cache: pip
           cache-dependency-path: docs/requirements.txt
 
-      - run: pip install -r docs/requirements.txt
+      - name: Install documentation dependencies
+        run: pip install -r docs/requirements.txt
 
-      # --strict turns broken internal links and nav typos into failures.
-      - run: mkdocs build --strict
+      - name: Build documentation
+        run: mkdocs build --strict
 
       - name: Preserve the published APT repository
-        if: github.ref == 'refs/heads/master'
         run: |
           if git ls-remote --exit-code --heads origin apt >/dev/null 2>&1; then
-            git clone --depth 1 --branch apt "${{ github.server_url }}/${{ github.repository }}.git" apt-repo
+            git clone --depth 1 --branch apt \
+              "${{ github.server_url }}/${{ github.repository }}.git" apt-repo
             mkdir -p site/apt
             rsync -a --exclude .git apt-repo/ site/apt/
           fi
 
-      - uses: actions/upload-pages-artifact@v3
-        if: github.ref == 'refs/heads/master'
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site
 
   deploy:
     name: GitHub Pages
-    if: github.ref == 'refs/heads/master'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       pages: write
       id-token: write
@@ -57,5 +73,6 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
-      - id: deploy
-        uses: actions/deploy-pages@v4
+      - name: Deploy Pages
+        id: deploy
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,17 +14,28 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   release:
     name: Build package and publish APT repository
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+
+      - name: Set up Go for actionlint
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.25.x'
+          cache: false
 
       - name: Install build tools
         run: |
@@ -33,6 +44,10 @@ jobs:
             build-essential debhelper devscripts expect gnupg reprepro shellcheck \
             python3-pip rsync whiptail zsh
           pip install -r docs/requirements.txt
+          install -d "$RUNNER_TEMP/actionlint"
+          GOBIN="$RUNNER_TEMP/actionlint" \
+            go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+          printf '%s\n' "$RUNNER_TEMP/actionlint" >> "$GITHUB_PATH"
 
       - name: Resolve release version
         run: |
@@ -145,9 +160,9 @@ jobs:
           mkdir -p site/apt
           rsync -a --exclude .git apt-repo/ site/apt/
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site
 
       - id: deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ FILES := pve-toolbox $(sort $(wildcard lib/*.sh)) $(sort $(wildcard modules/*/*.
 
 lint: syntax
 	@command -v shellcheck >/dev/null || { echo "shellcheck not installed: apt install shellcheck"; exit 1; }
+	@command -v actionlint >/dev/null || { echo "actionlint not installed: https://github.com/rhysd/actionlint"; exit 1; }
 	shellcheck -x -S warning $(FILES)
+	actionlint
 
 syntax:
 	@for f in $(FILES); do bash -n $$f && echo "ok  $$f"; done

--- a/README.md
+++ b/README.md
@@ -139,16 +139,18 @@ Full contract, helper reference and the Discord reporting API:
 
 ```bash
 make syntax    # bash -n everything
-make lint      # shellcheck everything
+make lint      # shellcheck scripts and actionlint workflows
 make test      # syntax + tests/ against throwaway dirs
 make test-tui  # drive `ui` through a pty, needs whiptail + expect
 ```
 
-CI runs these on every push and pull request, plus the tests again inside a
-`debian:13` container to match the PVE 9 host. The ui test skips wherever
-whiptail is missing, so in practice it runs in that container, where CI marks
-it required rather than skippable. The docs build with
-`mkdocs build --strict`, so a broken internal link fails the build.
+`make lint` requires
+[ShellCheck](https://www.shellcheck.net/) and
+[actionlint](https://github.com/rhysd/actionlint). CI runs the portable suite,
+strict documentation build, and complete Debian 13 package suite as separate
+jobs. One stable aggregate job requires all three. The Debian job builds one
+`.deb`, then passes that exact file through package, repository, APT download,
+and install checks. The ui test is required there rather than skippable.
 
 ```bash
 pip install -r docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ strict documentation build, and complete Debian 13 package suite as separate
 jobs. One stable aggregate job requires all three. The Debian job builds one
 `.deb`, then passes that exact file through package, repository, APT download,
 and install checks. The ui test is required there rather than skippable.
+Root-only package lifecycle and APT consumer checks run only when their
+required-gate variables are set, and must be used on a clean disposable host.
 
 ```bash
 pip install -r docs/requirements.txt

--- a/docs/apt-repository.md
+++ b/docs/apt-repository.md
@@ -125,9 +125,15 @@ release workflow can run from that tag, or be started manually from `master`.
 A manual run derives the tag from `VERSION` and refuses any other branch or an
 existing tag.
 
-The workflow requires every test group, including the terminal UI, both shell
-completions, config-backup gates, package lifecycle, and signed repository
-tests. It then builds the `.deb`, imports the dedicated
+CI requires the portable tests, strict documentation build, and complete
+Debian 13 suite through one stable aggregate check. The Debian job builds the
+`.deb` once, records its SHA-256 digest, verifies every runtime source is in
+the package, and carries those exact bytes through signed repository metadata,
+APT update, candidate selection, download, and installation.
+
+The release workflow requires every test group, including the terminal UI,
+both shell completions, config-backup gates, package lifecycle, and signed
+repository tests. It then builds the `.deb`, imports the dedicated
 signing subkey from the `APT_SIGNING_KEY` Actions secret, and verifies that it
 matches the public certificate committed at `keys/pve-toolbox.asc`. It updates
 the signed `trixie/main` repository on the `apt` branch, publishes both public

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -176,12 +176,13 @@ The per-module pages list the variables each one accepts.
 
 ```bash
 make syntax    # bash -n everything
-make lint      # shellcheck everything
+make lint      # shellcheck scripts and actionlint workflows
 make test      # syntax + tests/ against throwaway dirs
 make test-tui  # drive `ui` through a pty, needs whiptail + expect
 ```
 
-CI runs these on every push and pull request, plus the tests again inside a
-`debian:13` container to match the PVE 9 host. The ui test skips wherever
-whiptail is missing, so in practice it runs in that container, where CI marks
-it required rather than skippable.
+CI runs portable tests, the strict documentation build, and the complete
+Debian 13 package suite as separate jobs behind one aggregate required check.
+The Debian job requires the terminal UI and other dependency-sensitive tests,
+then validates one `.deb` through package inspection, signed repository
+creation, APT download, and installation.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -186,3 +186,5 @@ Debian 13 package suite as separate jobs behind one aggregate required check.
 The Debian job requires the terminal UI and other dependency-sensitive tests,
 then validates one `.deb` through package inspection, signed repository
 creation, APT download, and installation.
+The package lifecycle and APT consumer mutations are opt-in required gates for
+a clean disposable root environment; a normal `make test` does not run them.

--- a/docs/writing-a-module.md
+++ b/docs/writing-a-module.md
@@ -205,3 +205,6 @@ missing; `make test-tui` demands them instead. CI sets every required-test flag
 in its Debian 13 job. That job builds one `.deb` and supplies its path and
 SHA-256 digest to both the package and repository tests, including a real APT
 update, selection, download, and install.
+Those root-only lifecycle and APT consumer checks run only when their required
+gate variables are set. Run them on a clean disposable Debian 13 environment;
+they refuse existing toolbox package, binary, configuration, or state paths.

--- a/docs/writing-a-module.md
+++ b/docs/writing-a-module.md
@@ -194,12 +194,14 @@ make test
 
 `make lint` runs `shellcheck -x -S warning` over the launcher, `lib/*.sh`,
 every `modules/*/*.sh`, the bash completion and `tests/*.sh`, so a helper
-script you add is linted too. The zsh completion and `tests/tui.exp` are left
-out — neither is bash.
+script you add is linted too. It also runs `actionlint` over the GitHub Actions
+workflows. The zsh completion and `tests/tui.exp` are left out — neither is
+Bash.
 
 `make test` runs `tests/smoke.sh`, which drives the launcher in place and
 through a symlink against throwaway directories, then `tests/tui.sh`, which
 drives `ui` through a pty. The ui test skips where `expect` or `whiptail` is
-missing; `make test-tui` demands them instead. CI gets the same effect by
-setting `TUI_TEST_REQUIRED=1` on `make test` in the Debian job, which is the
-one that has them.
+missing; `make test-tui` demands them instead. CI sets every required-test flag
+in its Debian 13 job. That job builds one `.deb` and supplies its path and
+SHA-256 digest to both the package and repository tests, including a real APT
+update, selection, download, and install.

--- a/tests/package.sh
+++ b/tests/package.sh
@@ -153,6 +153,10 @@ if [[ ${PACKAGING_INSTALL_TEST_REQUIRED:-0} == 1 ]]; then
         | grep -q '^installed$'; then
         fail "refusing to replace an existing pve-toolbox package"
     fi
+    for path in /usr/bin/pve-toolbox /etc/pve-toolbox /var/lib/pve-toolbox; do
+        [[ ! -e $path && ! -L $path ]] \
+            || fail "refusing to replace an existing package path: $path"
+    done
     for dependency in curl jq; do
         dpkg-query -W -f='${db:Status-Status}' "$dependency" 2>/dev/null \
             | grep -q '^installed$' || fail "$dependency must be installed for the lifecycle test"

--- a/tests/package.sh
+++ b/tests/package.sh
@@ -27,10 +27,19 @@ fi
 WORK=$(mktemp -d)
 PACKAGE_TOUCHED=0
 cleanup() {
+    status=$?
+    trap - EXIT
     if [[ $PACKAGE_TOUCHED -eq 1 ]]; then
-        dpkg --purge pve-toolbox >/dev/null 2>&1 || true
+        if ! dpkg --purge pve-toolbox >/dev/null; then
+            printf 'FAIL could not purge pve-toolbox during cleanup\n' >&2
+            status=1
+        fi
     fi
-    rm -rf "$WORK"
+    if ! rm -rf -- "$WORK"; then
+        printf 'FAIL could not remove package-test workspace: %s\n' "$WORK" >&2
+        status=1
+    fi
+    exit "$status"
 }
 trap cleanup EXIT
 mkdir -p "$WORK/src"

--- a/tests/package.sh
+++ b/tests/package.sh
@@ -1,20 +1,24 @@
 #!/usr/bin/env bash
 # Build and inspect the Debian package without installing it on the test host.
-set -euo pipefail
+set -Eeuo pipefail
 
 cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
+ROOT=$PWD
 
 pass() { printf 'ok  %s\n' "$1"; }
 fail() { printf 'FAIL %s\n' "$1" >&2; exit 1; }
 
-for command in dpkg-buildpackage dpkg-deb; do
+commands=(dpkg-deb)
+[[ -n ${PACKAGE_DEB:-} ]] || commands+=(dpkg-buildpackage)
+[[ -z ${PACKAGE_DEB_SHA256:-} ]] || commands+=(sha256sum)
+for command in "${commands[@]}"; do
     if ! command -v "$command" >/dev/null 2>&1; then
         [[ ${PACKAGING_TEST_REQUIRED:-0} == 1 ]] && fail "$command is required"
         printf 'skip package test, no %s\n' "$command"
         exit 0
     fi
 done
-if ! dpkg-checkbuilddeps >/dev/null 2>&1; then
+if [[ -z ${PACKAGE_DEB:-} ]] && ! dpkg-checkbuilddeps >/dev/null 2>&1; then
     [[ ${PACKAGING_TEST_REQUIRED:-0} == 1 ]] && fail "Debian build dependencies are missing"
     printf 'skip package test, Debian build dependencies are missing\n'
     exit 0
@@ -30,40 +34,95 @@ cleanup() {
 }
 trap cleanup EXIT
 mkdir -p "$WORK/src"
-tar --exclude=.git --exclude=site --exclude='*.deb' -cf - . \
-    | tar -xf - -C "$WORK/src"
+if [[ -n ${PACKAGE_DEB:-} ]]; then
+    if [[ $PACKAGE_DEB == /* ]]; then
+        deb=$PACKAGE_DEB
+    else
+        deb="$ROOT/$PACKAGE_DEB"
+    fi
+    [[ -f $deb && ! -L $deb ]] || fail "prebuilt package is missing or unsafe: $deb"
+else
+    tar --exclude=.git --exclude=site --exclude='*.deb' -cf - . \
+        | tar -xf - -C "$WORK/src"
+    (cd "$WORK/src" && dpkg-buildpackage --build=binary --no-sign >/dev/null)
+    deb=$(find "$WORK" -maxdepth 1 -name 'pve-toolbox_*_all.deb' -print -quit)
+    [[ -n $deb ]] || fail "dpkg-buildpackage produced no architecture-all package"
+fi
 
-(cd "$WORK/src" && dpkg-buildpackage --build=binary --no-sign >/dev/null)
-deb=$(find "$WORK" -maxdepth 1 -name 'pve-toolbox_*_all.deb' -print -quit)
-[[ -n $deb ]] || fail "dpkg-buildpackage produced no architecture-all package"
+if [[ -n ${PACKAGE_DEB_SHA256:-} ]]; then
+    [[ $PACKAGE_DEB_SHA256 =~ ^[0-9a-f]{64}$ ]] \
+        || fail "PACKAGE_DEB_SHA256 is not a lowercase SHA-256 digest"
+    actual_sha=$(sha256sum "$deb" | awk '{print $1}')
+    [[ $actual_sha == "$PACKAGE_DEB_SHA256" ]] \
+        || fail "prebuilt package digest changed before package validation"
+fi
 
-contents=$(dpkg-deb --contents "$deb")
-for path in \
-    ./usr/bin/pve-toolbox \
-    ./usr/lib/pve-toolbox/lib/common.sh \
-    ./usr/lib/pve-toolbox/lib/doctor.sh \
-    ./usr/lib/pve-toolbox/lib/pve.sh \
-    ./usr/lib/pve-toolbox/lib/report.sh \
-    ./usr/lib/pve-toolbox/modules/backup-audit/module.sh \
-    ./usr/lib/pve-toolbox/modules/config-backup/module.sh \
-    ./usr/lib/pve-toolbox/modules/native-notifications/module.sh \
-    ./usr/lib/pve-toolbox/modules/native-notifications/pve-toolbox-native-notify \
-    ./usr/lib/pve-toolbox/modules/storage-hygiene/module.sh \
-    ./usr/lib/pve-toolbox/modules/certificate-watch/module.sh \
-    ./usr/lib/pve-toolbox/modules/upgrade-readiness/module.sh \
-    ./usr/lib/pve-toolbox/modules/upgrade-readiness/policies/pve-9.conf \
-    ./usr/lib/pve-toolbox/modules/restore-drill/module.sh \
-    ./usr/lib/pve-toolbox/modules/restore-drill/pve-toolbox-restore-drill \
-    ./usr/share/man/man1/pve-toolbox.1.gz \
-    ./usr/share/bash-completion/completions/pve-toolbox \
-    ./usr/share/zsh/vendor-completions/_pve-toolbox
-do
-    [[ $contents == *"$path"* ]] || fail "package omitted $path"
+mkdir "$WORK/control" "$WORK/root"
+dpkg-deb --control "$deb" "$WORK/control"
+dpkg-deb --extract "$deb" "$WORK/root"
+
+expected_manifest="$WORK/expected-runtime-manifest"
+actual_manifest="$WORK/actual-runtime-manifest"
+{
+    printf '%s\n' VERSION
+    for source in "$ROOT"/lib/*.sh; do
+        printf 'lib/%s\n' "${source##*/}"
+    done
+    while IFS= read -r -d '' source; do
+        printf '%s\n' "${source#"$ROOT/"}"
+    done < <(find "$ROOT/modules" -mindepth 2 -type f \
+        ! -path "$ROOT/modules/_*/*" -print0)
+} | LC_ALL=C sort > "$expected_manifest"
+find "$WORK/root/usr/lib/pve-toolbox" -type f -printf '%P\n' \
+    | LC_ALL=C sort > "$actual_manifest"
+cmp -s "$expected_manifest" "$actual_manifest" \
+    || fail "package runtime manifest differs from source"
+
+for source in "$ROOT"/lib/*.sh; do
+    target="$WORK/root/usr/lib/pve-toolbox/lib/${source##*/}"
+    cmp -s "$source" "$target" || fail "packaged lib/${source##*/} differs from source"
+    expected_mode=644
+    [[ -x $source ]] && expected_mode=755
+    [[ $(stat -c '%a' "$target") == "$expected_mode" ]] \
+        || fail "packaged lib/${source##*/} has the wrong mode"
 done
-[[ $contents != *'/modules/_template/'* ]] || fail "package shipped the module template"
-pass "package layout"
+while IFS= read -r -d '' source; do
+    relative=${source#"$ROOT/"}
+    target="$WORK/root/usr/lib/pve-toolbox/$relative"
+    cmp -s "$source" "$target" || fail "packaged $relative differs from source"
+    expected_mode=644
+    [[ -x $source ]] && expected_mode=755
+    [[ $(stat -c '%a' "$target") == "$expected_mode" ]] \
+        || fail "packaged $relative has the wrong mode"
+done < <(find "$ROOT/modules" -mindepth 2 -type f ! -path "$ROOT/modules/_*/*" -print0)
+for target in \
+    "$WORK/root/usr/bin/pve-toolbox" \
+    "$WORK/root/usr/share/man/man1/pve-toolbox.1.gz" \
+    "$WORK/root/usr/share/bash-completion/completions/pve-toolbox" \
+    "$WORK/root/usr/share/zsh/vendor-completions/_pve-toolbox"
+do
+    [[ -f $target ]] || fail "package omitted ${target#"$WORK/root"}"
+done
+cmp -s "$ROOT/pve-toolbox" "$WORK/root/usr/bin/pve-toolbox" \
+    || fail "packaged launcher differs from source"
+cmp -s "$ROOT/completions/pve-toolbox.bash" \
+    "$WORK/root/usr/share/bash-completion/completions/pve-toolbox" \
+    || fail "packaged Bash completion differs from source"
+cmp -s "$ROOT/completions/_pve-toolbox" \
+    "$WORK/root/usr/share/zsh/vendor-completions/_pve-toolbox" \
+    || fail "packaged Zsh completion differs from source"
+[[ $(<"$WORK/root/usr/lib/pve-toolbox/VERSION") == "$(<VERSION)" ]] \
+    || fail "packaged VERSION differs from source"
+[[ ! -e $WORK/root/usr/lib/pve-toolbox/modules/_template ]] \
+    || fail "package shipped the module template"
+pass "package layout matches every runtime source"
 
 control=$(dpkg-deb --field "$deb")
+expected_version=$(<VERSION)
+[[ $(dpkg-deb --field "$deb" Package) == pve-toolbox ]] \
+    || fail "package has the wrong name"
+[[ $(dpkg-deb --field "$deb" Version) == "$expected_version" ]] \
+    || fail "package version does not match VERSION"
 [[ $control == *'Architecture: all'* ]] || fail "package architecture is not all"
 [[ $control == *'Depends: curl, jq'* ]] || fail "hard dependencies are incomplete"
 [[ $control == *'Recommends: whiptail, zfsutils-linux'* ]] \
@@ -72,8 +131,6 @@ control=$(dpkg-deb --field "$deb")
     || fail "suggested dependencies are incomplete"
 pass "package metadata"
 
-mkdir "$WORK/control" "$WORK/root"
-dpkg-deb --control "$deb" "$WORK/control"
 [[ ! -e $WORK/control/conffiles ]] || fail "runtime config was declared as conffiles"
 grep -q '/usr/local/bin/pve-toolbox' "$WORK/control/postinst" \
     || fail "postinst does not warn about a shadowing checkout"
@@ -81,14 +138,12 @@ grep -q 'targets Debian 13 (trixie) / PVE 9' "$WORK/control/postinst" \
     || fail "postinst does not warn on unsupported hosts"
 grep -q '\[ "$1" = purge \]' "$WORK/control/postrm" \
     || fail "postrm does not distinguish purge from remove"
-dpkg-deb --extract "$deb" "$WORK/root"
 [[ $(stat -c '%a' "$WORK/root/etc/pve-toolbox") == 750 ]] \
     || fail "/etc/pve-toolbox is not mode 0750"
 [[ $(stat -c '%a' "$WORK/root/var/lib/pve-toolbox") == 755 ]] \
     || fail "/var/lib/pve-toolbox is not mode 0755"
 version=$(PVE_TOOLBOX_ROOT="$WORK/root/usr/lib/pve-toolbox" \
     "$WORK/root/usr/bin/pve-toolbox" --version)
-expected_version=$(<VERSION)
 [[ $version == "pve-toolbox $expected_version" ]] || fail "installed version is wrong: $version"
 pass "package runtime paths and lifecycle"
 

--- a/tests/repository.sh
+++ b/tests/repository.sh
@@ -119,12 +119,11 @@ gpgv --keyring "$repo/pve-toolbox.gpg" "$repo/dists/trixie/InRelease" \
     >/dev/null 2>&1 || fail "repository InRelease signature did not verify"
 pass "signed APT repository metadata"
 
-if [[ $EUID -ne 0 ]]; then
-    [[ ${REPOSITORY_TEST_REQUIRED:-0} == 1 ]] \
-        && fail "the required APT consumer test must run as root"
-    printf 'skip APT consumer test, root is required\n'
+if [[ ${REPOSITORY_TEST_REQUIRED:-0} != 1 ]]; then
+    printf 'skip APT consumer test, REPOSITORY_TEST_REQUIRED is not set\n'
     exit 0
 fi
+[[ $EUID -eq 0 ]] || fail "the required APT consumer test must run as root"
 for command in apt-get apt-cache dpkg dpkg-query; do
     command -v "$command" >/dev/null 2>&1 \
         || fail "$command is required for the APT consumer test"
@@ -133,6 +132,10 @@ if dpkg-query -W -f='${db:Status-Status}' pve-toolbox 2>/dev/null \
     | grep -q '^installed$'; then
     fail "refusing to replace an existing pve-toolbox package"
 fi
+for path in /usr/bin/pve-toolbox /etc/pve-toolbox /var/lib/pve-toolbox; do
+    [[ ! -e $path && ! -L $path ]] \
+        || fail "refusing to replace an existing package path: $path"
+done
 
 apt_root="$WORK/apt-consumer"
 source_file="$apt_root/pve-toolbox.sources"

--- a/tests/repository.sh
+++ b/tests/repository.sh
@@ -27,10 +27,19 @@ fi
 WORK=$(mktemp -d)
 PACKAGE_TOUCHED=0
 cleanup() {
+    status=$?
+    trap - EXIT
     if [[ $PACKAGE_TOUCHED -eq 1 ]]; then
-        dpkg --purge pve-toolbox >/dev/null 2>&1 || true
+        if ! dpkg --purge pve-toolbox >/dev/null; then
+            printf 'FAIL could not purge pve-toolbox during cleanup\n' >&2
+            status=1
+        fi
     fi
-    rm -rf "$WORK"
+    if ! rm -rf -- "$WORK"; then
+        printf 'FAIL could not remove repository-test workspace: %s\n' "$WORK" >&2
+        status=1
+    fi
+    exit "$status"
 }
 trap cleanup EXIT
 mkdir -p "$WORK/src"

--- a/tests/repository.sh
+++ b/tests/repository.sh
@@ -1,33 +1,65 @@
 #!/usr/bin/env bash
 # Build a package, publish it into an ephemeral signed repository, and verify it.
-set -euo pipefail
+set -Eeuo pipefail
 
 cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
+ROOT=$PWD
 
 pass() { printf 'ok  %s\n' "$1"; }
 fail() { printf 'FAIL %s\n' "$1" >&2; exit 1; }
 
-for command in dpkg-buildpackage gpg gpgv reprepro; do
+commands=(dpkg-deb gpg gpgv reprepro)
+[[ -n ${PACKAGE_DEB:-} ]] || commands+=(dpkg-buildpackage)
+[[ -z ${PACKAGE_DEB_SHA256:-} ]] || commands+=(sha256sum)
+for command in "${commands[@]}"; do
     if ! command -v "$command" >/dev/null 2>&1; then
         [[ ${REPOSITORY_TEST_REQUIRED:-0} == 1 ]] && fail "$command is required"
         printf 'skip repository test, no %s\n' "$command"
         exit 0
     fi
 done
-if ! dpkg-checkbuilddeps >/dev/null 2>&1; then
+if [[ -z ${PACKAGE_DEB:-} ]] && ! dpkg-checkbuilddeps >/dev/null 2>&1; then
     [[ ${REPOSITORY_TEST_REQUIRED:-0} == 1 ]] && fail "Debian build dependencies are missing"
     printf 'skip repository test, Debian build dependencies are missing\n'
     exit 0
 fi
 
 WORK=$(mktemp -d)
-trap 'rm -rf "$WORK"' EXIT
+PACKAGE_TOUCHED=0
+cleanup() {
+    if [[ $PACKAGE_TOUCHED -eq 1 ]]; then
+        dpkg --purge pve-toolbox >/dev/null 2>&1 || true
+    fi
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
 mkdir -p "$WORK/src"
-tar --exclude=.git --exclude=site --exclude='*.deb' -cf - . \
-    | tar -xf - -C "$WORK/src"
-(cd "$WORK/src" && dpkg-buildpackage --build=binary --no-sign >/dev/null)
-deb=$(find "$WORK" -maxdepth 1 -name 'pve-toolbox_*_all.deb' -print -quit)
-[[ -n $deb ]] || fail "package build produced no .deb"
+if [[ -n ${PACKAGE_DEB:-} ]]; then
+    if [[ $PACKAGE_DEB == /* ]]; then
+        deb=$PACKAGE_DEB
+    else
+        deb="$ROOT/$PACKAGE_DEB"
+    fi
+    [[ -f $deb && ! -L $deb ]] || fail "prebuilt package is missing or unsafe: $deb"
+else
+    tar --exclude=.git --exclude=site --exclude='*.deb' -cf - . \
+        | tar -xf - -C "$WORK/src"
+    (cd "$WORK/src" && dpkg-buildpackage --build=binary --no-sign >/dev/null)
+    deb=$(find "$WORK" -maxdepth 1 -name 'pve-toolbox_*_all.deb' -print -quit)
+    [[ -n $deb ]] || fail "package build produced no .deb"
+fi
+
+if [[ -n ${PACKAGE_DEB_SHA256:-} ]]; then
+    [[ $PACKAGE_DEB_SHA256 =~ ^[0-9a-f]{64}$ ]] \
+        || fail "PACKAGE_DEB_SHA256 is not a lowercase SHA-256 digest"
+    actual_sha=$(sha256sum "$deb" | awk '{print $1}')
+    [[ $actual_sha == "$PACKAGE_DEB_SHA256" ]] \
+        || fail "prebuilt package digest changed before repository validation"
+fi
+[[ $(dpkg-deb --field "$deb" Package) == pve-toolbox ]] \
+    || fail "repository test received the wrong package"
+[[ $(dpkg-deb --field "$deb" Version) == "$(<VERSION)" ]] \
+    || fail "repository package version does not match VERSION"
 
 export GNUPGHOME="$WORK/gnupg"
 mkdir -m 0700 "$GNUPGHOME"
@@ -83,4 +115,58 @@ cmp -s "$public_key" "$repo/pve-toolbox.asc" \
 gpgv --keyring "$repo/pve-toolbox.gpg" \
     "$repo/dists/trixie/Release.gpg" "$repo/dists/trixie/Release" \
     >/dev/null 2>&1 || fail "repository Release signature did not verify"
-pass "signed APT repository"
+gpgv --keyring "$repo/pve-toolbox.gpg" "$repo/dists/trixie/InRelease" \
+    >/dev/null 2>&1 || fail "repository InRelease signature did not verify"
+pass "signed APT repository metadata"
+
+if [[ $EUID -ne 0 ]]; then
+    [[ ${REPOSITORY_TEST_REQUIRED:-0} == 1 ]] \
+        && fail "the required APT consumer test must run as root"
+    printf 'skip APT consumer test, root is required\n'
+    exit 0
+fi
+for command in apt-get apt-cache dpkg dpkg-query; do
+    command -v "$command" >/dev/null 2>&1 \
+        || fail "$command is required for the APT consumer test"
+done
+if dpkg-query -W -f='${db:Status-Status}' pve-toolbox 2>/dev/null \
+    | grep -q '^installed$'; then
+    fail "refusing to replace an existing pve-toolbox package"
+fi
+
+apt_root="$WORK/apt-consumer"
+source_file="$apt_root/pve-toolbox.sources"
+mkdir -p "$apt_root/lists/partial" "$apt_root/cache/partial" "$apt_root/download"
+printf '%s\n' \
+    'Types: deb' \
+    "URIs: file:$repo" \
+    'Suites: trixie' \
+    'Components: main' \
+    'Architectures: amd64' \
+    "Signed-By: $repo/pve-toolbox.gpg" \
+    > "$source_file"
+apt_options=(
+    -o "Dir::Etc::sourcelist=$source_file"
+    -o Dir::Etc::sourceparts=-
+    -o "Dir::State::lists=$apt_root/lists"
+    -o "Dir::Cache::archives=$apt_root/cache"
+    -o APT::Get::List-Cleanup=0
+    -o APT::Sandbox::User=root
+)
+apt-get "${apt_options[@]}" update >/dev/null
+candidate=$(apt-cache "${apt_options[@]}" policy pve-toolbox \
+    | awk '$1 == "Candidate:" {print $2}')
+[[ $candidate == "$(<VERSION)" ]] || fail "APT selected unexpected candidate $candidate"
+(cd "$apt_root/download" && apt-get "${apt_options[@]}" download pve-toolbox >/dev/null)
+downloaded=$(find "$apt_root/download" -maxdepth 1 -type f -name 'pve-toolbox_*.deb' \
+    -print -quit)
+[[ -n $downloaded ]] || fail "APT did not download pve-toolbox"
+cmp -s "$deb" "$downloaded" || fail "APT downloaded bytes differ from the tested package"
+
+PACKAGE_TOUCHED=1
+apt-get "${apt_options[@]}" --no-install-recommends -y install pve-toolbox >/dev/null
+[[ $(/usr/bin/pve-toolbox --version) == "pve-toolbox $(<VERSION)" ]] \
+    || fail "APT installed an unexpected pve-toolbox version"
+dpkg --purge pve-toolbox >/dev/null
+PACKAGE_TOUCHED=0
+pass "APT update, policy, download, and install use the tested package"


### PR DESCRIPTION
## What

Consolidates pull-request validation behind one stable aggregate check and builds one Debian package on Debian 13 for exact-artifact package, repository, and APT consumer testing.

It also pins every GitHub Action by full SHA, adds actionlint, explicit job timeouts, and weekly Dependabot updates.

## Why

The package inspected by CI was not the same package later exercised by repository tests, and the only required branch check omitted Debian 13 and documentation validation.

## How

The Debian job records the package SHA-256 and passes the same file through a complete runtime manifest check, lifecycle tests, signed `InRelease` validation, and isolated APT update, policy, download, and install checks. The docs deployment now follows successful CI on `master` instead of duplicating pull-request validation.

## Testing

- `make lint`
- `mkdocs build --strict`
- Prebuilt package validation against the published `v0.4.1` `.deb`
- `git diff --check`
- `make test` was started locally but stopped at the root-only restore-drill test because passwordless `sudo` is unavailable; the required Debian 13 CI job runs the complete suite as root

## Notes

This changes CI and release workflow infrastructure. It does not change secrets, `VERSION`, or `debian/changelog`. Google Release Please, release-environment secrets, least-privilege publishing jobs, provenance, and APT version retention remain in the planned follow-up PR after this one merges.
