### PR TITLE
fix(release): verify signed APT repository metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,13 @@ on:
     inputs:
       release_as:
         description: Stable version to propose, for example 0.4.2
-        required: true
+        required: false
         type: string
+      repair_apt:
+        description: Re-sign and publish the latest stable APT repository
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -31,11 +36,12 @@ jobs:
       pull-requests: write
     outputs:
       release-created: ${{ steps.automatic.outputs.release_created || steps.manual.outputs.release_created }}
+      repair: ${{ steps.repair.outputs.repair }}
       prs-created: ${{ steps.automatic.outputs.prs_created || steps.manual.outputs.prs_created }}
       pr: ${{ steps.automatic.outputs.pr || steps.manual.outputs.pr }}
-      tag: ${{ steps.automatic.outputs.tag_name || steps.manual.outputs.tag_name }}
-      version: ${{ steps.automatic.outputs.version || steps.manual.outputs.version }}
-      sha: ${{ steps.automatic.outputs.sha || steps.manual.outputs.sha }}
+      tag: ${{ steps.automatic.outputs.tag_name || steps.manual.outputs.tag_name || steps.repair.outputs.tag }}
+      version: ${{ steps.automatic.outputs.version || steps.manual.outputs.version || steps.repair.outputs.version }}
+      sha: ${{ steps.automatic.outputs.sha || steps.manual.outputs.sha || steps.repair.outputs.sha }}
     steps:
       - name: Check out source
         if: github.event_name == 'workflow_dispatch'
@@ -44,7 +50,7 @@ jobs:
           fetch-depth: 0
 
       - name: Guard manual release request
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !inputs.repair_apt }}
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_AS: ${{ inputs.release_as }}
@@ -67,6 +73,31 @@ jobs:
             exit 1
           fi
 
+      - name: Resolve latest release for APT repair
+        if: github.event_name == 'workflow_dispatch' && inputs.repair_apt
+        id: repair
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_AS: ${{ inputs.release_as }}
+        run: |
+          test "$GITHUB_REF" = refs/heads/master
+          test -z "$RELEASE_AS"
+          latest=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest")
+          tag=$(jq -r '.tag_name // empty' <<< "$latest")
+          [[ $tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          version=${tag#v}
+          sha=$(git rev-list -n 1 "$tag")
+          ./scripts/verify-latest-release.sh "$tag" "$sha"
+          asset_names=$(jq -r '.assets[].name' <<< "$latest")
+          grep -Fxq "pve-toolbox_${version}_all.deb" <<< "$asset_names"
+          grep -Fxq SHA256SUMS <<< "$asset_names"
+          {
+            printf 'repair=true\n'
+            printf 'tag=%s\n' "$tag"
+            printf 'version=%s\n' "$version"
+            printf 'sha=%s\n' "$sha"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Run Release Please
         if: github.event_name == 'push'
         id: automatic
@@ -75,7 +106,7 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Run Release Please for requested version
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !inputs.repair_apt }}
         id: manual
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
@@ -206,7 +237,17 @@ jobs:
   publish-apt:
     name: Sign and publish APT repository
     needs: [release-please, build, attest]
-    if: needs.release-please.outputs.release-created == 'true'
+    if: |
+      always() &&
+      !cancelled() &&
+      (
+        (
+          needs.release-please.outputs.release-created == 'true' &&
+          needs.build.result == 'success' &&
+          needs.attest.result == 'success'
+        ) ||
+        needs.release-please.outputs.repair == 'true'
+      )
     outputs:
       apt-sha: ${{ steps.published-apt.outputs.sha }}
     runs-on: ubuntu-24.04
@@ -224,10 +265,26 @@ jobs:
           fetch-depth: 0
 
       - name: Download tested package
+        if: needs.release-please.outputs.release-created == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ needs.build.outputs.package-artifact }}
           path: dist
+
+      - name: Download published package for repair
+        if: needs.release-please.outputs.repair == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.release-please.outputs.tag }}
+          RELEASE_VERSION: ${{ needs.release-please.outputs.version }}
+        run: |
+          mkdir dist
+          package_name="pve-toolbox_${RELEASE_VERSION}_all.deb"
+          gh release download "$RELEASE_TAG" \
+            --pattern "$package_name" --pattern SHA256SUMS --dir dist
+          test -f "dist/$package_name"
+          test -f dist/SHA256SUMS
+          (cd dist && sha256sum --check SHA256SUMS)
 
       - name: Install repository tools
         run: |
@@ -241,14 +298,24 @@ jobs:
           RELEASE_SHA: ${{ needs.release-please.outputs.sha }}
           RELEASE_TAG: ${{ needs.release-please.outputs.tag }}
           RELEASE_VERSION: ${{ needs.release-please.outputs.version }}
+          REPAIR_MODE: ${{ needs.release-please.outputs.repair }}
         run: |
-          test "$RELEASE_SHA" = "$GITHUB_SHA"
           test "$RELEASE_TAG" = "v$RELEASE_VERSION"
-          test "$(<VERSION)" = "$RELEASE_VERSION"
-          test "$(dpkg-parsechangelog -S Version)" = "$RELEASE_VERSION"
+          test "$(git rev-list -n 1 "$RELEASE_TAG")" = "$RELEASE_SHA"
+          if [[ $REPAIR_MODE == true ]]; then
+            ./scripts/verify-latest-release.sh "$RELEASE_TAG" "$RELEASE_SHA"
+          else
+            test "$RELEASE_SHA" = "$GITHUB_SHA"
+            test "$(<VERSION)" = "$RELEASE_VERSION"
+            test "$(dpkg-parsechangelog -S Version)" = "$RELEASE_VERSION"
+          fi
           (cd dist && sha256sum --check SHA256SUMS)
           package="dist/pve-toolbox_${RELEASE_VERSION}_all.deb"
-          test "$(sha256sum "$package" | awk '{print $1}')" = "$EXPECTED_SHA256"
+          test "$(dpkg-deb --field "$package" Package)" = pve-toolbox
+          test "$(dpkg-deb --field "$package" Version)" = "$RELEASE_VERSION"
+          if [[ $REPAIR_MODE != true ]]; then
+            test "$(sha256sum "$package" | awk '{print $1}')" = "$EXPECTED_SHA256"
+          fi
 
       - name: Import repository signing key
         env:
@@ -284,6 +351,7 @@ jobs:
         env:
           RELEASE_TAG: ${{ needs.release-please.outputs.tag }}
           RELEASE_VERSION: ${{ needs.release-please.outputs.version }}
+          REPAIR_MODE: ${{ needs.release-please.outputs.repair }}
         run: |
           ./scripts/publish-apt-repo.sh \
             apt-repo "dist/pve-toolbox_${RELEASE_VERSION}_all.deb" \
@@ -295,7 +363,12 @@ jobs:
           if git -C apt-repo diff --cached --quiet; then
             printf 'APT repository already contains %s\n' "$RELEASE_TAG"
           else
-            git -C apt-repo commit -m "chore(repo): publish $RELEASE_TAG"
+            if [[ $REPAIR_MODE == true ]]; then
+              message="chore(repo): repair $RELEASE_TAG metadata"
+            else
+              message="chore(repo): publish $RELEASE_TAG"
+            fi
+            git -C apt-repo commit -m "$message"
             git -C apt-repo push origin HEAD:apt
           fi
 
@@ -410,16 +483,25 @@ jobs:
   pages-build:
     name: Assemble release Pages
     needs: [release-please, publish-apt, publish-release]
-    if: needs.release-please.outputs.release-created == 'true'
+    if: |
+      always() &&
+      !cancelled() &&
+      needs.publish-apt.result == 'success' &&
+      (
+        (
+          needs.release-please.outputs.release-created == 'true' &&
+          needs.publish-release.result == 'success'
+        ) ||
+        needs.release-please.outputs.repair == 'true'
+      )
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: read
     steps:
-      - name: Check out release source
+      - name: Check out workflow source and tags
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.release-please.outputs.sha }}
           fetch-depth: 0
 
       - name: Verify latest published release before assembly
@@ -429,19 +511,27 @@ jobs:
           RELEASE_TAG: ${{ needs.release-please.outputs.tag }}
         run: ./scripts/verify-latest-release.sh "$RELEASE_TAG" "$RELEASE_SHA"
 
+      - name: Check out release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.release-please.outputs.sha }}
+          path: release-source
+
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.13'
           cache: pip
-          cache-dependency-path: docs/requirements.txt
+          cache-dependency-path: release-source/docs/requirements.txt
 
       - name: Build documentation
+        working-directory: release-source
         run: |
           pip install -r docs/requirements.txt
           mkdocs build --strict
 
       - name: Include published APT repository
+        working-directory: release-source
         env:
           APT_SHA: ${{ needs.publish-apt.outputs.apt-sha }}
         run: |
@@ -458,12 +548,22 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          path: site
+          path: release-source/site
 
   pages-deploy:
     name: Deploy release Pages
     needs: [release-please, publish-release, pages-build]
-    if: needs.release-please.outputs.release-created == 'true'
+    if: |
+      always() &&
+      !cancelled() &&
+      needs.pages-build.result == 'success' &&
+      (
+        (
+          needs.release-please.outputs.release-created == 'true' &&
+          needs.publish-release.result == 'success'
+        ) ||
+        needs.release-please.outputs.repair == 'true'
+      )
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     concurrency:
@@ -477,10 +577,9 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
-      - name: Check out release source and tags
+      - name: Check out workflow source and tags
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.release-please.outputs.sha }}
           fetch-depth: 0
 
       - name: Verify latest published release before deployment

--- a/docs/apt-repository.md
+++ b/docs/apt-repository.md
@@ -137,6 +137,13 @@ new stable version such as `0.4.2`; the request fails if the version is not
 newer or its tag or GitHub Release already exists. It still creates a release
 pull request rather than bypassing review.
 
+To repair repository metadata for the current release, manually run the same
+workflow from `master`, leave `release_as` empty, and select `repair_apt`. The
+repair refuses any other branch or a simultaneous release request. It verifies
+the latest public stable tag and commit, downloads that release's exact `.deb`
+and SHA-256 manifest, then uses the protected signing environment to rebuild
+the repository metadata. It does not create a version, tag, or GitHub Release.
+
 CI requires the portable tests, strict documentation build, and complete
 Debian 13 suite through one stable aggregate check. The Debian job builds the
 `.deb` once, records its SHA-256 digest, verifies every runtime source is in
@@ -168,15 +175,19 @@ GitHub Release jobs.
 Rerunning a failed workflow is safe. The repository publisher stages and
 verifies complete metadata before changing the `apt` checkout, restores the
 previous contents if publication fails, accepts an identical version only when
-its bytes match, and rejects same-version substitutions. Pages runs only after
-the GitHub Release is public and verified. A Pages failure leaves that valid
-release published so the failed jobs can be rerun. An older release run cannot
-replace Pages after a newer stable release is public.
+its bytes match, and rejects same-version substitutions. Repository replacement
+compares file contents even when sizes and timestamps match, then verifies the
+published signatures and the signed size and SHA-256 of each package index. A
+mismatch fails the job and restores the previous repository before Git can push
+it. A repair deploys Pages from the exact repaired APT commit only after the
+target release is confirmed as the latest public stable release. A Pages
+failure leaves that valid release published so the failed jobs can be rerun. An
+older release run cannot replace Pages after a newer stable release is public.
 
 Verify a downloaded release package and its provenance with:
 
 ```bash
-gh attestation verify pve-toolbox_0.4.2_all.deb \
+gh attestation verify pve-toolbox_0.5.0_all.deb \
   --repo quwisky/pve-toolbox
 ```
 

--- a/scripts/publish-apt-repo.sh
+++ b/scripts/publish-apt-repo.sh
@@ -179,7 +179,8 @@ verify_repository() {
     local release_root="$repository/dists/trixie"
     local release="$release_root/Release"
     local keyring="$repository/pve-toolbox.gpg"
-    local entry expected_hash expected_size relative index
+    local verified_release="$work/verified-InRelease"
+    local required entry expected_hash expected_size relative index
     local actual_hash actual_size
     local packages_seen=0
     local packages_gz_seen=0
@@ -197,8 +198,18 @@ verify_repository() {
         printf 'repository Release signature did not verify\n' >&2
         return 1
     }
-    gpgv --keyring "$keyring" "$release_root/InRelease" >/dev/null 2>&1 || {
+    rm -f -- "$verified_release"
+    gpgv --keyring "$keyring" --output "$verified_release" \
+        "$release_root/InRelease" >/dev/null 2>&1 || {
         printf 'repository InRelease signature did not verify\n' >&2
+        return 1
+    }
+    cmp -s "$release" "$verified_release" || {
+        printf 'repository InRelease payload does not match Release\n' >&2
+        return 1
+    }
+    rm -f -- "$verified_release" || {
+        printf 'could not remove verified InRelease payload\n' >&2
         return 1
     }
 

--- a/scripts/publish-apt-repo.sh
+++ b/scripts/publish-apt-repo.sh
@@ -20,7 +20,7 @@ fail() {
 }
 
 for command in apt-ftparchive awk chmod cmp cp date dpkg-deb dpkg-scanpackages \
-    find gpg gpgv gzip install mktemp realpath rsync sort; do
+    find gpg gpgv gzip install mktemp realpath rsync sha256sum sort stat; do
     command -v "$command" >/dev/null 2>&1 || fail "$command is required"
 done
 [[ -f $deb && ! -L $deb ]] || fail "package is missing or unsafe: $deb"
@@ -147,6 +147,7 @@ mkdir -p "$index_dir"
 gzip -n -9 -c "$index_dir/Packages" > "$index_dir/Packages.gz"
 
 release_dir="$stage/dists/trixie"
+release_file="$work/Release"
 key_epoch=$(gpg --batch --with-colons --list-secret-keys "$fingerprint" \
     | awk -F: '$1 == "sec" { print $6; exit }')
 [[ $key_epoch =~ ^[0-9]+$ ]] || fail "signing key has no creation timestamp"
@@ -161,7 +162,8 @@ apt-ftparchive \
     -o APT::FTPArchive::Release::Components=main \
     -o "APT::FTPArchive::Release::Date=$release_date" \
     -o 'APT::FTPArchive::Release::Description=pve-toolbox packages for PVE 9 / Debian 13' \
-    release "$release_dir" > "$release_dir/Release"
+    release "$release_dir" > "$release_file"
+install -m 0644 "$release_file" "$release_dir/Release"
 gpg --batch --yes --faked-system-time "$release_epoch" \
     --local-user "$fingerprint" --clearsign \
     --output "$release_dir/InRelease" "$release_dir/Release"
@@ -171,21 +173,110 @@ gpg --batch --yes --faked-system-time "$release_epoch" \
 install -m 0644 "$public_key" "$stage/pve-toolbox.asc"
 gpg --batch --yes --dearmor \
     --output "$stage/pve-toolbox.gpg" "$public_key"
-gpgv --keyring "$stage/pve-toolbox.gpg" \
-    "$release_dir/Release.gpg" "$release_dir/Release" >/dev/null 2>&1 \
-    || fail "staged Release signature did not verify"
-gpgv --keyring "$stage/pve-toolbox.gpg" "$release_dir/InRelease" \
-    >/dev/null 2>&1 || fail "staged InRelease signature did not verify"
+
+verify_repository() {
+    local repository=$1
+    local release_root="$repository/dists/trixie"
+    local release="$release_root/Release"
+    local keyring="$repository/pve-toolbox.gpg"
+    local entry expected_hash expected_size relative index
+    local actual_hash actual_size
+    local packages_seen=0
+    local packages_gz_seen=0
+    local -a sha256_entries=()
+
+    for required in "$release" "$release_root/InRelease" \
+        "$release_root/Release.gpg" "$keyring"; do
+        [[ -f $required && ! -L $required ]] || {
+            printf 'repository metadata is missing or unsafe: %s\n' "$required" >&2
+            return 1
+        }
+    done
+    gpgv --keyring "$keyring" "$release_root/Release.gpg" "$release" \
+        >/dev/null 2>&1 || {
+        printf 'repository Release signature did not verify\n' >&2
+        return 1
+    }
+    gpgv --keyring "$keyring" "$release_root/InRelease" >/dev/null 2>&1 || {
+        printf 'repository InRelease signature did not verify\n' >&2
+        return 1
+    }
+
+    mapfile -t sha256_entries < <(awk '
+        $1 == "SHA256:" { in_sha256 = 1; next }
+        in_sha256 && /^[A-Z][A-Za-z0-9-]*:/ { in_sha256 = 0 }
+        in_sha256 && NF == 3 { print }
+    ' "$release")
+    [[ ${#sha256_entries[@]} -eq 2 ]] || {
+        printf 'repository Release has an unexpected SHA256 index set\n' >&2
+        return 1
+    }
+    for entry in "${sha256_entries[@]}"; do
+        read -r expected_hash expected_size relative <<< "$entry"
+        case "$relative" in
+            main/binary-amd64/Packages)
+                packages_seen=1
+                ;;
+            main/binary-amd64/Packages.gz)
+                packages_gz_seen=1
+                ;;
+            *)
+                printf 'repository Release references an unexpected index: %s\n' \
+                    "$relative" >&2
+                return 1
+                ;;
+        esac
+        [[ $expected_hash =~ ^[0-9a-fA-F]{64}$ \
+            && $expected_size =~ ^[0-9]+$ ]] || {
+            printf 'repository Release has invalid index metadata: %s\n' \
+                "$relative" >&2
+            return 1
+        }
+        index="$release_root/$relative"
+        [[ -f $index && ! -L $index ]] || {
+            printf 'repository index is missing or unsafe: %s\n' "$index" >&2
+            return 1
+        }
+        actual_hash=$(sha256sum "$index" | awk '{print $1}')
+        actual_size=$(stat -c %s "$index")
+        [[ ${expected_hash,,} == "$actual_hash" \
+            && $expected_size == "$actual_size" ]] || {
+            printf 'repository Release does not match index: %s\n' "$relative" >&2
+            return 1
+        }
+    done
+    [[ $packages_seen -eq 1 && $packages_gz_seen -eq 1 ]] || {
+        printf 'repository Release omits a required package index\n' >&2
+        return 1
+    }
+}
+
+verify_repository "$stage" || fail "staged repository metadata did not verify"
+
+restore_repository() {
+    if [[ $repo_exists -eq 0 ]]; then
+        rm -rf -- "$repo_abs"
+    else
+        rsync -a --checksum --delete --exclude '.git/' "$backup/" "$repo_abs/"
+    fi
+}
 
 if [[ $repo_exists -eq 0 ]]; then
     mkdir -- "$repo_abs"
 else
-    rsync -a --exclude '.git/' "$repo_abs/" "$backup/"
+    rsync -a --checksum --exclude '.git/' "$repo_abs/" "$backup/"
 fi
-if ! rsync -a --delete --exclude '.git/' "$stage/" "$repo_abs/"; then
+if ! rsync -a --checksum --delete --exclude '.git/' "$stage/" "$repo_abs/"; then
     printf 'error: repository update failed; restoring previous contents\n' >&2
-    if ! rsync -a --delete --exclude '.git/' "$backup/" "$repo_abs/"; then
+    if ! restore_repository; then
         fail "repository update and rollback both failed"
     fi
     fail "repository update failed and was rolled back"
+fi
+if ! verify_repository "$repo_abs"; then
+    printf 'error: published repository validation failed; restoring previous contents\n' >&2
+    if ! restore_repository; then
+        fail "repository validation and rollback both failed"
+    fi
+    fail "repository validation failed and was rolled back"
 fi

--- a/tests/release.sh
+++ b/tests/release.sh
@@ -52,6 +52,7 @@ pages_writers=$(grep -El '^[[:space:]]+pages: write$' \
     || fail "release.yml must contain exactly one Pages deployment"
 
 publish_release_job=$(workflow_job publish-release)
+publish_apt_job=$(workflow_job publish-apt)
 pages_build_job=$(workflow_job pages-build)
 pages_deploy_job=$(workflow_job pages-deploy)
 grep -Fqx '    needs: [release-please, build, attest, publish-apt]' \
@@ -64,12 +65,24 @@ grep -Fqx '    needs: [release-please, publish-release, pages-build]' \
     <<< "$pages_deploy_job" \
     || fail "Pages deployment does not require a published release"
 [[ $(grep -Fc './scripts/verify-latest-release.sh "$RELEASE_TAG" "$RELEASE_SHA"' \
-    .github/workflows/release.yml) -eq 3 ]] \
+    .github/workflows/release.yml) -eq 4 ]] \
     || fail "release and Pages jobs do not share the latest-release guard"
 grep -Fq 'APT_SHA: ${{ needs.publish-apt.outputs.apt-sha }}' \
     <<< "$pages_build_job" \
     || fail "Pages does not consume the release APT repository commit"
-pass "Pages publication is release-only and ordered after publication"
+grep -Fq "needs.release-please.outputs.repair == 'true'" \
+    <<< "$publish_apt_job" \
+    || fail "APT publisher does not accept an explicit repair request"
+grep -Fq 'gh release download "$RELEASE_TAG"' <<< "$publish_apt_job" \
+    || fail "APT repair does not use published release assets"
+[[ $(grep -Fc './scripts/publish-apt-repo.sh' <<< "$publish_apt_job") -eq 1 ]] \
+    || fail "APT repair does not use the verified repository publisher"
+grep -Fq 'repair_apt:' .github/workflows/release.yml \
+    || fail "release workflow does not expose the APT repair input"
+grep -Fq "needs.release-please.outputs.repair == 'true'" \
+    <<< "$pages_build_job$pages_deploy_job" \
+    || fail "Pages does not deploy a repaired APT repository"
+pass "Pages publication and guarded APT repair preserve release ordering"
 
 WORK=$(mktemp -d)
 cleanup() {

--- a/tests/repository.sh
+++ b/tests/repository.sh
@@ -239,9 +239,7 @@ source=${args[$((${#args[@]} - 2))]}
 destination=${args[$((${#args[@]} - 1))]}
 if [[ ${source%/} == */stage && ${destination%/} == "$PUBLISH_VALIDATION_REPO" ]]; then
     "$REAL_RSYNC" \
-        --exclude dists/trixie/Release \
         --exclude dists/trixie/InRelease \
-        --exclude dists/trixie/Release.gpg \
         "$@"
 else
     "$REAL_RSYNC" "$@"

--- a/tests/repository.sh
+++ b/tests/repository.sh
@@ -102,18 +102,41 @@ repo="$WORK/repository"
 ./scripts/publish-apt-repo.sh \
     "$repo" "$deb" "$fingerprint" "$public_key" 3 >/dev/null
 snapshot_repository() {
-    local output=$1
-    find "$repo" -path "$repo/.git" -prune -o -type f -exec sha256sum {} + \
-        | sort > "$output"
+    local repository=$1
+    local output=$2
+    (
+        cd "$repository"
+        find . -path ./.git -prune -o -type f -exec sha256sum {} + | sort
+    ) > "$output"
+}
+
+verify_release_indexes() {
+    local repository=$1
+    local release="$repository/dists/trixie/Release"
+    local relative index expected actual
+
+    for relative in \
+        main/binary-amd64/Packages \
+        main/binary-amd64/Packages.gz; do
+        index="$repository/dists/trixie/$relative"
+        expected=$(awk -v target="$relative" '
+            $1 == "SHA256:" { in_sha256 = 1; next }
+            in_sha256 && /^[A-Z][A-Za-z0-9-]*:/ { in_sha256 = 0 }
+            in_sha256 && $3 == target { print $1, $2; exit }
+        ' "$release")
+        actual="$(sha256sum "$index" | awk '{print $1}') $(stat -c %s "$index")"
+        [[ -n $expected && $expected == "$actual" ]] \
+            || fail "Release metadata does not match $relative"
+    done
 }
 # A workflow retry after the APT branch was pushed must be a no-op, not a
 # blocker that prevents the GitHub Release or Pages steps from running.
-snapshot_repository "$WORK/repository-before-retry"
+snapshot_repository "$repo" "$WORK/repository-before-retry"
 sleep 1
 ./scripts/publish-apt-repo.sh \
     "$repo" "$deb" "$fingerprint" "$public_key" 3 >/dev/null \
     || fail "repository publisher rejected an identical retry"
-snapshot_repository "$WORK/repository-after-retry"
+snapshot_repository "$repo" "$WORK/repository-after-retry"
 cmp -s "$WORK/repository-before-retry" "$WORK/repository-after-retry" \
     || fail "identical repository retry changed published bytes"
 mkdir -p "$WORK/conflicting-package"
@@ -122,12 +145,12 @@ mkdir -p "$WORK/conflicting-package/usr/share/pve-toolbox"
 printf 'different build\n' > "$WORK/conflicting-package/usr/share/pve-toolbox/retry-conflict"
 conflicting_deb="$WORK/conflicting.deb"
 dpkg-deb --build "$WORK/conflicting-package" "$conflicting_deb" >/dev/null
-snapshot_repository "$WORK/repository-before-conflict"
+snapshot_repository "$repo" "$WORK/repository-before-conflict"
 if ./scripts/publish-apt-repo.sh \
     "$repo" "$conflicting_deb" "$fingerprint" "$public_key" 3 >/dev/null 2>&1; then
     fail "repository publisher replaced an existing version with different bytes"
 fi
-snapshot_repository "$WORK/repository-after-conflict"
+snapshot_repository "$repo" "$WORK/repository-after-conflict"
 cmp -s "$WORK/repository-before-conflict" "$WORK/repository-after-conflict" \
     || fail "conflicting repository publication changed published bytes"
 [[ -s $repo/dists/trixie/main/binary-amd64/Packages.gz ]] \
@@ -144,6 +167,103 @@ gpgv --keyring "$repo/pve-toolbox.gpg" "$repo/dists/trixie/InRelease" \
     >/dev/null 2>&1 || fail "repository InRelease signature did not verify"
 pass "signed APT repository metadata"
 
+# A freshly cloned repository and newly generated metadata can have identical
+# timestamps and sizes even when their contents differ. Reproduce that
+# filesystem state at the publisher boundary rather than relying on timing.
+collision_repo="$WORK/timestamp-collision-repository"
+cp -a -- "$repo" "$collision_repo"
+collision_root="$WORK/timestamp-collision-package"
+dpkg-deb --raw-extract "$deb" "$collision_root"
+sed -i 's/^Version: .*/Version: 0.5.1/' "$collision_root/DEBIAN/control"
+printf '%s\n' 0.5.1 > "$collision_root/usr/lib/pve-toolbox/VERSION"
+collision_deb="$WORK/pve-toolbox_0.5.1_all.deb"
+dpkg-deb --build "$collision_root" "$collision_deb" >/dev/null
+
+collision_bin="$WORK/timestamp-collision-bin"
+mkdir "$collision_bin"
+cat > "$collision_bin/apt-ftparchive" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+"$REAL_APT_FTPARCHIVE" "$@"
+touch -r "$PUBLISH_COLLISION_REPO/dists/trixie/Release" /proc/self/fd/1
+EOF
+cat > "$collision_bin/gpg" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+args=("$@")
+output=
+for ((index = 0; index < ${#args[@]}; index++)); do
+    if [[ ${args[$index]} == --output ]]; then
+        output=${args[$((index + 1))]}
+        break
+    fi
+done
+"$REAL_GPG" "$@"
+if [[ -n $output ]]; then
+    published="$PUBLISH_COLLISION_REPO/dists/trixie/${output##*/}"
+    [[ ! -f $published ]] || touch -r "$published" "$output"
+fi
+EOF
+chmod +x "$collision_bin/apt-ftparchive" "$collision_bin/gpg"
+
+real_apt_ftparchive=$(command -v apt-ftparchive)
+real_gpg=$(command -v gpg)
+PATH="$collision_bin:$PATH" \
+REAL_APT_FTPARCHIVE="$real_apt_ftparchive" \
+REAL_GPG="$real_gpg" \
+PUBLISH_COLLISION_REPO="$collision_repo" \
+    ./scripts/publish-apt-repo.sh \
+    "$collision_repo" "$collision_deb" "$fingerprint" "$public_key" 3 \
+    >/dev/null
+verify_release_indexes "$collision_repo"
+gpgv --keyring "$collision_repo/pve-toolbox.gpg" \
+    "$collision_repo/dists/trixie/Release.gpg" \
+    "$collision_repo/dists/trixie/Release" >/dev/null 2>&1 \
+    || fail "timestamp collision left an invalid detached Release signature"
+gpgv --keyring "$collision_repo/pve-toolbox.gpg" \
+    "$collision_repo/dists/trixie/InRelease" >/dev/null 2>&1 \
+    || fail "timestamp collision left an invalid InRelease signature"
+pass "APT publication replaces same-size metadata with matching timestamps"
+
+validation_repo="$WORK/post-copy-validation-repository"
+cp -a -- "$repo" "$validation_repo"
+snapshot_repository "$validation_repo" \
+    "$WORK/validation-repository-before-failure"
+validation_bin="$WORK/post-copy-validation-bin"
+mkdir "$validation_bin"
+cat > "$validation_bin/rsync" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+args=("$@")
+source=${args[$((${#args[@]} - 2))]}
+destination=${args[$((${#args[@]} - 1))]}
+if [[ ${source%/} == */stage && ${destination%/} == "$PUBLISH_VALIDATION_REPO" ]]; then
+    "$REAL_RSYNC" \
+        --exclude dists/trixie/Release \
+        --exclude dists/trixie/InRelease \
+        --exclude dists/trixie/Release.gpg \
+        "$@"
+else
+    "$REAL_RSYNC" "$@"
+fi
+EOF
+chmod +x "$validation_bin/rsync"
+real_rsync=$(command -v rsync)
+if PATH="$validation_bin:$PATH" \
+    REAL_RSYNC="$real_rsync" \
+    PUBLISH_VALIDATION_REPO="$validation_repo" \
+        ./scripts/publish-apt-repo.sh \
+        "$validation_repo" "$collision_deb" "$fingerprint" "$public_key" 3 \
+        >/dev/null 2>&1; then
+    fail "publisher accepted mismatched metadata after repository update"
+fi
+snapshot_repository "$validation_repo" \
+    "$WORK/validation-repository-after-failure"
+cmp -s "$WORK/validation-repository-before-failure" \
+    "$WORK/validation-repository-after-failure" \
+    || fail "publisher did not roll back a mismatched repository update"
+pass "APT publication validates final metadata and rolls back mismatches"
+
 retention_repo="$WORK/retention-repository"
 for retained_version in 0.4.0 0.4.1 0.4.2 0.4.3; do
     package_root="$WORK/package-$retained_version"
@@ -157,6 +277,7 @@ for retained_version in 0.4.0 0.4.1 0.4.2 0.4.3; do
     ./scripts/publish-apt-repo.sh \
         "$retention_repo" "$retained_deb" "$fingerprint" "$public_key" 3 >/dev/null
 done
+verify_release_indexes "$retention_repo"
 retained_packages=$(gzip -dc \
     "$retention_repo/dists/trixie/main/binary-amd64/Packages.gz")
 mapfile -t retained_versions < <(


### PR DESCRIPTION
## What

Regenerate and validate signed APT metadata from the final package indexes, including byte-for-byte agreement between `InRelease` and `Release`. Add a guarded repair mode that republishes the latest stable repository and deploys Pages from its exact APT commit.

## Why

The v0.5.0 package indexes were published while same-size, same-timestamp signed metadata remained stale, so APT clients could not see the release.

Closes #44

## How

Repository replacement now compares file contents, validates hashes, sizes, both signatures, and the clear-signed payload after copying, and rolls back any mismatch. Manual repair reuses the latest public release assets through the protected signing job without creating a new version or release.

## Testing

- `make lint` in Debian 13 with ShellCheck and actionlint
- Complete required Debian 13 `make test` suite with TUI, Zsh, circuit-breaker, packaging, install, and repository gates enabled
- Real APT update, candidate selection, download, install, and purge validation
- `mkdocs build --strict` with Python 3.13
- Independent standards and issue-spec reviews; no remaining findings

## Notes

This changes release infrastructure and uses the existing protected `APT_SIGNING_KEY`; no secret values or signing material changed. After merge, run the Release workflow from `master` with `repair_apt=true` and an empty `release_as` to repair v0.5.0 and redeploy Pages. The root-run suite skips two chmod-000 permission fixtures because root can still read them; all required gate scripts ran.
