### PR TITLE
test(release): derive repository fixture version

### DIFF
--- a/tests/repository.sh
+++ b/tests/repository.sh
@@ -174,9 +174,12 @@ collision_repo="$WORK/timestamp-collision-repository"
 cp -a -- "$repo" "$collision_repo"
 collision_root="$WORK/timestamp-collision-package"
 dpkg-deb --raw-extract "$deb" "$collision_root"
-sed -i 's/^Version: .*/Version: 0.5.1/' "$collision_root/DEBIAN/control"
-printf '%s\n' 0.5.1 > "$collision_root/usr/lib/pve-toolbox/VERSION"
-collision_deb="$WORK/pve-toolbox_0.5.1_all.deb"
+collision_version=$(awk -F. '{printf "%d.%d.%d\n", $1, $2, $3 + 1}' VERSION)
+sed -i "s/^Version: .*/Version: $collision_version/" \
+    "$collision_root/DEBIAN/control"
+printf '%s\n' "$collision_version" \
+    > "$collision_root/usr/lib/pve-toolbox/VERSION"
+collision_deb="$WORK/pve-toolbox_${collision_version}_all.deb"
 dpkg-deb --build "$collision_root" "$collision_deb" >/dev/null
 
 collision_bin="$WORK/timestamp-collision-bin"


### PR DESCRIPTION
## What

Derive the synthetic repository package version by incrementing the version under test instead of hardcoding `0.5.1`.

## Why

The Release Please `0.5.1` branch built the real package and the timestamp-collision fixture with the same version but different bytes. The publisher correctly rejected that substitution, causing CI run 33793511598 to fail.

## Testing

- Reproduced the failure with `tests/repository.sh` at failing SHA `c31cb268`
- Re-ran that exact `0.5.1` checkout with the patch; repository test passed
- `make lint` passed on the patched `0.5.1` checkout
- Complete required Debian 13 `make test` suite passed on the patched `0.5.1` checkout

## Notes

The root-run suite skips two chmod-000 permission fixtures because root can still read them; all required gate scripts ran. No release version, workflow, package, or runtime behavior changes.

Refs #44
