### PR TITLE
feat(lxc-update): schedule automatic container updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ test: syntax
 	@./tests/certificate-watch.sh
 	@./tests/upgrade-readiness.sh
 	@./tests/restore-drill.sh
+	@./tests/lxc-schedule.sh
 	@./tests/lxc-update.sh
 	@./tests/discord.sh
 	@./tests/config-backup.sh

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pve-toolbox/
 │   ├── backup-audit/        # read-only guest backup protection and freshness audit
 │   ├── certificate-watch/   # read-only cluster TLS and ACME health audit
 │   ├── config-backup/       # snapshots /etc/pve and host config, reported to Discord
-│   ├── lxc-update/          # confirmed Debian/Ubuntu container package updates
+│   ├── lxc-update/          # confirmed or scheduled container package updates
 │   ├── native-notifications/ # owned native PVE targets, matchers, and shared sender
 │   ├── restore-drill/       # guarded isolated backup restore validation
 │   ├── scrutiny-collectors/ # SMART/ZFS/MDADM collectors for a remote Scrutiny
@@ -90,7 +90,9 @@ Flags: `-y` non-interactive (modules read their env vars instead of prompting),
 Use `pve-toolbox lxc-update --dry-run` as root on PVE 9 to preview container
 package updates. Execution requires a terminal and confirmation; `--allow-removals`
 enables removals and cleanup, and `--notify` sends an optional Discord summary.
-Configure exclusions and the webhook with `pve-toolbox install lxc-update`.
+Configure exclusions, the webhook, and optional automatic updates with
+`pve-toolbox install lxc-update`. Automatic updates use a node-local systemd
+timer and always keep the non-removing package policy.
 See [LXC package updates](docs/modules/lxc-update.md) for safeguards and limitations.
 
 `doctor` checks cluster quorum, failed units, ZFS pools, Proxmox storage,
@@ -112,7 +114,7 @@ without regenerating anything. See
 | --- | --- |
 | [backup-audit](https://quwisky.github.io/pve-toolbox/modules/backup-audit/) | Finds uncovered guests, stale or failed backups, excluded volumes, weak retention, and unhealthy backup storage |
 | [certificate-watch](https://quwisky.github.io/pve-toolbox/modules/certificate-watch/) | Checks cluster TLS expiry, hostname coverage, chains, reachability, and ACME task history |
-| [lxc-update](https://quwisky.github.io/pve-toolbox/modules/lxc-update/) | Updates local running Debian/Ubuntu containers with confirmation, exclusions, previews, and optional Discord reporting |
+| [lxc-update](https://quwisky.github.io/pve-toolbox/modules/lxc-update/) | Updates local running Debian/Ubuntu containers through confirmed runs or an opt-in safe schedule, with exclusions, previews, and optional Discord reporting |
 | [config-backup](https://quwisky.github.io/pve-toolbox/modules/config-backup/) | Snapshots `/etc/pve` and host config into verified tar.gz archives on a timer |
 | [native-notifications](https://quwisky.github.io/pve-toolbox/modules/native-notifications/) | Provisions owned PVE notification targets and matchers with protected credentials and rollback |
 | [restore-drill](https://quwisky.github.io/pve-toolbox/modules/restore-drill/) | Plans and explicitly runs isolated, ownership-checked VM or container restore drills |

--- a/debian/pve-toolbox.1
+++ b/debian/pve-toolbox.1
@@ -39,6 +39,11 @@ root and interactive confirmation. Use --dry-run for a cached preview,
 --allow-removals to enable package removals and cleanup, and --notify for
 a Discord report. Saved exclusions always apply. No automatic reboots,
 backups, rollback, or distribution upgrades. Package scripts may restart services.
+Use "pve-toolbox install lxc-update" to configure an optional node-local
+systemd schedule. Scheduled runs update every eligible local container with
+the non-removing policy, never catch up after downtime, and can report every
+batch to Discord when explicitly enabled. Use "pve-toolbox status lxc-update"
+to inspect timer health and recent results.
 .TP
 .B uninstall module ...
 Remove modules after confirmation.

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -8,7 +8,7 @@ launcher discovers them at runtime; directories starting with `_` are skipped.
 | [backup-audit](backup-audit.md) | `backup audit monitoring` | yes | none; contributes doctor checks |
 | [certificate-watch](certificate-watch.md) | `monitoring tls certificate acme notify` | yes | none; contributes doctor checks |
 | [config-backup](config-backup.md) | `backup config notify` | yes | `pve-config-backup` |
-| [lxc-update](lxc-update.md) | `lxc upgrade apt notify` | yes | none; dedicated launcher command |
+| [lxc-update](lxc-update.md) | `lxc upgrade apt notify schedule` | yes | `pve-toolbox-lxc-update` when scheduled |
 | [native-notifications](native-notifications.md) | `monitoring notify webhook smtp gotify` | yes | `pve-toolbox-native-notify` |
 | [restore-drill](restore-drill.md) | `backup restore audit isolation notify` | yes | `pve-toolbox-restore-drill` |
 | [storage-hygiene](storage-hygiene.md) | `storage audit monitoring zfs lvm` | yes | none; contributes doctor checks |

--- a/docs/modules/lxc-update.md
+++ b/docs/modules/lxc-update.md
@@ -1,15 +1,16 @@
 # LXC package updates
 
 `pve-toolbox lxc-update` updates packages inside running Debian and Ubuntu LXC
-containers on the **local PVE 9 host**. It is a manual maintenance command;
-ordinary `pve-toolbox update` only updates toolkit modules.
+containers on the **local PVE 9 host**. Updates can be confirmed manually or
+explicitly scheduled. Ordinary `pve-toolbox update` only updates toolkit
+modules and never starts guest maintenance.
 
 ## Run
 
 Run these commands **as root on the PVE host**:
 
 ```bash
-# Optional: configure saved exclusions and a Discord webhook.
+# Configure exclusions, a Discord webhook and optional automatic updates.
 pve-toolbox install lxc-update
 
 # Read-only guest preview using cached indexes, which may be stale.
@@ -26,16 +27,63 @@ pve-toolbox lxc-update --allow-removals
 
 # Request one final Discord report (requires a configured webhook).
 pve-toolbox lxc-update --notify
+
+# Inspect schedule health, next and previous runs, and the retained report.
+pve-toolbox status lxc-update
+
+# Explicitly test an enabled automatic-update service now.
+systemctl start pve-toolbox-lxc-update.service
 ```
 
 Flags may be combined. `--yes` and `--force` cannot authorize execution;
 a terminal and explicit confirmation are required. `--json` and `--quiet`
 remain limited to the existing read-only reporting commands.
 
-The plain menu has an `l` action. The full-screen menu has **Update LXC container
-packages**, with preview selected by default and removals/Discord unchecked.
-Enter optional IDs after selecting the options; leaving the field empty selects
-all eligible guests. Package execution asks for confirmation once.
+The plain menu has an `l` action for manual updates and an `a` action for
+automatic-update configuration. The full-screen menu has separate **Update LXC
+container packages** and **Configure automatic LXC updates** actions. Manual
+updates default to a preview with removals and Discord unchecked. Enter optional
+IDs after selecting the options; leaving the field empty selects all eligible
+guests. Package execution asks for confirmation once.
+
+## Automatic schedule
+
+Automatic updates are disabled until an operator enables them through
+`pve-toolbox install lxc-update` or either menu. Configuration offers daily and
+weekly presets plus a custom systemd `OnCalendar` expression. The suggested
+schedule is Sunday at 04:00 in the host's local timezone.
+
+One host timer runs one sequential batch over all currently eligible local
+containers, honoring the saved exclusions. Configure every PVE node separately;
+the service never enters containers on another node. New eligible containers are
+included on later runs without reconfiguration.
+
+The timer adds a random delay of up to 30 minutes so separately configured PVE
+nodes do not all begin together. It does not catch up after host downtime and
+does not start an update when first enabled. Use the explicit `systemctl start`
+command above when an immediate test is wanted.
+
+The service uses an installed runner, guest helper, and shared toolbox
+libraries, so it does not depend on the source checkout remaining in place.
+
+Scheduled runs always use the default non-removing upgrade policy. They cannot
+accept container IDs, previews, `--allow-removals`, or `--notify`. The configured
+service is the only unattended path; ordinary command-line execution continues
+to require a terminal and confirmation. Automatic Discord reporting is a
+separate opt-in setting and sends one final report for every scheduled batch.
+
+Useful service commands, run as root, are:
+
+```bash
+systemctl list-timers pve-toolbox-lxc-update.timer
+journalctl -u pve-toolbox-lxc-update.service
+systemctl start pve-toolbox-lxc-update.service
+```
+
+Reconfigure the module and answer **No** to automatic updates to disable future
+runs. This removes the service and timer while keeping exclusions, webhook
+configuration, the saved calendar, the scheduled notification preference and
+the last report. A later reconfiguration can enable the saved calendar again.
 
 ## Selection and package policy
 
@@ -76,16 +124,31 @@ connection can leave the active container's outcome unknown; inspect the
 saved in-progress state and guest package logs before running again.
 
 There are **no automatic backups, snapshots, rollback, container starts,
-reboots, distribution-release upgrades, or scheduled/unattended runs**. Arrange
-backups separately. Package maintainer scripts and existing guest hooks can
-restart services; run during an appropriate maintenance window. A reboot result
-only reports the guest's `/var/run/reboot-required` marker, not application health.
+reboots, or distribution-release upgrades**. Arrange backups separately. Package
+maintainer scripts and existing guest hooks can restart services; choose an
+appropriate maintenance window. A reboot result only reports the guest's
+`/var/run/reboot-required` marker, not application health.
+
+A scheduled batch that finds only documented skips succeeds. If an attempted
+container update fails, later containers are still attempted and the service
+returns failure after the batch. Failed containers are not retried or queued;
+the next attempt is the next configured window or an explicit manual start.
+Another manual or scheduled batch holding the updater lock causes the new run to
+exit without entering a guest. An overlapping scheduled invocation is a
+successful skip, records its timestamp separately from the active batch report,
+and remains visible in status and the system journal.
+
+The service runs with reduced CPU and idle I/O priority. systemd does not impose
+a start or stop timeout and signals only the supervising process, allowing the
+existing cancellation path to wait for an active APT/dpkg transaction. A stuck
+maintainer script can therefore require manual intervention.
 
 ## Reports and configuration
 
 The command shows progress and a final per-container summary. The last execution
 or preview report is stored in `/var/lib/pve-toolbox/lxc-update.state`, with one JSON
-record per `ct_ID` key plus completion, policy and notification state.
+record per `ct_ID` key plus invocation type, planned schedule, start and
+completion times, policy and notification state.
 Use `pve-toolbox status lxc-update` to inspect it. Reports use the shared credential filter, retain a bounded output tail
 per container, and replace the previous run. Preview writes local report state
 but never sends a notification.
@@ -98,19 +161,41 @@ Operator input is stored through the config helpers in
 | --- | --- |
 | `LX_EXCLUDE` | Space-separated container IDs to skip |
 | `DISCORD_WEBHOOK` | Optional Discord webhook URL for this module |
+| `LX_SCHEDULE_ENABLED` | `1` when automatic updates are explicitly enabled |
+| `LX_SCHEDULE` | Validated systemd `OnCalendar` expression |
+| `LX_SCHEDULE_NOTIFY` | `1` to report every scheduled batch to Discord |
 
 Run `pve-toolbox install lxc-update` to reconfigure. Use `none` to clear a field.
-Configuration is optional unless exclusions or notifications are wanted.
-Uninstall removes configuration and retains the last report.
+Configuration is optional unless exclusions, notifications, or scheduling are
+wanted. Existing hosts remain unscheduled until enabled. Module updates preserve
+the exact saved calendar, enabled state, and scheduled-notification choice. If
+the scheduled runner needs replacement while a batch is active, the module
+update fails and asks the operator to retry after the batch finishes.
 
-`--notify` sends one bounded summary after a confirmed run, including failures or
-cancellation. It contains the host, removal policy and per-container outcomes,
+Uninstall disables and removes the timer, service, scheduled runner and
+configuration, and retains the last report.
+
+`--notify` sends one bounded summary after a confirmed manual run, including
+failures or cancellation. An enabled automatic report uses the same bounded
+format after every scheduled batch. It contains the invocation type, host,
+removal policy and per-container outcomes,
 including held packages and reported reboot requirements when available. Long
 summaries are marked as truncated; full retained detail stays local. Raw package
 output is never sent. A missing or malformed webhook blocks execution before
 any package changes. Delivery failure is displayed and recorded without changing
 the package-update exit status. No notification is sent for previews or declined
-confirmation.
+confirmation. If automatic reporting is enabled but its webhook is missing or
+malformed, the scheduled service fails before entering any container.
+
+`pve-toolbox status lxc-update` reports a configured timer as degraded when its
+calendar is invalid, its runner or units are missing or unsafe, its timer is
+disabled, inactive or failed, its webhook cannot support requested reports, or
+its previous service execution failed. Timer history remains visible when a
+degraded systemd timer can still provide it. Full execution history remains in
+the system journal; the main structured state file contains only the most recent
+preview, manual run, or scheduled run. The latest overlap skip is stored in
+`/var/lib/pve-toolbox/lxc-update-overlap.state` so it cannot race the active
+batch's report writes.
 
 Exit status is `0` for successful execution (including documented skips), `1`
 for an operational or attempted-update failure, `64` for invalid arguments, and

--- a/modules/lxc-update/module.sh
+++ b/modules/lxc-update/module.sh
@@ -3,14 +3,342 @@
 # shellcheck disable=SC2034
 MODULE_NAME="lxc-update"
 MODULE_TITLE="LXC package updates"
-MODULE_DESC="confirmed local Debian/Ubuntu container package updates"
-MODULE_TAGS="lxc upgrade apt notify"
+MODULE_DESC="confirmed or scheduled local Debian/Ubuntu package updates"
+MODULE_TAGS="lxc upgrade apt notify schedule"
 MODULE_HOST_ONLY=1
+
+LX_UNIT="pve-toolbox-lxc-update"
+LX_BIN="pve-toolbox-lxc-update"
+LX_DEFAULT_SCHEDULE="Sun *-*-* 04:00:00"
+
+_lx_dir() { printf '%s/modules/%s' "${TOOLBOX_ROOT:-/usr/lib/pve-toolbox}" "$MODULE_NAME"; }
+_lx_src() { printf '%s/run.sh' "$(_lx_dir)"; }
+_lx_guest_src() { printf '%s/guest.sh' "$(_lx_dir)"; }
+_lx_runner() { printf '%s/%s' "$TOOLBOX_BIN_DIR" "$LX_BIN"; }
+_lx_guest() { printf '%s/lxc-update-guest.sh' "$TOOLBOX_LIB_DIR"; }
+_lx_lib_src() { printf '%s/lib/%s' "${TOOLBOX_ROOT:-/usr/lib/pve-toolbox}" "$1"; }
+_lx_service() { printf '%s/%s.service' "$TOOLBOX_SYSTEMD_DIR" "$LX_UNIT"; }
+_lx_timer() { printf '%s/%s.timer' "$TOOLBOX_SYSTEMD_DIR" "$LX_UNIT"; }
+_lx_exec() {
+    printf '/usr/bin/env PVE_TOOLBOX_LIB=%s LX_GUEST_HELPER=%s TOOLBOX_CONF_DIR=%s TOOLBOX_STATE_DIR=%s %s --scheduled' \
+        "$TOOLBOX_LIB_DIR" "$(_lx_guest)" "$TOOLBOX_CONF_DIR" \
+        "$TOOLBOX_STATE_DIR" "$(_lx_runner)"
+}
+
+_lx_valid_schedule() {
+    local output
+    [[ -n ${1:-} ]] || return 1
+    command -v systemd-analyze >/dev/null 2>&1 || return 1
+    output=$(LC_ALL=C systemd-analyze calendar --iterations=1 "$1" 2>/dev/null) \
+        || return 1
+    [[ $output == *'Next elapse:'* && $output != *'Next elapse: never'* ]]
+}
+
+_lx_schedule_preset() { # _lx_schedule_preset <daily|weekly>
+    case $1 in
+        daily) printf '*-*-* 04:00:00' ;;
+        weekly) printf '%s' "$LX_DEFAULT_SCHEDULE" ;;
+        *) return 1 ;;
+    esac
+}
+
+_lx_schedule_kind() { # _lx_schedule_kind <OnCalendar>
+    case $1 in
+        '*-*-* 04:00:00') printf daily ;;
+        "$LX_DEFAULT_SCHEDULE") printf weekly ;;
+        *) printf custom ;;
+    esac
+}
+
+_lx_write_units() { # _lx_write_units <OnCalendar>
+    local schedule=$1 service timer work
+    service=$(_lx_service); timer=$(_lx_timer)
+    _lx_valid_schedule "$schedule" \
+        || { warn "invalid systemd OnCalendar: $schedule"; return 1; }
+    [[ -d $TOOLBOX_SYSTEMD_DIR && ! -L $TOOLBOX_SYSTEMD_DIR ]] \
+        || { warn "unsafe systemd unit directory: $TOOLBOX_SYSTEMD_DIR"; return 1; }
+    [[ -d $TOOLBOX_BIN_DIR && ! -L $TOOLBOX_BIN_DIR ]] \
+        || { warn "unsafe binary directory: $TOOLBOX_BIN_DIR"; return 1; }
+    [[ ! -L $TOOLBOX_LIB_DIR && ( ! -e $TOOLBOX_LIB_DIR || -d $TOOLBOX_LIB_DIR ) ]] \
+        || { warn "unsafe library directory: $TOOLBOX_LIB_DIR"; return 1; }
+    for path in "$service" "$timer"; do
+        [[ ! -L $path && ( ! -e $path || -f $path ) ]] \
+            || { warn "unsafe LXC update unit path: $path"; return 1; }
+    done
+    for path in "$(_lx_runner)" "$(_lx_guest)" \
+        "$TOOLBOX_LIB_DIR/common.sh" "$TOOLBOX_LIB_DIR/report.sh" \
+        "$TOOLBOX_LIB_DIR/discord.sh"; do
+        [[ ! -L $path && ( ! -e $path || -f $path ) ]] \
+            || { warn "unsafe LXC scheduler runtime path: $path"; return 1; }
+    done
+
+    work=$(mktemp -d)
+    cat > "$work/service" <<EOF
+[Unit]
+Description=pve-toolbox automatic LXC package updates
+After=pve-cluster.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=$(_lx_exec)
+Nice=10
+IOSchedulingClass=idle
+UMask=0077
+TimeoutStartSec=infinity
+TimeoutStopSec=infinity
+KillMode=process
+StandardOutput=journal
+StandardError=journal
+EOF
+    cat > "$work/timer" <<EOF
+[Unit]
+Description=pve-toolbox automatic LXC package updates (timer)
+
+[Timer]
+OnCalendar=$schedule
+RandomizedDelaySec=1800
+AccuracySec=1s
+Persistent=false
+Unit=$LX_UNIT.service
+
+[Install]
+WantedBy=timers.target
+EOF
+    if ! install_toolbox_lib common.sh report.sh discord.sh \
+        || ! install -m 0644 "$(_lx_guest_src)" "$(_lx_guest)" \
+        || ! install -m 0755 "$(_lx_src)" "$(_lx_runner)" \
+        || ! install -m 0644 "$work/service" "$service" \
+        || ! install -m 0644 "$work/timer" "$timer" \
+        || ! systemctl daemon-reload \
+        || ! systemctl enable --now "$LX_UNIT.timer" >/dev/null 2>&1; then
+        rm -rf -- "$work"
+        warn "could not install and enable $LX_UNIT.timer"
+        return 1
+    fi
+    rm -rf -- "$work"
+    ok "enabled $LX_UNIT.timer ($schedule, delay up to 30 minutes)"
+}
+
+_lx_stop_timer() {
+    local timer known=0
+    timer=$(_lx_timer)
+    if [[ -e $timer || -L $timer ]] \
+        || systemctl is-enabled --quiet "$LX_UNIT.timer" 2>/dev/null \
+        || systemctl is-active --quiet "$LX_UNIT.timer" 2>/dev/null \
+        || systemctl is-failed --quiet "$LX_UNIT.timer" 2>/dev/null; then
+        known=1
+    fi
+    [[ $known == 0 ]] && return 0
+    if ! systemctl disable --now "$LX_UNIT.timer" >/dev/null 2>&1; then
+        warn "could not disable and stop $LX_UNIT.timer"
+        return 1
+    fi
+}
+
+_lx_remove_units() {
+    local service timer path timer_failed=0 service_failed=0
+    service=$(_lx_service); timer=$(_lx_timer)
+    for path in "$service" "$timer"; do
+        [[ ! -L $path && ( ! -e $path || -f $path ) ]] \
+            || { warn "unsafe LXC update unit path: $path"; return 1; }
+    done
+    systemctl is-failed --quiet "$LX_UNIT.timer" 2>/dev/null && timer_failed=1
+    systemctl is-failed --quiet "$LX_UNIT.service" 2>/dev/null && service_failed=1
+    _lx_stop_timer || return 1
+    rm -f -- "$service" "$timer" || return 1
+    systemctl daemon-reload || return 1
+    if [[ $timer_failed == 1 ]] \
+        && ! systemctl reset-failed "$LX_UNIT.timer" >/dev/null 2>&1; then
+        warn "could not clear the failed $LX_UNIT.timer state"
+        return 1
+    fi
+    if [[ $service_failed == 1 ]] \
+        && ! systemctl reset-failed "$LX_UNIT.service" >/dev/null 2>&1; then
+        warn "could not clear the failed $LX_UNIT.service state"
+        return 1
+    fi
+}
+
+_lx_backup_one() { # _lx_backup_one <source> <backup>
+    if [[ -L $1 || ( -e $1 && ! -f $1 ) ]]; then
+        warn "unsafe LXC scheduler path: $1"
+        return 1
+    elif [[ -f $1 ]]; then
+        cp -a -- "$1" "$2"
+    else
+        : > "$2.missing"
+    fi
+}
+
+_lx_restore_one() { # _lx_restore_one <backup> <target>
+    rm -f -- "$2"
+    [[ -f $1.missing ]] || cp -a -- "$1" "$2"
+}
+
+_lx_backup_install() { # _lx_backup_install <directory>
+    _lx_backup_one "$(conf_file "$MODULE_NAME")" "$1/config" \
+        && _lx_backup_one "$(_lx_runner)" "$1/runner" \
+        && _lx_backup_one "$(_lx_guest)" "$1/guest" \
+        && _lx_backup_one "$TOOLBOX_LIB_DIR/common.sh" "$1/common" \
+        && _lx_backup_one "$TOOLBOX_LIB_DIR/report.sh" "$1/report" \
+        && _lx_backup_one "$TOOLBOX_LIB_DIR/discord.sh" "$1/discord" \
+        && _lx_backup_one "$(_lx_service)" "$1/service" \
+        && _lx_backup_one "$(_lx_timer)" "$1/timer" \
+        || return 1
+    if systemctl is-enabled --quiet "$LX_UNIT.timer" 2>/dev/null; then
+        : > "$1/timer-enabled"
+    fi
+}
+
+_lx_restore_install() { # _lx_restore_install <directory>
+    _lx_restore_one "$1/config" "$(conf_file "$MODULE_NAME")" || return 1
+    _lx_stop_timer || return 1
+    _lx_restore_one "$1/runner" "$(_lx_runner)" \
+        && _lx_restore_one "$1/guest" "$(_lx_guest)" \
+        && _lx_restore_one "$1/common" "$TOOLBOX_LIB_DIR/common.sh" \
+        && _lx_restore_one "$1/report" "$TOOLBOX_LIB_DIR/report.sh" \
+        && _lx_restore_one "$1/discord" "$TOOLBOX_LIB_DIR/discord.sh" \
+        && _lx_restore_one "$1/service" "$(_lx_service)" \
+        && _lx_restore_one "$1/timer" "$(_lx_timer)" \
+        && systemctl daemon-reload \
+        || return 1
+    if [[ -f $1/timer-enabled ]]; then
+        systemctl enable --now "$LX_UNIT.timer" >/dev/null 2>&1 || return 1
+    fi
+}
+
+_lx_write_config() { # enabled schedule notify exclusions webhook
+    conf_set "$MODULE_NAME" LX_EXCLUDE "$4" \
+        && conf_set "$MODULE_NAME" DISCORD_WEBHOOK "$5" \
+        && conf_set "$MODULE_NAME" LX_SCHEDULE_ENABLED "$1" \
+        && conf_set "$MODULE_NAME" LX_SCHEDULE "$2" \
+        && conf_set "$MODULE_NAME" LX_SCHEDULE_NOTIFY "$3"
+}
+
+_lx_enabled() { [[ $(conf_get "$MODULE_NAME" LX_SCHEDULE_ENABLED) == 1 ]]; }
+_lx_enabled_setting_valid() {
+    case $(conf_get "$MODULE_NAME" LX_SCHEDULE_ENABLED) in ''|0|1) return 0 ;; *) return 1 ;; esac
+}
+_lx_unit_files_exist() {
+    [[ -e $(_lx_service) || -L $(_lx_service) \
+        || -e $(_lx_timer) || -L $(_lx_timer) ]]
+}
+_lx_units_exist() {
+    _lx_unit_files_exist \
+        || systemctl is-enabled --quiet "$LX_UNIT.timer" 2>/dev/null \
+        || systemctl is-active --quiet "$LX_UNIT.timer" 2>/dev/null \
+        || systemctl is-failed --quiet "$LX_UNIT.timer" 2>/dev/null
+}
+_lx_assets_exist() {
+    [[ -e $(_lx_runner) || -L $(_lx_runner) \
+        || -e $(_lx_guest) || -L $(_lx_guest) \
+        || -e $(_lx_service) || -L $(_lx_service) \
+        || -e $(_lx_timer) || -L $(_lx_timer) ]]
+}
+
+_lx_config_health() {
+    local schedule
+    schedule=$(conf_get "$MODULE_NAME" LX_SCHEDULE)
+    _lx_valid_schedule "$schedule" \
+        || { LX_HEALTH_REASON="configured schedule is invalid"; return 1; }
+    [[ $(conf_get "$MODULE_NAME" LX_SCHEDULE_NOTIFY) =~ ^[01]$ ]] \
+        || { LX_HEALTH_REASON="automatic notification setting is invalid"; return 1; }
+    if [[ $(conf_get "$MODULE_NAME" LX_SCHEDULE_NOTIFY) == 1 ]]; then
+        local webhook
+        webhook=$(conf_get "$MODULE_NAME" DISCORD_WEBHOOK)
+        [[ $webhook =~ ^https://(discord\.com|discordapp\.com)/api/webhooks/[0-9]+/[A-Za-z0-9._-]+$ ]] \
+            || { LX_HEALTH_REASON="automatic Discord webhook is invalid"; return 1; }
+    fi
+}
+
+_lx_runtime_health() { # _lx_runtime_health <OnCalendar>
+    local schedule=$1 service timer lib
+    service=$(_lx_service); timer=$(_lx_timer)
+    [[ -f $(_lx_runner) && ! -L $(_lx_runner) && -x $(_lx_runner) ]] \
+        || { LX_HEALTH_REASON="scheduled runner is missing or unsafe"; return 1; }
+    cmp -s "$(_lx_src)" "$(_lx_runner)" \
+        || { LX_HEALTH_REASON="scheduled runner differs from this toolbox"; return 1; }
+    [[ -f $(_lx_guest) && ! -L $(_lx_guest) ]] \
+        || { LX_HEALTH_REASON="scheduled guest helper is missing or unsafe"; return 1; }
+    cmp -s "$(_lx_guest_src)" "$(_lx_guest)" \
+        || { LX_HEALTH_REASON="scheduled guest helper differs from this toolbox"; return 1; }
+    for lib in common.sh report.sh discord.sh; do
+        [[ -f $TOOLBOX_LIB_DIR/$lib && ! -L $TOOLBOX_LIB_DIR/$lib ]] \
+            || { LX_HEALTH_REASON="scheduled library $lib is missing or unsafe"; return 1; }
+        cmp -s "$(_lx_lib_src "$lib")" "$TOOLBOX_LIB_DIR/$lib" \
+            || { LX_HEALTH_REASON="scheduled library $lib differs from this toolbox"; return 1; }
+    done
+    [[ -f $service && ! -L $service ]] \
+        || { LX_HEALTH_REASON="service file is missing or unsafe"; return 1; }
+    [[ -f $timer && ! -L $timer ]] \
+        || { LX_HEALTH_REASON="timer file is missing or unsafe"; return 1; }
+    grep -Fqx "ExecStart=$(_lx_exec)" "$service" \
+        || { LX_HEALTH_REASON="service command differs from configuration"; return 1; }
+    if ! grep -Fqx 'TimeoutStartSec=infinity' "$service" \
+        || ! grep -Fqx 'TimeoutStopSec=infinity' "$service" \
+        || ! grep -Fqx 'KillMode=process' "$service"; then
+        LX_HEALTH_REASON="service transaction protection is incomplete"
+        return 1
+    fi
+    grep -Fqx "OnCalendar=$schedule" "$timer" \
+        || { LX_HEALTH_REASON="timer schedule differs from configuration"; return 1; }
+    if ! grep -Fqx 'Persistent=false' "$timer"; then
+        LX_HEALTH_REASON="timer catch-up policy is unsafe"
+        return 1
+    fi
+    if ! grep -Fqx 'RandomizedDelaySec=1800' "$timer" \
+        || ! grep -Fqx 'AccuracySec=1s' "$timer"; then
+        LX_HEALTH_REASON="timer delay policy differs from configuration"
+        return 1
+    fi
+}
+
+_lx_health() {
+    LX_HEALTH_REASON=""
+    local schedule
+    schedule=$(conf_get "$MODULE_NAME" LX_SCHEDULE)
+    _lx_config_health || return 1
+    _lx_runtime_health "$schedule" || return 1
+    systemctl is-enabled --quiet "$LX_UNIT.timer" 2>/dev/null \
+        || { LX_HEALTH_REASON="timer is disabled"; return 1; }
+    if systemctl is-failed --quiet "$LX_UNIT.timer" 2>/dev/null; then
+        LX_HEALTH_REASON="automatic update timer failed"
+        return 1
+    fi
+    systemctl is-active --quiet "$LX_UNIT.timer" 2>/dev/null \
+        || { LX_HEALTH_REASON="timer is inactive"; return 1; }
+    if systemctl is-failed --quiet "$LX_UNIT.service" 2>/dev/null; then
+        LX_HEALTH_REASON="last automatic update service failed"
+        return 1
+    fi
+}
+
+_lx_lock_idle() {
+    command -v flock >/dev/null 2>&1 || die "missing host command: flock"
+    [[ ! -L $TOOLBOX_STATE_DIR ]] || die "unsafe state directory"
+    mkdir -p "$TOOLBOX_STATE_DIR"
+    local lock="$TOOLBOX_STATE_DIR/lxc-update.lock"
+    [[ ! -L $lock && ( ! -e $lock || -f $lock ) ]] \
+        || die "unsafe LXC updater lock path"
+    exec {LX_CHANGE_LOCK}>"$lock"
+    flock -n "$LX_CHANGE_LOCK" \
+        || die "an LXC update batch is active; retry the module update after it finishes"
+}
 
 module_install() {
     require_root
-    local LX_EXCLUDE="" DISCORD_WEBHOOK="" id replacement=""
+    local requested_enabled=${LX_SCHEDULE_ENABLED:-}
+    local requested_preset=${LX_SCHEDULE_PRESET:-}
+    local requested_schedule=${LX_SCHEDULE:-}
+    local requested_notify=${LX_SCHEDULE_NOTIFY:-}
+    local LX_EXCLUDE="" DISCORD_WEBHOOK="" LX_SCHEDULE_ENABLED=0
+    local LX_SCHEDULE="$LX_DEFAULT_SCHEDULE" LX_SCHEDULE_NOTIFY=0
+    local id replacement="" schedule_enabled schedule_notify schedule_preset rollback install_failed=0
     if conf_exists "$MODULE_NAME"; then conf_load "$MODULE_NAME"; fi
+    [[ -z $requested_enabled ]] || LX_SCHEDULE_ENABLED=$requested_enabled
+    [[ -z $requested_schedule ]] || LX_SCHEDULE=$requested_schedule
+    [[ -z $requested_notify ]] || LX_SCHEDULE_NOTIFY=$requested_notify
     ask LX_EXCLUDE "Excluded container IDs, space-separated (use none to clear)" "${LX_EXCLUDE:-none}"
     [[ $LX_EXCLUDE != none ]] || LX_EXCLUDE=""
     for id in $LX_EXCLUDE; do
@@ -21,38 +349,261 @@ module_install() {
         [[ -z $replacement ]] || DISCORD_WEBHOOK=$replacement
     fi
     [[ $DISCORD_WEBHOOK != none ]] || DISCORD_WEBHOOK=""
-    conf_set "$MODULE_NAME" LX_EXCLUDE "$LX_EXCLUDE"
-    conf_set "$MODULE_NAME" DISCORD_WEBHOOK "$DISCORD_WEBHOOK"
+
+    schedule_enabled=n
+    case ${LX_SCHEDULE_ENABLED,,} in 1|y|yes) schedule_enabled=y ;; esac
+    ask_yn schedule_enabled "Enable automatic LXC package updates" "$schedule_enabled"
+    if [[ $schedule_enabled == y ]]; then
+        schedule_preset=${requested_preset:-$(_lx_schedule_kind "$LX_SCHEDULE")}
+        while true; do
+            ask schedule_preset "Schedule preset (daily, weekly, custom)" "$schedule_preset"
+            case ${schedule_preset,,} in
+                daily|weekly)
+                    LX_SCHEDULE=$(_lx_schedule_preset "${schedule_preset,,}")
+                    break ;;
+                custom)
+                    ask LX_SCHEDULE "systemd OnCalendar" "$LX_SCHEDULE"
+                    _lx_valid_schedule "$LX_SCHEDULE" && break
+                    [[ $ASSUME_YES -eq 1 ]] && die "invalid systemd OnCalendar: $LX_SCHEDULE"
+                    warn "invalid systemd OnCalendar: $LX_SCHEDULE" ;;
+                *)
+                    [[ $ASSUME_YES -eq 1 ]] \
+                        && die "schedule preset must be daily, weekly, or custom"
+                    warn "choose daily, weekly, or custom" ;;
+            esac
+        done
+        _lx_valid_schedule "$LX_SCHEDULE" || die "invalid systemd OnCalendar: $LX_SCHEDULE"
+        schedule_notify=n
+        case ${LX_SCHEDULE_NOTIFY,,} in 1|y|yes) schedule_notify=y ;; esac
+        ask_yn schedule_notify "Send a Discord report after every automatic run" "$schedule_notify"
+        if [[ $schedule_notify == y ]]; then
+            [[ $DISCORD_WEBHOOK =~ ^https://(discord\.com|discordapp\.com)/api/webhooks/[0-9]+/[A-Za-z0-9._-]+$ ]] \
+                || die "automatic reports require a configured Discord webhook"
+        fi
+    else
+        schedule_notify=n
+        case ${LX_SCHEDULE_NOTIFY,,} in 1|y|yes) schedule_notify=y ;; esac
+    fi
+
+    _lx_lock_idle
+    rollback=$(mktemp -d)
+    _lx_backup_install "$rollback" \
+        || { rm -rf -- "$rollback"; die "could not back up the existing LXC scheduler"; }
+    trap '_lx_restore_install "$rollback" >/dev/null 2>&1 || true; rm -rf -- "$rollback"; exit 130' INT TERM HUP
+    if ! _lx_write_config \
+        "$([[ $schedule_enabled == y ]] && printf 1 || printf 0)" \
+        "$LX_SCHEDULE" \
+        "$([[ $schedule_notify == y ]] && printf 1 || printf 0)" \
+        "$LX_EXCLUDE" "$DISCORD_WEBHOOK"; then
+        install_failed=1
+    elif [[ $schedule_enabled == y ]]; then
+        _lx_write_units "$LX_SCHEDULE" || install_failed=1
+    else
+        _lx_remove_units || install_failed=1
+    fi
+    if [[ $install_failed == 1 ]]; then
+        if ! _lx_restore_install "$rollback"; then
+            rm -rf -- "$rollback"
+            die "LXC scheduler configuration failed and its previous state could not be restored"
+        fi
+        rm -rf -- "$rollback"
+        trap - INT TERM HUP
+        warn "LXC scheduler configuration failed; restored the previous state"
+        return 1
+    fi
+    rm -rf -- "$rollback"
+    trap - INT TERM HUP
+    [[ $schedule_enabled == y ]] || ok "automatic LXC package updates disabled"
     ok "configured; run pve-toolbox lxc-update --dry-run to preview"
 }
 
 module_update() {
-    # Updating the toolbox must never start guest maintenance.
-    info "LXC updater follows the installed toolbox version; guest packages unchanged"
+    require_root
+    conf_exists "$MODULE_NAME" || die "not installed"
+    local check_only=0 schedule drift=0
+    [[ ${1:-} == --check ]] && check_only=1
+    _lx_enabled_setting_valid \
+        || die "invalid automatic update setting; reconfigure lxc-update"
+
+    if ! _lx_enabled; then
+        if ! _lx_units_exist; then
+            info "automatic LXC updates are disabled; guest packages unchanged"
+            return 0
+        fi
+        if [[ $check_only == 1 ]]; then
+            info "update available: remove scheduler units disabled by configuration"
+            return 0
+        fi
+        _lx_remove_units || die "could not remove scheduler units disabled by configuration"
+        ok "removed scheduler units; automatic LXC updates remain disabled"
+        return 0
+    fi
+    schedule=$(conf_get "$MODULE_NAME" LX_SCHEDULE)
+    LX_HEALTH_REASON=""
+    _lx_config_health || die "$LX_HEALTH_REASON; reconfigure lxc-update"
+    _lx_runtime_health "$schedule" || drift=1
+    systemctl is-enabled --quiet "$LX_UNIT.timer" 2>/dev/null || drift=1
+    systemctl is-active --quiet "$LX_UNIT.timer" 2>/dev/null || drift=1
+    if systemctl is-failed --quiet "$LX_UNIT.timer" 2>/dev/null; then drift=1; fi
+    if [[ $drift == 0 && ${FORCE:-0} == 0 ]]; then
+        ok "up to date; automatic updates remain $schedule"
+        return 0
+    fi
+    if [[ $check_only == 1 ]]; then
+        info "update available: the scheduled runner or units are out of sync"
+        return 0
+    fi
+
+    _lx_lock_idle
+    local rollback
+    rollback=$(mktemp -d)
+    _lx_backup_install "$rollback" \
+        || { rm -rf -- "$rollback"; die "could not back up the existing LXC scheduler"; }
+    trap '_lx_restore_install "$rollback" >/dev/null 2>&1 || true; rm -rf -- "$rollback"; exit 130' INT TERM HUP
+    if ! _lx_write_units "$schedule"; then
+        if ! _lx_restore_install "$rollback"; then
+            rm -rf -- "$rollback"
+            trap - INT TERM HUP
+            die "scheduled runner update failed and its previous state could not be restored"
+        fi
+        rm -rf -- "$rollback"
+        trap - INT TERM HUP
+        die "scheduled runner update failed; restored the previous state"
+    fi
+    rm -rf -- "$rollback"
+    trap - INT TERM HUP
+    ok "scheduled runner updated; guest packages unchanged"
 }
 
 module_status() {
-    conf_exists "$MODULE_NAME" || { printf 'not installed'; return 1; }
-    printf 'configured (manual updates)'
+    if ! conf_exists "$MODULE_NAME"; then
+        if _lx_assets_exist; then
+            printf 'degraded  [scheduler files exist without configuration]'
+            return 0
+        fi
+        printf 'not installed'
+        return 1
+    fi
+    if ! _lx_enabled_setting_valid; then
+        printf 'degraded  [automatic update setting is invalid]'
+        return 0
+    fi
+    if ! _lx_enabled; then
+        if _lx_units_exist; then
+            printf 'degraded  [scheduler files remain while automatic updates are disabled]'
+        else
+            printf 'configured (manual updates)'
+        fi
+    elif _lx_health; then
+        printf 'scheduled  [%s]' "$(conf_get "$MODULE_NAME" LX_SCHEDULE)"
+    else
+        printf 'degraded  [%s]' "$LX_HEALTH_REASON"
+    fi
 }
 
 module_status_long() {
-    module_status || return 1
-    printf '\nExcluded IDs: %s\n' "$(conf_get "$MODULE_NAME" LX_EXCLUDE)"
-    if [[ -n $(conf_get "$MODULE_NAME" DISCORD_WEBHOOK) ]]; then
-        printf 'Discord webhook: configured (send only with --notify)\n'
+    local status schedule next last_trigger invocation started completed overlap ids id value
+    local degraded=0 health_ok=1 enabled_valid=1
+    status=$(module_status) || { printf '%s' "$status"; return 1; }
+    if ! conf_exists "$MODULE_NAME"; then
+        printf '%s\n' "$status"
+        printf 'Configuration: missing; reinstall or uninstall the module to repair this state\n'
+        return 1
     fi
+    [[ $status != degraded* ]] || degraded=1
+    schedule=$(conf_get "$MODULE_NAME" LX_SCHEDULE)
+    if ! _lx_enabled_setting_valid; then
+        enabled_valid=0
+        health_ok=0
+    elif _lx_enabled; then
+        if ! _lx_health; then
+            status="degraded  [$LX_HEALTH_REASON]"
+            degraded=1
+            health_ok=0
+        fi
+    elif _lx_units_exist; then
+        status='degraded  [scheduler files remain while automatic updates are disabled]'
+        degraded=1
+    fi
+    printf '%s\n' "$status"
+    if [[ $enabled_valid == 0 ]]; then
+        printf 'Automatic updates: invalid configuration\n'
+        printf 'Saved schedule: %s\n' "${schedule:-$LX_DEFAULT_SCHEDULE}"
+    elif _lx_enabled; then
+        printf 'Automatic updates: enabled\n'
+        printf 'Schedule: %s (host local time, delay up to 30 minutes)\n' "$schedule"
+        [[ $health_ok == 1 ]] \
+            || printf 'Schedule health: degraded - %s\n' "$LX_HEALTH_REASON"
+        next=$(systemctl show "$LX_UNIT.timer" \
+            --property=NextElapseUSecRealtime --value 2>/dev/null) || next=""
+        last_trigger=$(systemctl show "$LX_UNIT.timer" \
+            --property=LastTriggerUSec --value 2>/dev/null) || last_trigger=""
+        if [[ -n $next ]]; then
+            printf 'Next run: %s\n' "$next"
+        else
+            printf 'Next run: unavailable\n'
+        fi
+        printf 'Last timer trigger: %s\n' "${last_trigger:-never}"
+        printf 'Automatic Discord report: %s\n' \
+            "$([[ $(conf_get "$MODULE_NAME" LX_SCHEDULE_NOTIFY) == 1 ]] && printf enabled || printf disabled)"
+        printf 'Start now: systemctl start %s.service\n' "$LX_UNIT"
+        printf 'Journal: journalctl -u %s.service\n' "$LX_UNIT"
+    else
+        printf 'Automatic updates: disabled\n'
+        printf 'Saved schedule: %s\n' "${schedule:-$LX_DEFAULT_SCHEDULE}"
+    fi
+    printf 'Excluded IDs: %s\n' "$(conf_get "$MODULE_NAME" LX_EXCLUDE)"
+    if [[ -n $(conf_get "$MODULE_NAME" DISCORD_WEBHOOK) ]]; then
+        printf 'Discord webhook: configured (manual and optional automatic reports)\n'
+    fi
+    invocation=$(state_get "$MODULE_NAME" invocation)
+    started=$(state_get "$MODULE_NAME" started_at)
+    completed=$(state_get "$MODULE_NAME" completed_at)
+    printf 'Invocation: %s\n' "${invocation:-none}"
+    printf 'Started: %s\n' "${started:-never}"
+    printf 'Completed: %s\n' "${completed:-never}"
     printf 'Last run: %s\n' "$(state_get "$MODULE_NAME" last_summary)"
+    overlap=$(state_get lxc-update-overlap skipped_at)
+    printf 'Last overlap skip: %s\n' "${overlap:-never}"
     printf 'Last report: %s/lxc-update.state\n' "$TOOLBOX_STATE_DIR"
-    if state_exists "$MODULE_NAME"; then
-        awk '/^ct_[0-9]+=/ {id=$0; sub(/=.*/, "", id); sub(/^[^=]*=/, ""); print id " " $0}' \
-            "$(_state_file "$MODULE_NAME")"
+    ids=$(state_get "$MODULE_NAME" container_ids)
+    for id in $ids; do
+        [[ $id =~ ^[1-9][0-9]{2,8}$ ]] || continue
+        value=$(state_get "$MODULE_NAME" "ct_$id")
+        printf 'ct_%s %s\n' "$id" "$value"
+    done
+    return "$degraded"
+}
+
+module_doctor() {
+    if ! conf_exists "$MODULE_NAME"; then
+        doctor_result fail configuration "scheduler files exist without configuration"
+    elif ! _lx_enabled_setting_valid; then
+        doctor_result fail schedule "automatic update setting is invalid"
+    elif ! _lx_enabled && _lx_units_exist; then
+        doctor_result fail schedule "scheduler files remain while automatic updates are disabled"
+    elif ! _lx_enabled; then
+        doctor_result pass schedule "automatic LXC updates are disabled"
+    elif _lx_health; then
+        doctor_result pass schedule "automatic LXC update timer is healthy" \
+            "$(conf_get "$MODULE_NAME" LX_SCHEDULE)"
+    else
+        doctor_result fail schedule "$LX_HEALTH_REASON"
     fi
 }
 
 module_uninstall() {
     require_root
-    conf_clear "$MODULE_NAME"
-    # Retain the last report and the lock inode; neither is an installed helper.
+    _lx_lock_idle
+    _lx_remove_units || die "could not remove the LXC update units"
+    local path
+    for path in "$(_lx_runner)" "$(_lx_guest)"; do
+        [[ ! -e $path || -f $path || -L $path ]] \
+            || die "unsafe scheduled runtime path: $path"
+    done
+    rm -f -- "$(_lx_runner)" "$(_lx_guest)" \
+        || die "could not remove the scheduled runtime"
+    conf_clear "$MODULE_NAME" || die "could not remove the LXC updater configuration"
+    # Retain reports and the lock inode; shared libraries may serve other modules.
     ok "removed LXC updater configuration; last report retained"
 }

--- a/modules/lxc-update/run.sh
+++ b/modules/lxc-update/run.sh
@@ -1,15 +1,21 @@
 #!/usr/bin/env bash
-# Runs only through the launcher; guest code is shipped with this module.
+# Runs through the launcher for manual work and as an installed systemd helper.
 set -Eeuo pipefail
-MODULE_PATH=$(cd -- "${BASH_SOURCE[0]%/*}" && pwd -P)
-TOOLBOX_ROOT=${TOOLBOX_ROOT:-${MODULE_PATH%/modules/lxc-update}}
+SCRIPT_PATH=$(cd -- "${BASH_SOURCE[0]%/*}" && pwd -P)
+if [[ -z ${PVE_TOOLBOX_LIB:-} ]]; then
+    TOOLBOX_ROOT=${TOOLBOX_ROOT:-${SCRIPT_PATH%/modules/lxc-update}}
+    PVE_TOOLBOX_LIB="$TOOLBOX_ROOT/lib"
+    LX_GUEST_HELPER=${LX_GUEST_HELPER:-$SCRIPT_PATH/guest.sh}
+else
+    LX_GUEST_HELPER=${LX_GUEST_HELPER:-$PVE_TOOLBOX_LIB/lxc-update-guest.sh}
+fi
 # shellcheck source=lib/common.sh
-source "$TOOLBOX_ROOT/lib/common.sh"
+source "$PVE_TOOLBOX_LIB/common.sh"
 # shellcheck source=lib/report.sh
-source "$TOOLBOX_ROOT/lib/report.sh"
+source "$PVE_TOOLBOX_LIB/report.sh"
 
-LX_DRY=0 LX_REMOVE=0 LX_NOTIFY=0 LX_CANCEL=0 LX_FAILED=0
-LX_EXCLUDE="" DISCORD_WEBHOOK=""
+LX_DRY=0 LX_REMOVE=0 LX_NOTIFY=0 LX_CANCEL=0 LX_FAILED=0 LX_SCHEDULED=0
+LX_EXCLUDE="" DISCORD_WEBHOOK="" LX_SCHEDULE_ENABLED=0 LX_SCHEDULE="" LX_SCHEDULE_NOTIFY=0
 LX_IDS=() LX_TARGETS=()
 declare -A LX_NAMES=()
 for arg in "$@"; do
@@ -17,21 +23,32 @@ for arg in "$@"; do
         --dry-run) LX_DRY=1 ;;
         --allow-removals) LX_REMOVE=1 ;;
         --notify) LX_NOTIFY=1 ;;
+        --scheduled) LX_SCHEDULED=1 ;;
         *) [[ $arg =~ ^[1-9][0-9]{2,8}$ ]] || { warn "invalid container ID or flag: $arg"; exit 64; }
            [[ " ${LX_IDS[*]} " == *" $arg "* ]] || LX_IDS+=("$arg") ;;
     esac
 done
+if [[ $LX_SCHEDULED == 1 && ( $LX_DRY == 1 || $LX_REMOVE == 1 || $LX_NOTIFY == 1 || ${#LX_IDS[@]} -gt 0 ) ]]; then
+    warn "scheduled mode does not accept IDs, previews, removals, or notification flags"
+    exit 64
+fi
 require_root
 for cmd in pveversion pvesh pct jq flock setsid; do
     command -v "$cmd" >/dev/null || die "missing host command: $cmd"
 done
 [[ $(pveversion) == pve-manager/9.* ]] || die "LXC updates require a PVE 9 host"
 in_lxc && die "run LXC updates on the PVE host"
-if [[ $LX_DRY == 0 ]]; then
+if [[ $LX_DRY == 0 && $LX_SCHEDULED == 0 ]]; then
     [[ $ASSUME_YES == 0 && ${FORCE:-0} == 0 && -t 0 && -t 1 ]] \
         || die "LXC updates require interactive confirmation; --yes/--force are not supported"
 fi
 if conf_exists lxc-update; then conf_load lxc-update; fi
+if [[ $LX_SCHEDULED == 1 ]]; then
+    [[ $LX_SCHEDULE_ENABLED == 1 ]] || die "automatic LXC updates are not enabled"
+    [[ $LX_SCHEDULE_NOTIFY == 0 || $LX_SCHEDULE_NOTIFY == 1 ]] \
+        || die "invalid automatic notification setting; reconfigure lxc-update"
+    LX_NOTIFY=$LX_SCHEDULE_NOTIFY
+fi
 exclude_ids=()
 # Intentional whitespace splitting: configuration stores a list of numeric IDs.
 for id in $LX_EXCLUDE; do
@@ -44,6 +61,32 @@ if [[ $LX_NOTIFY == 1 && $LX_DRY == 0 ]]; then
         || die "--notify requires a configured Discord webhook; run pve-toolbox install lxc-update"
     command -v curl >/dev/null || die "--notify requires curl"
 fi
+
+[[ ! -L $TOOLBOX_STATE_DIR ]] || die "unsafe state directory"
+mkdir -p "$TOOLBOX_STATE_DIR"
+for path in "$TOOLBOX_STATE_DIR/lxc-update.lock" \
+    "$TOOLBOX_STATE_DIR/lxc-update.state" \
+    "$TOOLBOX_STATE_DIR/lxc-update-overlap.state"; do
+    [[ ! -L $path && ( ! -e $path || -f $path ) ]] \
+        || die "unsafe LXC updater state path"
+done
+exec {LX_LOCK}>"$TOOLBOX_STATE_DIR/lxc-update.lock"
+if ! flock -n "$LX_LOCK"; then
+    if [[ $LX_SCHEDULED == 1 ]]; then
+        overlap_time=$(date -u +%FT%TZ)
+        state_set lxc-update-overlap invocation scheduled \
+            && state_set lxc-update-overlap schedule "$LX_SCHEDULE" \
+            && state_set lxc-update-overlap started_at "$overlap_time" \
+            && state_set lxc-update-overlap completed_at "$overlap_time" \
+            && state_set lxc-update-overlap result busy \
+            && state_set lxc-update-overlap skipped_at "$overlap_time" \
+            || die "could not record the skipped overlapping run"
+        warn "another LXC updater is already running; scheduled batch skipped"
+        exit 0
+    fi
+    die "another LXC updater is already running"
+fi
+
 LX_NODE=$(hostname -s)
 [[ $LX_NODE =~ ^[a-zA-Z0-9][a-zA-Z0-9-]*$ ]] || die "invalid local node name"
 LX_INVENTORY=$(pvesh get "/nodes/$LX_NODE/lxc" --output-format json) \
@@ -61,6 +104,10 @@ for id in "${LX_IDS[@]}"; do
 done
 
 report_reset lxc-update
+LX_INVOCATION=manual
+[[ $LX_DRY == 0 ]] || LX_INVOCATION=preview
+[[ $LX_SCHEDULED == 0 ]] || LX_INVOCATION=scheduled
+LX_STARTED_AT=$(date -u +%FT%TZ)
 LX_WORK=$(mktemp -d)
 trap 'rm -rf -- "$LX_WORK"' EXIT
 # Each pct process has a separate session, so Ctrl+C reaches the supervisor
@@ -74,16 +121,16 @@ lx_guest() { # <id> <guest phase>; output streamed after credential filtering
     # Keep the reader outside the terminal process group too. Its output is
     # untrusted terminal text, so strip control bytes before displaying it.
     setsid --wait bash -c '
-        source "$1/lib/common.sh"
-        source "$1/lib/report.sh"
+        source "$1/common.sh"
+        source "$1/report.sh"
         while IFS= read -r line || [[ -n $line ]]; do
             line=$(printf "%s" "$line" | LC_ALL=C tr -d "\000-\010\013\014\016-\037\177")
             report_clean_text "$line"
         done | tee "$2"
-    ' _ "$TOOLBOX_ROOT" "$LX_WORK/output" < "$LX_WORK/stream" &
+    ' _ "$PVE_TOOLBOX_LIB" "$LX_WORK/output" < "$LX_WORK/stream" &
     reader=$!
     setsid --wait pct exec "$id" -- bash -s -- "$phase" "$LX_REMOVE" \
-        < "$MODULE_PATH/guest.sh" > "$LX_WORK/stream" 2>&1 &
+        < "$LX_GUEST_HELPER" > "$LX_WORK/stream" 2>&1 &
     child=$!
     while :; do
         rc=0
@@ -150,16 +197,8 @@ for row in "${LX_ROWS[@]}"; do
     LX_TARGETS+=("$id")
 done
 
-[[ ! -L $TOOLBOX_STATE_DIR ]] || die "unsafe state directory"
-mkdir -p "$TOOLBOX_STATE_DIR"
-for path in "$TOOLBOX_STATE_DIR/lxc-update.lock" "$TOOLBOX_STATE_DIR/lxc-update.state"; do
-    [[ ! -L $path && ( ! -e $path || -f $path ) ]] || die "unsafe LXC updater state path"
-done
-exec {LX_LOCK}>"$TOOLBOX_STATE_DIR/lxc-update.lock"
-flock -n "$LX_LOCK" || die "another LXC updater is already running"
-
 lx_save() {
-    local json index
+    local json index result_ids="" report_id
     # One bounded record per container avoids passing an entire large batch
     # through a single environment variable in the shared state helpers.
     for ((index=LX_SAVED; index<${#REPORT_IDS[@]}; index++)); do
@@ -169,6 +208,11 @@ lx_save() {
         lx_record "ct_${REPORT_IDS[$index]#ct.}" "$json" || return 1
     done
     LX_SAVED=${#REPORT_IDS[@]}
+    for report_id in "${REPORT_IDS[@]}"; do
+        [[ $report_id == ct.* ]] || continue
+        result_ids+="${report_id#ct.} "
+    done
+    lx_record container_ids "${result_ids% }" || return 1
     lx_record exit_code "$1" || return 1
     lx_record last_summary "$(date -u +%FT%TZ) $2" || return 1
 }
@@ -180,6 +224,11 @@ lx_report_start() {
     LX_SAVED=0
     state_clear lxc-update
     lx_record host "$LX_NODE" || die "could not initialize report; nothing updated"
+    lx_record invocation "$LX_INVOCATION" || die "could not initialize report; nothing updated"
+    lx_record schedule "$([[ $LX_SCHEDULED == 1 ]] && printf '%s' "$LX_SCHEDULE" || printf none)" \
+        || die "could not initialize report; nothing updated"
+    lx_record started_at "$LX_STARTED_AT" || die "could not initialize report; nothing updated"
+    lx_record completed_at pending || die "could not initialize report; nothing updated"
     lx_record allow_removals "$LX_REMOVE" || die "could not initialize report; nothing updated"
     lx_record notification pending || die "could not initialize report; nothing updated"
     lx_save "$LX_FAILED" 'in progress' || die "could not save initial report; nothing updated"
@@ -211,12 +260,17 @@ if [[ $LX_DRY == 1 ]]; then
         printf '%s: %s - %s\n' "${REPORT_IDS[$i]}" "${REPORT_STATES[$i]}" "${REPORT_SUMMARIES[$i]}"
     done
     lx_record notification not-requested || die "could not save preview notification state"
+    lx_record completed_at "$(date -u +%FT%TZ)" || die "could not save preview completion time"
     lx_save "$LX_FAILED" "preview completed (exit $LX_FAILED)" || die "could not save preview report"
     exit "$LX_FAILED"
 fi
 [[ $LX_CANCEL == 0 ]] || exit 130
 printf '\nPackages may restart services. No automatic backup, snapshot, rollback, or reboot.\n'
-confirm "Update these containers with this policy?" n || exit 0
+if [[ $LX_SCHEDULED == 0 ]]; then
+    confirm "Update these containers with this policy?" n || exit 0
+else
+    printf 'Authorized by the configured automatic-update timer; no removals or cleanup.\n'
+fi
 lx_report_start
 
 for id in "${LX_TARGETS[@]}"; do
@@ -279,9 +333,10 @@ step 'Container update results'
 for ((i=0; i<${#REPORT_IDS[@]}; i++)); do
     printf '%s: %s - %s\n' "${REPORT_IDS[$i]}" "${REPORT_STATES[$i]}" "${REPORT_SUMMARIES[$i]}"
 done
+lx_record completed_at "$(date -u +%FT%TZ)" || die "could not save completion time"
 lx_save "$LX_FAILED" "completed (exit $LX_FAILED)" || die "could not save final report"
 if [[ $LX_NOTIFY == 1 ]]; then
-    summary="Host: $LX_NODE | removals/cleanup: $LX_REMOVE | exit: $LX_FAILED"
+    summary="Invocation: $LX_INVOCATION | Host: $LX_NODE | removals/cleanup: $LX_REMOVE | exit: $LX_FAILED"
     for ((i=0; i<${#REPORT_IDS[@]}; i++)); do
         summary+=$'\n'"${REPORT_IDS[$i]}: ${REPORT_STATES[$i]} - ${REPORT_SUMMARIES[$i]}"
     done

--- a/pve-toolbox
+++ b/pve-toolbox
@@ -172,7 +172,8 @@ menu() {
             "$c_bold" "$c_reset" "$c_bold" "$c_reset"
         printf '  %sx%s uninstall selected             %sq%s quit\n\n' \
             "$c_bold" "$c_reset" "$c_bold" "$c_reset"
-        printf '  %sl%s update LXC container packages\n\n' "$c_bold" "$c_reset"
+        printf '  %sl%s update LXC container packages\n' "$c_bold" "$c_reset"
+        printf '  %sa%s configure automatic LXC updates\n\n' "$c_bold" "$c_reset"
 
         local reply
         read -r -p "> " reply || { echo; return 0; }
@@ -181,6 +182,12 @@ menu() {
         case ${reply,,} in
             q|quit|exit) return 0 ;;
             l|lxc-update) cmd_lxc_update || warn "LXC update did not complete" ;;
+            a|lxc-schedule)
+                step "Configure automatic LXC updates"
+                run_module lxc-update module_status_long || true
+                echo
+                run_module lxc-update module_install \
+                    || warn "LXC automatic-update configuration did not complete" ;;
             i|install)
                 [[ ${#SELECTED[@]} -eq 0 ]] && { warn "nothing selected"; continue; }
                 local m; for m in "${SELECTED[@]}"; do
@@ -485,6 +492,7 @@ cmd_ui() {
             status    "Show detailed status" \
             uninstall "Remove installed modules" \
             lxc-update "Update LXC container packages" \
+            lxc-schedule "Configure automatic LXC updates" \
             quit      "Exit") || { tui_clear; return 0; }
         case $choice in
             install)   ui_action "Install / reconfigure" module_install     all       off ;;
@@ -493,6 +501,7 @@ cmd_ui() {
             status)    ui_action "Status"                module_status_long all       on  ;;
             uninstall) ui_action "Uninstall"             module_uninstall   installed off ;;
             lxc-update) ui_lxc_update ;;
+            lxc-schedule) ui_lxc_schedule ;;
             quit)      tui_clear; return 0 ;;
         esac
     done
@@ -514,6 +523,18 @@ ui_lxc_update() {
     cmd_lxc_update "${flags[@]}" "${targets[@]}" || rc=$?
     [[ $rc == 0 ]] || warn "LXC update returned $rc; inspect the results above"
     read -rsn1 -p "press any key to go back to the menu " _ || true
+}
+
+ui_lxc_schedule() {
+    tui_clear
+    step "Configure automatic LXC updates"
+    run_module lxc-update module_status_long || true
+    echo
+    run_module lxc-update module_install \
+        || warn "LXC automatic-update configuration did not complete"
+    echo
+    read -rsn1 -p "press any key to go back to the menu " _ || true
+    echo
 }
 
 cmd_link() {
@@ -613,7 +634,7 @@ done
 
 command_name=${ARGS[0]:-menu}
 [[ ${#LXC_FLAGS[@]} == 0 || $command_name == lxc-update ]] \
-    || usage_error "--dry-run, --allow-removals, and --notify apply only to lxc-update"
+    || usage_error "LXC update flags apply only to lxc-update"
 if [[ $OUTPUT_JSON -eq 1 || $OUTPUT_QUIET -eq 1 ]]; then
     case $command_name in
         status|check|doctor) ;;

--- a/tests/fixtures/lxc-update/command.sh
+++ b/tests/fixtures/lxc-update/command.sh
@@ -66,5 +66,56 @@ case $name in
             if [[ $1 == -d ]]; then printf "%s" "$2" > "$LX_TEST/discord.json"; break; fi
             shift
         done ;;
+    systemd-analyze)
+        schedule=${*: -1}
+        [[ $1 == calendar && -n $schedule && $schedule != nonsense ]] || exit 1
+        if [[ $schedule == '*-02-30 04:00:00' ]]; then
+            printf 'Normalized form: *-02-30 04:00:00\n    Next elapse: never\n'
+        else
+            printf 'Normalized form: %s\n    Next elapse: Sun 2026-09-06 04:00:00 CEST\n' "$schedule"
+        fi ;;
+    systemctl)
+        printf '%s\n' "$*" >> "$LX_TEST/calls"
+        case ${1:-} in
+            daemon-reload) ;;
+            enable)
+                [[ ${2:-} == --now && -n ${3:-} ]] || exit 1
+                if [[ -f $LX_TEST/fail-enable ]]; then
+                    rm "$LX_TEST/fail-enable"
+                    exit 1
+                fi
+                rm -f "$LX_TEST/timer-inactive" "$LX_TEST/timer-failed"
+                printf '%s\n' "$3" > "$LX_TEST/enabled-unit" ;;
+            disable)
+                if [[ -f $LX_TEST/fail-disable ]]; then
+                    rm "$LX_TEST/fail-disable"
+                    exit 1
+                fi
+                rm -f "$LX_TEST/enabled-unit" ;;
+            is-enabled)
+                unit=${*: -1}
+                [[ -f $LX_TEST/enabled-unit && $(<"$LX_TEST/enabled-unit") == "$unit" ]] ;;
+            is-active)
+                unit=${*: -1}
+                [[ $unit == *.timer && -f $LX_TEST/enabled-unit \
+                    && ! -f $LX_TEST/timer-inactive ]] ;;
+            is-failed)
+                unit=${*: -1}
+                if [[ $unit == *.timer ]]; then [[ -f $LX_TEST/timer-failed ]]
+                else [[ -f $LX_TEST/service-failed ]]; fi ;;
+            reset-failed)
+                unit=${*: -1}
+                if [[ $unit == *.timer ]]; then rm -f "$LX_TEST/timer-failed"
+                else rm -f "$LX_TEST/service-failed"; fi ;;
+            show)
+                if [[ $* == *NextElapseUSecRealtime* ]]; then
+                    printf 'Sun 2026-09-06 04:17:00 CEST\n'
+                else
+                    printf 'Sun 2026-08-30 04:11:00 CEST\n'
+                fi ;;
+            list-unit-files)
+                [[ ! -f $LX_TEST/enabled-unit ]] || printf '%s enabled\n' "$(<"$LX_TEST/enabled-unit")" ;;
+            *) ;;
+        esac ;;
     *) exit 64 ;;
 esac

--- a/tests/fixtures/lxc-update/menu.exp
+++ b/tests/fixtures/lxc-update/menu.exp
@@ -14,7 +14,12 @@ proc choose_lxc {} {
     for {set i 0} {$i < 5} {incr i} {send -- "\033\[B"}
     send -- "\r"
 }
+proc choose_lxc_schedule {} {
+    for {set i 0} {$i < 6} {incr i} {send -- "\033\[B"}
+    send -- "\r"
+}
 need {Install or reconfigure modules}
+need {Configure automatic LXC updates}
 choose_lxc
 need {Choose options}
 need {Send Discord report}
@@ -41,6 +46,21 @@ need {notified: LXC package update report}
 need {press any key to go back}
 send -- " "
 need {Install or reconfigure modules}
+choose_lxc_schedule
+need {Excluded container IDs}
+send -- "\r"
+need {Discord webhook URL}
+send -- "\r"
+need {Enable automatic LXC package updates}
+send -- "y\r"
+need {Schedule preset}
+send -- "\r"
+need {Send a Discord report after every automatic run}
+send -- "\r"
+need {enabled pve-toolbox-lxc-update.timer}
+need {press any key to go back}
+send -- " "
+need {Configure automatic LXC updates}
 send -- "\033"
 expect eof
 catch wait result

--- a/tests/fixtures/lxc-update/plain-menu.exp
+++ b/tests/fixtures/lxc-update/plain-menu.exp
@@ -1,0 +1,29 @@
+set timeout 30
+log_user 0
+set env(TERM) xterm
+spawn ./pve-toolbox
+proc need {pattern} {
+    expect {
+        -re $pattern {}
+        timeout {puts "FAIL LXC plain menu timeout: $pattern"; exit 1}
+        eof {puts "FAIL LXC plain menu closed: $pattern"; exit 1}
+    }
+}
+need {configure automatic LXC updates}
+send -- "a\r"
+need {Excluded container IDs}
+send -- "\r"
+need {Discord webhook URL}
+send -- "\r"
+need {Enable automatic LXC package updates}
+send -- "\r"
+need {Schedule preset}
+send -- "\r"
+need {Send a Discord report after every automatic run}
+send -- "\r"
+need {enabled pve-toolbox-lxc-update.timer}
+need {configure automatic LXC updates}
+send -- "q\r"
+expect eof
+catch wait result
+exit [lindex $result 3]

--- a/tests/lxc-schedule.sh
+++ b/tests/lxc-schedule.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+# Exercise the public scheduled-update lifecycle without touching host systemd.
+set -Eeuo pipefail
+
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
+ROOT=$PWD
+
+pass() { printf 'ok  %s\n' "$1"; }
+fail() { printf 'FAIL %s\n' "$1" >&2; exit 1; }
+
+if [[ $EUID -ne 0 ]]; then
+    if command -v unshare >/dev/null 2>&1 && unshare -Ur true 2>/dev/null; then
+        exec unshare -Ur "$0" "$@"
+    fi
+    printf 'skip LXC schedule test, root or an unprivileged user namespace is required\n'
+    exit 0
+fi
+
+LX_TEST=$(mktemp -d)
+trap 'rm -rf -- "$LX_TEST"' EXIT
+export LX_TEST
+mkdir -p "$LX_TEST/bin" "$LX_TEST/conf" "$LX_TEST/state" "$LX_TEST/systemd" \
+    "$LX_TEST/toolbox-bin" "$LX_TEST/toolbox-lib"
+for cmd in pveversion pvesh pct apt-get apt-mark dpkg awk curl systemctl systemd-analyze; do
+    ln -s "$ROOT/tests/fixtures/lxc-update/command.sh" "$LX_TEST/bin/$cmd"
+done
+export PATH="$LX_TEST/bin:$PATH"
+export TOOLBOX_CONF_DIR="$LX_TEST/conf" TOOLBOX_STATE_DIR="$LX_TEST/state" \
+    TOOLBOX_SYSTEMD_DIR="$LX_TEST/systemd" TOOLBOX_BIN_DIR="$LX_TEST/toolbox-bin" \
+    TOOLBOX_LIB_DIR="$LX_TEST/toolbox-lib"
+scheduled_runner() {
+    PVE_TOOLBOX_LIB="$TOOLBOX_LIB_DIR" \
+    LX_GUEST_HELPER="$TOOLBOX_LIB_DIR/lxc-update-guest.sh" \
+        "$TOOLBOX_BIN_DIR/pve-toolbox-lxc-update" --scheduled "$@"
+}
+
+# shellcheck source=lib/common.sh
+source lib/common.sh
+conf_set lxc-update LX_EXCLUDE 103
+conf_set lxc-update DISCORD_WEBHOOK https://discord.com/api/webhooks/123/test-webhook
+cat > "$LX_TEST/inventory.json" <<'JSON'
+[{"vmid":101,"name":"web","status":"running"},
+ {"vmid":102,"name":"db","status":"running"},
+ {"vmid":103,"name":"excluded","status":"running"},
+ {"vmid":104,"name":"off","status":"stopped"}]
+JSON
+: > "$LX_TEST/calls"
+
+./pve-toolbox update lxc-update >/dev/null
+[[ ! -e $LX_TEST/systemd/pve-toolbox-lxc-update.timer ]] \
+    || fail 'upgrading a legacy configuration enabled automatic updates'
+[[ $(./pve-toolbox status lxc-update) == *'configured (manual updates)'* ]] \
+    || fail 'legacy configuration did not remain manual'
+
+LX_SCHEDULE_ENABLED=y LX_SCHEDULE_PRESET=weekly LX_SCHEDULE_NOTIFY=n \
+    ./pve-toolbox --yes install lxc-update >/dev/null
+[[ $(conf_get lxc-update LX_SCHEDULE_ENABLED) == 1 ]] \
+    || fail 'automatic updates were not enabled in configuration'
+[[ $(conf_get lxc-update LX_SCHEDULE) == 'Sun *-*-* 04:00:00' ]] \
+    || fail 'weekly schedule was not saved'
+
+service="$TOOLBOX_SYSTEMD_DIR/pve-toolbox-lxc-update.service"
+timer="$TOOLBOX_SYSTEMD_DIR/pve-toolbox-lxc-update.timer"
+[[ -f $service && -f $timer ]] || fail 'scheduled service or timer was not installed'
+grep -q '^ExecStart=.*pve-toolbox-lxc-update --scheduled$' "$service" \
+    || fail 'service does not use the scheduled runner mode'
+grep -q '^Nice=10$' "$service" || fail 'scheduled service has no reduced CPU priority'
+grep -q '^IOSchedulingClass=idle$' "$service" || fail 'scheduled service has no idle I/O priority'
+grep -q '^TimeoutStartSec=infinity$' "$service" || fail 'scheduled service can terminate apt'
+grep -q '^TimeoutStopSec=infinity$' "$service" || fail 'systemd can time out a stopping apt transaction'
+grep -q '^KillMode=process$' "$service" || fail 'systemd can signal the active pct transaction directly'
+grep -q '^OnCalendar=Sun \*-\*-\* 04:00:00$' "$timer" || fail 'timer lost its calendar'
+grep -q '^RandomizedDelaySec=1800$' "$timer" || fail 'timer has no 30 minute staggering'
+grep -q '^AccuracySec=1s$' "$timer" || fail 'timer delay accuracy is not bounded'
+grep -q '^Persistent=false$' "$timer" || fail 'timer catches up outside the maintenance window'
+grep -q '^enable --now pve-toolbox-lxc-update.timer$' "$LX_TEST/calls" \
+    || fail 'timer was not enabled'
+[[ $(<"$LX_TEST/calls") != *'pct '* ]] \
+    || fail 'enabling the timer immediately entered a container'
+[[ -f $TOOLBOX_LIB_DIR/common.sh && -f $TOOLBOX_LIB_DIR/report.sh \
+    && -f $TOOLBOX_LIB_DIR/discord.sh && -f $TOOLBOX_LIB_DIR/lxc-update-guest.sh ]] \
+    || fail 'scheduled runner dependencies were not installed'
+if grep -q 'TOOLBOX_ROOT=' "$service"; then
+    fail 'scheduled service still depends on the toolbox checkout'
+fi
+
+: > "$LX_TEST/calls"
+scheduled_runner >/dev/null \
+    || fail 'configured scheduled runner failed'
+calls=$(<"$LX_TEST/calls")
+[[ $calls == *'--assume-yes upgrade --with-new-pkgs --no-remove'* ]] \
+    || fail 'scheduled runner did not use the safe upgrade policy'
+[[ $calls != *' dist-upgrade '* && $calls != *' autoremove '* && $calls != *' autoclean '* ]] \
+    || fail 'scheduled runner allowed removals or cleanup'
+[[ $(state_get lxc-update invocation) == scheduled ]] \
+    || fail 'scheduled report did not identify its invocation'
+[[ -n $(state_get lxc-update started_at) && -n $(state_get lxc-update completed_at) ]] \
+    || fail 'scheduled report omitted execution times'
+[[ $(state_get lxc-update container_ids) == *101* ]] \
+    || fail 'scheduled report did not retain result IDs through the state API'
+
+: > "$LX_TEST/calls"
+if scheduled_runner --allow-removals >/dev/null 2>&1; then
+    fail 'scheduled mode accepted removals'
+fi
+[[ ! -s $LX_TEST/calls ]] || fail 'invalid scheduled policy entered a guest'
+
+exec {busy_lock}>"$TOOLBOX_STATE_DIR/lxc-update.lock"
+flock -n "$busy_lock"
+: > "$LX_TEST/calls"
+busy_output=""
+busy_rc=0
+busy_output=$(scheduled_runner 2>&1) || busy_rc=$?
+[[ $busy_rc == 0 && $busy_output == *'scheduled batch skipped'* ]] \
+    || fail 'overlapping scheduled batch was not reported as busy'
+[[ ! -s $LX_TEST/calls ]] || fail 'overlapping scheduled batch entered a guest'
+[[ $(state_get lxc-update-overlap result) == busy \
+    && -n $(state_get lxc-update-overlap skipped_at) ]] \
+    || fail 'overlapping scheduled batch was not retained as a skip'
+flock -u "$busy_lock"
+exec {busy_lock}>&-
+pass 'configured timer runs unattended with the safe scheduled policy'
+
+status=$(./pve-toolbox status lxc-update)
+[[ $status == *'Automatic updates: enabled'* \
+    && $status == *'Schedule: Sun *-*-* 04:00:00'* \
+    && $status == *'Next run: Sun 2026-09-06 04:17:00 CEST'* \
+    && $status == *'Last timer trigger: Sun 2026-08-30 04:11:00 CEST'* \
+    && $status == *'Start now: systemctl start pve-toolbox-lxc-update.service'* \
+    && $status == *'Invocation: scheduled'* ]] \
+    || fail "scheduled status is incomplete: $status"
+
+touch "$LX_TEST/timer-inactive"
+status=$(./pve-toolbox status lxc-update)
+[[ $status == *'degraded'* && $status == *'timer is inactive'* \
+    && $status == *'Next run: Sun 2026-09-06 04:17:00 CEST'* \
+    && $status == *'Last timer trigger: Sun 2026-08-30 04:11:00 CEST'* ]] \
+    || fail "inactive timer lost degraded status or timer history: $status"
+rm "$LX_TEST/timer-inactive"
+touch "$LX_TEST/timer-failed"
+status=$(./pve-toolbox status lxc-update)
+[[ $status == *'degraded'* && $status == *'automatic update timer failed'* ]] \
+    || fail "failed timer was reported healthy: $status"
+rm "$LX_TEST/timer-failed"
+
+rm "$timer"
+status=$(./pve-toolbox status lxc-update)
+[[ $status == *'degraded'* && $status == *'timer file is missing'* ]] \
+    || fail "missing timer was reported healthy: $status"
+if ./pve-toolbox --quiet status lxc-update; then
+    fail 'quiet status returned success for a degraded timer'
+fi
+LX_SCHEDULE_ENABLED=y LX_SCHEDULE_PRESET=weekly LX_SCHEDULE_NOTIFY=n \
+    ./pve-toolbox --yes install lxc-update >/dev/null
+sed -i 's/^OnCalendar=.*/OnCalendar=Mon *-*-* 01:00:00/' "$timer"
+status=$(./pve-toolbox status lxc-update)
+[[ $status == *'degraded'* && $status == *'timer schedule differs from configuration'* ]] \
+    || fail "timer schedule drift was reported healthy: $status"
+LX_SCHEDULE_ENABLED=y LX_SCHEDULE_PRESET=weekly LX_SCHEDULE_NOTIFY=n \
+    ./pve-toolbox --yes install lxc-update >/dev/null
+pass 'status exposes schedule timing, execution origin and timer drift'
+
+# Scheduled notification policy is read from configuration. It reports every
+# batch, while preflight and delivery failures keep the package result rules of
+# the confirmed manual path.
+LX_SCHEDULE_ENABLED=y LX_SCHEDULE_PRESET=weekly LX_SCHEDULE_NOTIFY=y \
+    ./pve-toolbox --yes install lxc-update >/dev/null
+: > "$LX_TEST/calls"
+scheduled_runner >/dev/null \
+    || fail 'Discord-enabled scheduled run failed'
+jq -e '.embeds[0].description | contains("Invocation: scheduled") and contains("ct.101")' \
+    "$LX_TEST/discord.json" >/dev/null || fail 'scheduled Discord report lost its identity or results'
+[[ $(state_get lxc-update notification) == delivered ]] \
+    || fail 'scheduled Discord delivery was not recorded'
+
+: > "$LX_TEST/fail-notify"
+: > "$LX_TEST/calls"
+scheduled_runner >/dev/null \
+    || fail 'Discord delivery failure changed the scheduled package result'
+[[ $(state_get lxc-update notification) == failed ]] \
+    || fail 'scheduled Discord failure was not recorded'
+rm "$LX_TEST/fail-notify"
+
+conf_set lxc-update DISCORD_WEBHOOK ''
+: > "$LX_TEST/calls"
+status=$(./pve-toolbox status lxc-update)
+[[ $status == *'degraded'* && $status == *'automatic Discord webhook is invalid'* ]] \
+    || fail "invalid automatic webhook was reported healthy: $status"
+if scheduled_runner >/dev/null 2>&1; then
+    fail 'scheduled run accepted a missing requested webhook'
+fi
+if grep -Eq '^(pct|apt|discord) ' "$LX_TEST/calls"; then
+    fail 'missing scheduled webhook did not fail before guest work'
+fi
+conf_set lxc-update DISCORD_WEBHOOK https://discord.com/api/webhooks/123/test-webhook
+
+: > "$LX_TEST/fail-refresh-101"
+: > "$LX_TEST/calls"
+if scheduled_runner >/dev/null; then
+    fail 'scheduled container failure returned success'
+fi
+grep -q '^pct 102 refresh$' "$LX_TEST/calls" \
+    || fail 'scheduled batch stopped after one container failed'
+[[ $(state_get lxc-update exit_code) == 1 ]] \
+    || fail 'scheduled failure was not retained'
+rm "$LX_TEST/fail-refresh-101"
+
+cat > "$LX_TEST/inventory.json" <<'JSON'
+[{"vmid":103,"name":"excluded","status":"running"},
+ {"vmid":104,"name":"off","status":"stopped"}]
+JSON
+: > "$LX_TEST/calls"
+scheduled_runner >/dev/null \
+    || fail 'all-skipped scheduled batch returned failure'
+[[ $(state_get lxc-update exit_code) == 0 ]] \
+    || fail 'all-skipped scheduled result was not successful'
+jq -e '.embeds[0].description | contains("ct.103: skipped") and contains("ct.104: skipped")' \
+    "$LX_TEST/discord.json" >/dev/null || fail 'all-skipped scheduled report was not delivered'
+pass 'scheduled reporting and partial failures retain the manual batch contract'
+
+# A module refresh keeps the exact configured calendar and refuses to replace
+# its runner while a package batch owns the shared lock.
+LX_SCHEDULE_ENABLED=y LX_SCHEDULE_PRESET=custom \
+LX_SCHEDULE='Tue *-*-* 02:30:00' LX_SCHEDULE_NOTIFY=n \
+    ./pve-toolbox --yes install lxc-update >/dev/null
+cp "$(conf_file lxc-update)" "$LX_TEST/conf-before-identical-active-change"
+exec {identical_lock}>"$TOOLBOX_STATE_DIR/lxc-update.lock"
+flock -n "$identical_lock"
+if LX_SCHEDULE_ENABLED=y LX_SCHEDULE_PRESET=daily LX_SCHEDULE_NOTIFY=n \
+    ./pve-toolbox --yes install lxc-update >/dev/null 2>&1; then
+    fail 'reconfiguration replaced an identical runner during an active batch'
+fi
+cmp -s "$(conf_file lxc-update)" "$LX_TEST/conf-before-identical-active-change" \
+    || fail 'active-batch refusal changed configuration with an identical runner'
+flock -u "$identical_lock"
+exec {identical_lock}>&-
+printf '# stale runner\n' > "$TOOLBOX_BIN_DIR/pve-toolbox-lxc-update"
+status=$(./pve-toolbox status lxc-update)
+[[ $status == *'degraded'* && $status == *'scheduled runner differs from this toolbox'* ]] \
+    || fail "stale scheduled runner was reported healthy: $status"
+cp "$(conf_file lxc-update)" "$LX_TEST/conf-before-active-change"
+exec {schedule_lock}>"$TOOLBOX_STATE_DIR/lxc-update.lock"
+flock -n "$schedule_lock"
+if LX_SCHEDULE_ENABLED=y LX_SCHEDULE_PRESET=daily LX_SCHEDULE_NOTIFY=n \
+    ./pve-toolbox --yes install lxc-update >/dev/null 2>&1; then
+    fail 'reconfiguration replaced a stale runner during an active batch'
+fi
+cmp -s "$(conf_file lxc-update)" "$LX_TEST/conf-before-active-change" \
+    || fail 'failed active-batch reconfiguration changed the schedule'
+if ./pve-toolbox update lxc-update >/dev/null 2>&1; then
+    fail 'module update replaced the runner during an active batch'
+fi
+grep -q '^# stale runner$' "$TOOLBOX_BIN_DIR/pve-toolbox-lxc-update" \
+    || fail 'active-batch refusal changed the runner'
+flock -u "$schedule_lock"
+exec {schedule_lock}>&-
+./pve-toolbox update lxc-update >/dev/null || fail 'idle module update failed'
+cmp -s modules/lxc-update/run.sh "$TOOLBOX_BIN_DIR/pve-toolbox-lxc-update" \
+    || fail 'module update did not refresh the scheduled runner'
+grep -q '^OnCalendar=Tue \*-\*-\* 02:30:00$' "$timer" \
+    || fail 'module update changed the configured schedule'
+pass 'module updates preserve schedules and cannot race a package batch'
+
+# Invalid reconfiguration leaves the working schedule intact. Disabling stops
+# future runs without discarding operator settings or the last report.
+conf_set lxc-update LX_SCHEDULE_NOTIFY 1
+cp "$timer" "$LX_TEST/timer-before-invalid"
+cp "$(conf_file lxc-update)" "$LX_TEST/conf-before-invalid"
+if LX_SCHEDULE_ENABLED=y LX_SCHEDULE_PRESET=custom LX_SCHEDULE=nonsense \
+    ./pve-toolbox --yes install lxc-update >/dev/null 2>&1; then
+    fail 'invalid custom schedule was accepted'
+fi
+cmp -s "$timer" "$LX_TEST/timer-before-invalid" \
+    || fail 'invalid schedule changed the working timer'
+cmp -s "$(conf_file lxc-update)" "$LX_TEST/conf-before-invalid" \
+    || fail 'invalid schedule changed configuration'
+if LX_SCHEDULE_ENABLED=y LX_SCHEDULE_PRESET=custom LX_SCHEDULE='*-02-30 04:00:00' \
+    ./pve-toolbox --yes install lxc-update >/dev/null 2>&1; then
+    fail 'custom schedule with no future elapse was accepted'
+fi
+cmp -s "$(conf_file lxc-update)" "$LX_TEST/conf-before-invalid" \
+    || fail 'dead schedule changed configuration'
+
+: > "$LX_TEST/fail-enable"
+if LX_SCHEDULE_ENABLED=y LX_SCHEDULE_PRESET=daily LX_SCHEDULE_NOTIFY=n \
+    ./pve-toolbox --yes install lxc-update >/dev/null 2>&1; then
+    fail 'timer enable failure returned success'
+fi
+rm -f "$LX_TEST/fail-enable"
+cmp -s "$timer" "$LX_TEST/timer-before-invalid" \
+    || fail 'timer enable failure did not restore the working unit'
+cmp -s "$(conf_file lxc-update)" "$LX_TEST/conf-before-invalid" \
+    || fail 'timer enable failure did not restore configuration'
+grep -q '^enable --now pve-toolbox-lxc-update.timer$' "$LX_TEST/calls" \
+    || fail 'working timer was not restored after enable failure'
+
+: > "$LX_TEST/fail-disable"
+if LX_SCHEDULE_ENABLED=n ./pve-toolbox --yes install lxc-update >/dev/null 2>&1; then
+    fail 'timer stop failure returned success'
+fi
+cmp -s "$timer" "$LX_TEST/timer-before-invalid" \
+    || fail 'timer stop failure did not retain the working unit'
+cmp -s "$(conf_file lxc-update)" "$LX_TEST/conf-before-invalid" \
+    || fail 'timer stop failure did not restore configuration'
+
+last_report=$(<"$TOOLBOX_STATE_DIR/lxc-update.state")
+LX_SCHEDULE_ENABLED=n ./pve-toolbox --yes install lxc-update >/dev/null
+[[ $(conf_get lxc-update LX_SCHEDULE_ENABLED) == 0 ]] \
+    || fail 'automatic updates remained enabled'
+[[ $(conf_get lxc-update LX_SCHEDULE) == 'Tue *-*-* 02:30:00' ]] \
+    || fail 'disabling discarded the configured calendar'
+[[ $(conf_get lxc-update LX_EXCLUDE) == 103 ]] \
+    || fail 'disabling discarded exclusions'
+[[ $(conf_get lxc-update LX_SCHEDULE_NOTIFY) == 1 ]] \
+    || fail 'disabling discarded the scheduled notification preference'
+[[ ! -e $service && ! -e $timer ]] || fail 'disabling retained systemd units'
+[[ $(<"$TOOLBOX_STATE_DIR/lxc-update.state") == "$last_report" ]] \
+    || fail 'disabling changed the last report'
+touch "$LX_TEST/timer-failed"
+status=$(./pve-toolbox status lxc-update)
+[[ $status == *'degraded'* \
+    && $status == *'scheduler files remain while automatic updates are disabled'* ]] \
+    || fail "orphan failed timer was hidden while scheduling was disabled: $status"
+./pve-toolbox update lxc-update >/dev/null \
+    || fail 'disabled module did not clear the orphan failed timer state'
+[[ ! -e $LX_TEST/timer-failed ]] || fail 'failed timer state was not cleared'
+: > "$LX_TEST/calls"
+if scheduled_runner >/dev/null 2>&1; then
+    fail 'disabled automatic runner still updated containers'
+fi
+[[ ! -s $LX_TEST/calls ]] || fail 'disabled automatic runner entered a guest'
+status=$(./pve-toolbox status lxc-update)
+[[ $status == *'Automatic updates: disabled'* ]] \
+    || fail "disabled schedule status is wrong: $status"
+pass 'invalid and disabled schedules preserve the last working operator state'
+
+# Re-enable so uninstall has a complete scheduled installation to remove.
+LX_SCHEDULE_ENABLED=y LX_SCHEDULE_PRESET=weekly LX_SCHEDULE_NOTIFY=n \
+    ./pve-toolbox --yes install lxc-update >/dev/null
+./pve-toolbox --yes uninstall lxc-update >/dev/null
+[[ ! -e $(conf_file lxc-update) && ! -e $service && ! -e $timer \
+    && ! -e $TOOLBOX_BIN_DIR/pve-toolbox-lxc-update \
+    && ! -e $TOOLBOX_LIB_DIR/lxc-update-guest.sh ]] \
+    || fail 'uninstall retained schedule configuration or runtime files'
+[[ -f $TOOLBOX_STATE_DIR/lxc-update.state ]] \
+    || fail 'uninstall removed the last report'
+pass 'uninstall removes scheduler files and retains the report'

--- a/tests/lxc-update.sh
+++ b/tests/lxc-update.sh
@@ -13,12 +13,15 @@ fi
 LX_TEST=$(mktemp -d)
 trap 'rm -rf -- "$LX_TEST"' EXIT
 export LX_TEST
-mkdir -p "$LX_TEST/bin" "$LX_TEST/conf" "$LX_TEST/state"
-for cmd in pveversion pvesh pct apt-get apt-mark dpkg awk curl; do
+mkdir -p "$LX_TEST/bin" "$LX_TEST/conf" "$LX_TEST/state" "$LX_TEST/systemd" \
+    "$LX_TEST/toolbox-bin" "$LX_TEST/toolbox-lib"
+for cmd in pveversion pvesh pct apt-get apt-mark dpkg awk curl systemctl systemd-analyze; do
     ln -s "$ROOT/tests/fixtures/lxc-update/command.sh" "$LX_TEST/bin/$cmd"
 done
 export PATH="$LX_TEST/bin:$PATH"
-export TOOLBOX_CONF_DIR="$LX_TEST/conf" TOOLBOX_STATE_DIR="$LX_TEST/state"
+export TOOLBOX_CONF_DIR="$LX_TEST/conf" TOOLBOX_STATE_DIR="$LX_TEST/state" \
+    TOOLBOX_SYSTEMD_DIR="$LX_TEST/systemd" TOOLBOX_BIN_DIR="$LX_TEST/toolbox-bin" \
+    TOOLBOX_LIB_DIR="$LX_TEST/toolbox-lib"
 # shellcheck source=lib/common.sh
 source lib/common.sh
 conf_set lxc-update LX_EXCLUDE 103
@@ -120,7 +123,7 @@ reset_calls
 execute 103 || fail 'explicit excluded container should remain a documented skip'
 [[ ! -s $LX_TEST/calls ]] || fail 'explicit selection bypassed saved exclusion'
 ./pve-toolbox update lxc-update >/dev/null
-[[ ! -s $LX_TEST/calls ]] || fail 'toolkit update ran guest updates'
+if grep -Eq '^(pct|apt) ' "$LX_TEST/calls"; then fail 'toolkit update ran guest updates'; fi
 pass 'exclusions stay authoritative and toolkit module updates do not enter guests'
 
 reset_calls
@@ -160,7 +163,8 @@ pass 'overlapping batch execution fails before entering any guest'
 conf_set lxc-update DISCORD_WEBHOOK https://discord.com/api/webhooks/123/test-webhook
 if command -v whiptail >/dev/null; then
     expect tests/fixtures/lxc-update/menu.exp || fail 'LXC menu flow failed'
-    pass 'driven terminal preview and confirmed Discord-enabled execution'
+    expect tests/fixtures/lxc-update/plain-menu.exp || fail 'LXC plain menu schedule flow failed'
+    pass 'driven terminal manual updates and automatic schedule configuration'
 elif [[ ${TUI_TEST_REQUIRED:-0} == 1 ]]; then
     fail 'LXC menu test requires whiptail'
 else

--- a/tests/tui.exp
+++ b/tests/tui.exp
@@ -71,7 +71,8 @@ need {Space toggles} "install checklist"
 send -- "\r"
 need {Install or reconfigure modules} "empty selection returns to the menu"
 
-# quit entry, six rows down from install
+# quit entry, seven rows down from install
+send -- "\033\[B"
 send -- "\033\[B"
 send -- "\033\[B"
 send -- "\033\[B"


### PR DESCRIPTION
## What

Adds opt-in automatic package updates for eligible local Debian and Ubuntu LXC containers. Operators can configure daily, weekly, or custom schedules from either terminal menu and optionally receive a Discord report after every completed batch.

## Why

Container updates previously required an interactive confirmed run, which made routine node maintenance entirely manual.

## How

A node-local systemd timer invokes an installed, checkout-independent runner. Scheduled batches keep the existing non-removing policy, saved exclusions, sequential execution, locking, credential filtering, and per-container failure reporting. Reconfiguration and module updates preserve the exact schedule and notification preference without starting guest work.

## Testing

- `make lint`
- `mkdocs build --strict`
- Driven plain and full-screen terminal flows
- Complete Debian 13 suite with all TUI, Zsh, config-backup, package-install, packaging, and signed-repository gates required
- Exact tested package SHA-256: `fd3306c613890751d6a542db919e9bee6fc496981cb9f1f83537d8fd60a6ee47`

Two permission-denial fixture cases were skipped because the disposable validation container ran as root; all required gates passed.

## UI evidence

![Full-screen menu with automatic LXC update configuration](https://github.com/user-attachments/assets/7cb175be-7db8-49b8-8bf8-7f05db9824c2)

![Automatic LXC update configuration flow](https://github.com/user-attachments/assets/1eabe64c-2bf7-443f-bcda-d4ae684725be)

## Notes

This adds systemd units, installed runtime helpers, and three operator configuration keys. Existing installations remain manual until scheduling is explicitly enabled. Version files remain at `0.5.1` for Release Please.
