### PR TITLE
feat(zfs-scrub): migrate schedules to native timers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ test: syntax
 	@./tests/lib.sh
 	@./tests/migrations.sh
 	@./tests/native-notification-migration.sh
+	@./tests/native-zfs-scrub-migration.sh
 	@./tests/pve.sh
 	@./tests/report.sh
 	@./tests/doctor.sh

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ delivery, and then removes the obsolete provisioning module and its private
 state. Manage notification targets and matchers in PVE; the package retains
 the independent `pve-toolbox-native-notify` sender. See
 [Native notifications](https://quwisky.github.io/pve-toolbox/native-notifications/).
+Existing toolbox ZFS scrub schedules are also validated and preserved through
+native Debian ZFS timer overrides without starting a scrub during the upgrade.
 The trusted repository signing key has fingerprint
 `C354 8BC5 2A3D 5375 57DB 2A7F 84A4 3B72 AE04 34F2`.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -60,6 +60,12 @@ package-owned sender and every PVE object, template, and credential. See
 [Native notifications](native-notifications.md) for ongoing management and
 safe removal.
 
+The ZFS scrub schedule migration preserves each pool's effective calendar in
+a native Debian ZFS timer override. It enables the native timer before
+disabling the toolbox timer and never starts a timer or scrub during package
+configuration. See [ZFS scrub](modules/zfs-scrub.md#package-upgrade-schedule-migration)
+for conflict handling, rollback, and activation after the upgrade.
+
 ## Git checkout
 
 PVE 8 hosts use the checkout path, which remains fully supported:

--- a/docs/modules/zfs-scrub.md
+++ b/docs/modules/zfs-scrub.md
@@ -41,6 +41,39 @@ pve-toolbox-zfs-scrub@backup.timer  Sun *-*-15..21 03:00:00
 Every schedule is a plain systemd `OnCalendar` you are asked about at install
 time, so the stagger is a default, not a rule.
 
+## Package upgrade schedule migration
+
+Upgrades from 0.6.x move every configured pool to the native
+`zfs-scrub@.service` supplied by Debian's `zfsutils-linux` package. The
+migration reads the installed pool list and the effective `OnCalendar` from
+each toolbox timer, validates them, and writes one override at:
+
+```text
+/etc/systemd/system/zfs-scrub-weekly@<pool>.timer.d/override.conf
+```
+
+The weekly template name identifies the native timer used; the override keeps
+the original schedule and 30-minute randomized delay. The migration refuses
+missing native units, mismatched pool state, unsafe timer files, existing
+native overrides, or an already enabled native schedule.
+
+Each native timer is enabled and verified before its old toolbox timer is
+disabled. Neither timer nor service is started during package configuration,
+so a persistent timer cannot launch a missed scrub in the middle of an
+upgrade. The enabled native timers become active at the next boot. To activate
+one earlier, first finish the package upgrade and check that its pool is not
+already scrubbing, then run:
+
+```bash
+systemctl start zfs-scrub-weekly@<pool>.timer
+```
+
+Starting a persistent timer may immediately run an event missed while it was
+inactive. A failed or interrupted migration restores the prior timer states,
+configuration, and native override files. After success, `install` and
+`update` leave native ownership unchanged; `status` identifies the native
+timers.
+
 ## What the report says
 
 | Colour                                            | When                                                                                            |

--- a/migrations/020-native-zfs-scrub-schedules.sh
+++ b/migrations/020-native-zfs-scrub-schedules.sh
@@ -1,0 +1,237 @@
+# shellcheck shell=bash disable=SC2034
+# Move toolbox scrub schedules to Debian's native ZFS timer and service.
+# This fragment is sourced by run-migrations.sh and must remain side-effect free.
+
+MIGRATION_TARGET_VERSION=0.7.0
+MIGRATION_FILES=(
+    "${PVE_TOOLBOX_CONF_DIR:-/etc/pve-toolbox}/zfs-scrub.conf"
+    "${PVE_TOOLBOX_STATE_DIR:-/var/lib/pve-toolbox}/zfs-scrub.state"
+)
+MIGRATION_SYSTEMD_FILES=()
+MIGRATION_UNITS=()
+MIGRATION_KEEP_UNIT_STATE=1
+
+_M020_POOLS=()
+_M020_SCHEDULES=()
+
+_m020_error() {
+    printf 'pve-toolbox: native ZFS scrub migration: %s\n' "$1" >&2
+}
+
+_m020_safe_file() {
+    local path=$1 private=$2 mode
+    [[ -f $path && ! -L $path ]] || return 1
+    [[ $(stat -c '%u' "$path") -eq $EUID ]] || return 1
+    mode=$(stat -c '%a' "$path")
+    if [[ $private -eq 1 ]]; then
+        (( (8#$mode & 077) == 0 ))
+    else
+        (( (8#$mode & 022) == 0 ))
+    fi
+}
+
+_m020_state_pools() (
+    local state=$1
+    unset POOLS
+    # Toolbox state contains only shell-quoted assignments and is read only
+    # after its type, owner, and write permissions have been checked.
+    # shellcheck source=/dev/null
+    source "$state"
+    printf '%s' "${POOLS:-}"
+)
+
+_m020_valid_pool() {
+    [[ $1 =~ ^[A-Za-z][A-Za-z0-9_.:-]*$ ]]
+}
+
+_m020_schedule_from() {
+    local timer=$1
+    local -a calendars=()
+    mapfile -t calendars < <(sed -n 's/^OnCalendar=//p' "$timer")
+    [[ ${#calendars[@]} -eq 1 && -n ${calendars[0]} ]] || return 1
+    printf '%s' "${calendars[0]}"
+}
+
+migration_prepare() {
+    local conf state systemd_dir timer pool schedule native monthly override
+    local state_value state_pool old_state native_state monthly_state
+    local -a timer_pools=() state_pools=()
+    local -A timer_seen=() state_seen=()
+
+    conf="${PVE_TOOLBOX_CONF_DIR:-/etc/pve-toolbox}/zfs-scrub.conf"
+    state="${PVE_TOOLBOX_STATE_DIR:-/var/lib/pve-toolbox}/zfs-scrub.state"
+    systemd_dir=${PVE_TOOLBOX_SYSTEMD_DIR:-/etc/systemd/system}
+    _M020_POOLS=()
+    _M020_SCHEDULES=()
+    MIGRATION_SYSTEMD_FILES=()
+    MIGRATION_UNITS=()
+
+    for timer in "$systemd_dir"/pve-toolbox-zfs-scrub@*.timer; do
+        [[ -e $timer || -L $timer ]] || continue
+        _m020_safe_file "$timer" 0 || {
+            _m020_error "legacy timer is not a protected regular file: $timer"
+            return 1
+        }
+        pool=${timer##*@}
+        pool=${pool%.timer}
+        _m020_valid_pool "$pool" || {
+            _m020_error "legacy timer has an unsafe pool instance: $timer"
+            return 1
+        }
+        [[ -z ${timer_seen[$pool]+x} ]] || {
+            _m020_error "legacy timer repeats pool '$pool'"
+            return 1
+        }
+        schedule=$(_m020_schedule_from "$timer") || {
+            _m020_error "legacy timer for '$pool' has no single effective OnCalendar"
+            return 1
+        }
+        systemd-analyze calendar "$schedule" >/dev/null 2>&1 || {
+            _m020_error "legacy timer for '$pool' has an invalid OnCalendar: $schedule"
+            return 1
+        }
+        timer_seen[$pool]=1
+        timer_pools+=("$pool")
+        _M020_SCHEDULES+=("$schedule")
+    done
+
+    if [[ ${#timer_pools[@]} -eq 0 && ! -e $conf && ! -L $conf \
+        && ! -e $state && ! -L $state ]]; then
+        return 0
+    fi
+    _m020_safe_file "$conf" 1 && _m020_safe_file "$state" 0 || {
+        _m020_error "legacy config and state must both be protected regular files"
+        return 1
+    }
+    state_value=$(_m020_state_pools "$state") || {
+        _m020_error "could not read the installed pool list from legacy state"
+        return 1
+    }
+    read -r -a state_pools <<<"$state_value"
+    [[ ${#state_pools[@]} -gt 0 ]] || {
+        _m020_error "legacy state contains no installed pool list"
+        return 1
+    }
+    for state_pool in "${state_pools[@]}"; do
+        _m020_valid_pool "$state_pool" || {
+            _m020_error "legacy state contains an unsafe pool name: $state_pool"
+            return 1
+        }
+        [[ -z ${state_seen[$state_pool]+x} ]] || {
+            _m020_error "legacy state repeats pool '$state_pool'"
+            return 1
+        }
+        state_seen[$state_pool]=1
+        [[ -n ${timer_seen[$state_pool]+x} ]] || {
+            _m020_error "legacy state lists '$state_pool' without a timer"
+            return 1
+        }
+    done
+    [[ ${#state_pools[@]} -eq ${#timer_pools[@]} ]] || {
+        _m020_error "legacy timer set does not match the installed pool list"
+        return 1
+    }
+
+    systemctl cat zfs-scrub@.service >/dev/null 2>&1 \
+        && systemctl cat zfs-scrub-weekly@.timer >/dev/null 2>&1 || {
+        _m020_error "native zfs-scrub service and weekly timer are required"
+        return 1
+    }
+
+    for pool in "${timer_pools[@]}"; do
+        native="zfs-scrub-weekly@$pool.timer"
+        monthly="zfs-scrub-monthly@$pool.timer"
+        override="$systemd_dir/$native.d/override.conf"
+        [[ ! -e ${override%/*} && ! -L ${override%/*} ]] || {
+            _m020_error "native timer for '$pool' already has local overrides"
+            return 1
+        }
+        old_state=$(systemctl is-enabled \
+            "pve-toolbox-zfs-scrub@$pool.timer" 2>/dev/null || true)
+        native_state=$(systemctl is-enabled "$native" 2>/dev/null || true)
+        monthly_state=$(systemctl is-enabled "$monthly" 2>/dev/null || true)
+        [[ $old_state == enabled || $old_state == disabled ]] || {
+            _m020_error "legacy timer for '$pool' has unsupported enablement state '$old_state'"
+            return 1
+        }
+        if [[ $native_state != disabled || $monthly_state != disabled ]] \
+            || systemctl is-active --quiet "$native" >/dev/null 2>&1 \
+            || systemctl is-active --quiet "$monthly" >/dev/null 2>&1; then
+            _m020_error "native scrub scheduling for '$pool' is already enabled, masked, or otherwise claimed"
+            return 1
+        fi
+        _M020_POOLS+=("$pool")
+        MIGRATION_SYSTEMD_FILES+=("$override")
+        MIGRATION_UNITS+=(
+            "pve-toolbox-zfs-scrub@$pool.timer"
+            "$native"
+            "$monthly"
+        )
+    done
+}
+
+migration_apply() {
+    local systemd_dir state pool schedule native monthly old override dir tmp i
+    systemd_dir=${PVE_TOOLBOX_SYSTEMD_DIR:-/etc/systemd/system}
+    state="${PVE_TOOLBOX_STATE_DIR}/zfs-scrub.state"
+    [[ ${#_M020_POOLS[@]} -gt 0 ]] || return 0
+
+    for i in "${!_M020_POOLS[@]}"; do
+        pool=${_M020_POOLS[$i]}
+        schedule=${_M020_SCHEDULES[$i]}
+        native="zfs-scrub-weekly@$pool.timer"
+        override="$systemd_dir/$native.d/override.conf"
+        dir=${override%/*}
+        [[ ! -e $dir && ! -L $dir ]] || {
+            _m020_error "refusing changed native timer override path for '$pool'"
+            return 1
+        }
+        mkdir -- "$dir"
+        chmod 0755 -- "$dir"
+        cat > "$override" <<EOF
+[Timer]
+OnCalendar=
+OnCalendar=$schedule
+RandomizedDelaySec=1800
+EOF
+        chmod 0644 -- "$override"
+    done
+    systemctl daemon-reload >/dev/null 2>&1 || {
+        _m020_error "could not reload systemd after writing native timer overrides"
+        return 1
+    }
+
+    # Enabling a timer does not start it, so Persistent=true cannot launch a
+    # missed scrub while dpkg is still configuring the package.
+    for pool in "${_M020_POOLS[@]}"; do
+        native="zfs-scrub-weekly@$pool.timer"
+        systemctl enable "$native" >/dev/null 2>&1 \
+            && systemctl is-enabled --quiet "$native" >/dev/null 2>&1 || {
+            _m020_error "could not enable and verify native timer '$native'"
+            return 1
+        }
+    done
+
+    for pool in "${_M020_POOLS[@]}"; do
+        native="zfs-scrub-weekly@$pool.timer"
+        monthly="zfs-scrub-monthly@$pool.timer"
+        old="pve-toolbox-zfs-scrub@$pool.timer"
+        systemctl disable "$old" >/dev/null 2>&1 || {
+            _m020_error "could not disable legacy scrub timer for '$pool'"
+            return 1
+        }
+        systemctl is-enabled --quiet "$native" >/dev/null 2>&1 \
+            && ! systemctl is-enabled --quiet "$monthly" >/dev/null 2>&1 \
+            && ! systemctl is-enabled --quiet "$old" >/dev/null 2>&1 || {
+            _m020_error "duplicate scrub schedule guard failed for '$pool'"
+            return 1
+        }
+    done
+
+    tmp=$(mktemp "${state%/*}/.zfs-scrub.state.XXXXXX")
+    grep -Ev '^(SCHEDULE_OWNER|NATIVE_TIMER_TEMPLATE)=' "$state" > "$tmp" || true
+    printf 'SCHEDULE_OWNER=%q\n' native >> "$tmp"
+    printf 'NATIVE_TIMER_TEMPLATE=%q\n' zfs-scrub-weekly@.timer >> "$tmp"
+    chmod 0644 -- "$tmp"
+    mv -f -- "$tmp" "$state"
+}

--- a/modules/zfs-scrub/module.sh
+++ b/modules/zfs-scrub/module.sh
@@ -37,6 +37,10 @@ _zs_defaults() {
 
 _zs_pools() { zpool list -H -o name 2>/dev/null; }
 
+_zs_native_owner() {
+    [[ $(state_get "$MODULE_NAME" SCHEDULE_OWNER 2>/dev/null) == native ]]
+}
+
 # Pool names may contain . - : which are not legal in a variable name.
 _zs_var() { # _zs_var <pool> -> ZFS_SCRUB_SCHEDULE_<POOL>
     local p=${1//[^A-Za-z0-9]/_}
@@ -195,6 +199,8 @@ _zs_webhook_shown() {
 
 module_install() {
     require_root
+    _zs_native_owner \
+        && die "scrub schedules were migrated to native ZFS timers; manage them with systemctl"
     require_pve
     have_zfs || die "no zpool binary - this module needs ZFS on the host"
     _zs_defaults
@@ -333,6 +339,10 @@ module_update() {
     require_root
     local check_only=0
     [[ ${1:-} == --check ]] && check_only=1
+    if _zs_native_owner; then
+        info "scrub schedules are managed by native ZFS timers"
+        return 0
+    fi
 
     _zs_scheduled
     [[ ${#ZS_SCHEDULED[@]} -eq 0 ]] && die "not installed"
@@ -458,6 +468,20 @@ module_update() {
 # ---------------------------------------------------------------- status --
 
 module_status() {
+    if _zs_native_owner; then
+        local native_pools pool
+        native_pools=$(state_get "$MODULE_NAME" POOLS)
+        [[ -n $native_pools ]] || { printf 'invalid native timer state'; return 0; }
+        for pool in $native_pools; do
+            if ! systemctl is-enabled --quiet \
+                "zfs-scrub-weekly@$pool.timer" 2>/dev/null; then
+                printf 'native timer disabled  [%s]' "$pool"
+                return 0
+            fi
+        done
+        printf 'native timers  [%s]' "$native_pools"
+        return 0
+    fi
     _zs_scheduled
     if [[ ${#ZS_SCHEDULED[@]} -eq 0 ]]; then
         printf 'not installed'
@@ -490,6 +514,15 @@ module_status() {
 }
 
 module_status_long() {
+    if _zs_native_owner; then
+        printf '  scheduling  native ZFS timers\n'
+        printf '  pools       %s\n' "$(state_get "$MODULE_NAME" POOLS)"
+        printf '  template    %s\n' \
+            "$(state_get "$MODULE_NAME" NATIVE_TIMER_TEMPLATE)"
+        echo
+        systemctl list-timers 'zfs-scrub-weekly@*' --no-pager 2>/dev/null || true
+        return 0
+    fi
     _zs_scheduled
     if [[ ${#ZS_SCHEDULED[@]} -eq 0 ]]; then
         warn "not installed"
@@ -518,6 +551,8 @@ module_status_long() {
 
 module_uninstall() {
     require_root
+    local native_owner=0
+    _zs_native_owner && native_owner=1
     _zs_scheduled
     local p
     for p in "${ZS_SCHEDULED[@]}"; do
@@ -542,5 +577,8 @@ module_uninstall() {
         fi
     fi
     dim "  $TOOLBOX_LIB_DIR/discord.sh is shared with other modules and stays"
+    if [[ $native_owner -eq 1 ]]; then
+        warn "native ZFS scrub timers and their preserved schedules stay enabled"
+    fi
     warn "a scrub already running in the kernel is not stopped - 'zpool scrub -s <pool>' does that"
 }

--- a/scripts/run-migrations.sh
+++ b/scripts/run-migrations.sh
@@ -17,6 +17,7 @@ else
 fi
 CONF_DIR=${PVE_TOOLBOX_CONF_DIR:-/etc/pve-toolbox}
 STATE_DIR=${PVE_TOOLBOX_STATE_DIR:-/var/lib/pve-toolbox}
+SYSTEMD_DIR=${PVE_TOOLBOX_SYSTEMD_DIR:-/etc/systemd/system}
 BACKUP_ROOT=${PVE_TOOLBOX_MIGRATION_BACKUP_DIR:-/var/backups/pve-toolbox/migrations}
 RUN_DIR=${PVE_TOOLBOX_RUN_DIR:-/run/pve-toolbox}
 PREVIOUS_VERSION=$1
@@ -93,12 +94,30 @@ completed() {
         && grep -Fqx -- "$1" "$STATE_DIR/migrations.state"
 }
 
-managed_file_path() {
+managed_data_file_path() {
     local path=$1 parent=${1%/*}
     [[ $path == /* && $path != *$'\n'* && $path != *$'\t'* ]] || return 1
     [[ $parent == "$CONF_DIR" || $parent == "$STATE_DIR" ]] || return 1
     [[ $path != "$STATE_DIR/migrations.state" \
         && $path != "$STATE_DIR/migration.pending" ]]
+}
+
+managed_systemd_file_path() {
+    local path=$1 parent relative canonical_systemd_dir
+    canonical_systemd_dir=$(realpath -e -- "$SYSTEMD_DIR" 2>/dev/null) || return 1
+    [[ $path == /* && $path != *$'\n'* && $path != *$'\t'* \
+        && -d $SYSTEMD_DIR && ! -L $SYSTEMD_DIR \
+        && $canonical_systemd_dir == "$SYSTEMD_DIR" ]] || return 1
+    relative=${path#"$SYSTEMD_DIR/"}
+    [[ $relative != "$path" \
+        && $relative =~ ^[A-Za-z0-9_.@:-]+\.timer\.d/override\.conf$ ]] \
+        || return 1
+    parent=${path%/*}
+    [[ ! -L $parent && ( ! -e $parent || -d $parent ) ]]
+}
+
+managed_file_path() {
+    managed_data_file_path "$1" || managed_systemd_file_path "$1"
 }
 
 record_completed() {
@@ -112,27 +131,37 @@ record_completed() {
     mv -f -- "$tmp" "$STATE_DIR/migrations.state"
 }
 
+backup_one_file() {
+    local backup=$1 path=$2 relative
+    if [[ -L $path || ( -e $path && ! -f $path ) ]]; then
+        printf 'pve-toolbox: refusing unsafe migration path: %s\n' "$path" >&2
+        return 1
+    fi
+    relative=${path#/}
+    if [[ -f $path ]]; then
+        mkdir -p -- "$backup/files/${relative%/*}"
+        cp -a -- "$path" "$backup/files/$relative"
+        printf 'present\t%s\n' "$path" >> "$backup/manifest"
+    else
+        printf 'absent\t%s\n' "$path" >> "$backup/manifest"
+    fi
+}
+
 backup_files() {
-    local backup=$1 path relative
+    local backup=$1 path
     mkdir -p -- "$backup/files"
     chmod 0700 -- "$backup" "$backup/files"
     : > "$backup/manifest"
     chmod 0600 -- "$backup/manifest"
     for path in "${MIGRATION_FILES[@]}"; do
-        managed_file_path "$path" \
+        managed_data_file_path "$path" \
             || { printf 'pve-toolbox: invalid migration path: %q\n' "$path" >&2; return 1; }
-        if [[ -L $path || ( -e $path && ! -f $path ) ]]; then
-            printf 'pve-toolbox: refusing unsafe migration path: %s\n' "$path" >&2
-            return 1
-        fi
-        if [[ -f $path ]]; then
-            relative=${path#/}
-            mkdir -p -- "$backup/files/${relative%/*}"
-            cp -a -- "$path" "$backup/files/$relative"
-            printf 'present\t%s\n' "$path" >> "$backup/manifest"
-        else
-            printf 'absent\t%s\n' "$path" >> "$backup/manifest"
-        fi
+        backup_one_file "$backup" "$path" || return 1
+    done
+    for path in "${MIGRATION_SYSTEMD_FILES[@]}"; do
+        managed_systemd_file_path "$path" \
+            || { printf 'pve-toolbox: invalid migration systemd path: %q\n' "$path" >&2; return 1; }
+        backup_one_file "$backup" "$path" || return 1
     done
 }
 
@@ -177,7 +206,14 @@ preserve_file_metadata() {
 validate_file_results() {
     local path
     for path in "${MIGRATION_FILES[@]}"; do
-        managed_file_path "$path" || return 1
+        managed_data_file_path "$path" || return 1
+        if [[ -L $path || ( -e $path && ! -f $path ) ]]; then
+            printf 'pve-toolbox: unsafe migration result: %s\n' "$path" >&2
+            return 1
+        fi
+    done
+    for path in "${MIGRATION_SYSTEMD_FILES[@]}"; do
+        managed_systemd_file_path "$path" || return 1
         if [[ -L $path || ( -e $path && ! -f $path ) ]]; then
             printf 'pve-toolbox: unsafe migration result: %s\n' "$path" >&2
             return 1
@@ -186,7 +222,7 @@ validate_file_results() {
 }
 
 restore_files() {
-    local backup=$1 kind path relative
+    local backup=$1 kind path relative parent
     [[ $backup == "$BACKUP_ROOT/"* && -d $backup && ! -L $backup \
         && -r $backup/manifest ]] || {
         printf 'pve-toolbox: migration backup is missing or unsafe: %s\n' "$backup" >&2
@@ -206,6 +242,10 @@ restore_files() {
             absent)
                 [[ ! -e $path || -f $path || -L $path ]] || return 1
                 rm -f -- "$path"
+                if managed_systemd_file_path "$path"; then
+                    parent=${path%/*}
+                    rmdir -- "$parent" 2>/dev/null || true
+                fi
                 ;;
             *) return 1 ;;
         esac
@@ -295,7 +335,7 @@ migration_failed() {
 }
 
 run_migration() {
-    local file=$1 id backup mode declaration
+    local file=$1 id backup mode declaration restore_after_apply=1
     id=${file##*/}; id=${id%.sh}
     [[ $id =~ ^[0-9][0-9A-Za-z._-]*$ ]] \
         || { printf 'pve-toolbox: invalid migration filename: %s\n' "${file##*/}" >&2; return 1; }
@@ -310,11 +350,14 @@ run_migration() {
     (( (8#$mode & 022) == 0 )) \
         || { printf 'pve-toolbox: migration is group/world writable: %s\n' "$file" >&2; return 1; }
 
-    unset -f migration_apply 2>/dev/null || true
-    unset MIGRATION_TARGET_VERSION MIGRATION_FILES MIGRATION_UNITS
+    unset -f migration_apply migration_prepare 2>/dev/null || true
+    unset MIGRATION_TARGET_VERSION MIGRATION_FILES MIGRATION_SYSTEMD_FILES \
+        MIGRATION_UNITS MIGRATION_KEEP_UNIT_STATE
     declare -g MIGRATION_TARGET_VERSION=
-    declare -ag MIGRATION_FILES=() MIGRATION_UNITS=()
-    # Package-owned migration fragments only define metadata and migration_apply.
+    declare -ag MIGRATION_FILES=() MIGRATION_SYSTEMD_FILES=() MIGRATION_UNITS=()
+    declare -gi MIGRATION_KEEP_UNIT_STATE=0
+    # Package-owned fragments define metadata, an optional read-only prepare
+    # hook, and migration_apply.
     # shellcheck source=/dev/null
     source "$file"
     declare -F migration_apply >/dev/null \
@@ -324,13 +367,21 @@ run_migration() {
         || { printf 'pve-toolbox: migration has no target version: %s\n' "$file" >&2; return 1; }
     dpkg --validate-version "$MIGRATION_TARGET_VERSION" >/dev/null 2>&1 \
         || { printf 'pve-toolbox: migration has invalid target version: %s\n' "$file" >&2; return 1; }
-    [[ $(declare -p MIGRATION_FILES 2>/dev/null) == 'declare -a '* \
-        && $(declare -p MIGRATION_UNITS 2>/dev/null) == 'declare -a '* ]] \
-        || { printf 'pve-toolbox: migration metadata must use indexed arrays: %s\n' "$file" >&2; return 1; }
     if dpkg --compare-versions "$PREVIOUS_VERSION" ge "$MIGRATION_TARGET_VERSION"; then
         record_completed "$id"
         return 0
     fi
+    if declare -F migration_prepare >/dev/null && ! migration_prepare; then
+        printf 'pve-toolbox: migration preparation failed: %s\n' "$file" >&2
+        return 1
+    fi
+    [[ $(declare -p MIGRATION_FILES 2>/dev/null) == 'declare -a '* \
+        && $(declare -p MIGRATION_SYSTEMD_FILES 2>/dev/null) == 'declare -a '* \
+        && $(declare -p MIGRATION_UNITS 2>/dev/null) == 'declare -a '* \
+        && $(declare -p MIGRATION_KEEP_UNIT_STATE 2>/dev/null) == 'declare -i '* \
+        && ( $MIGRATION_KEEP_UNIT_STATE -eq 0 || $MIGRATION_KEEP_UNIT_STATE -eq 1 ) ]] \
+        || { printf 'pve-toolbox: migration metadata is invalid: %s\n' "$file" >&2; return 1; }
+    [[ $MIGRATION_KEEP_UNIT_STATE -eq 0 ]] || restore_after_apply=0
 
     ensure_safe_directory "$BACKUP_ROOT" 0700
     backup="$BACKUP_ROOT/$id-$(date -u +%Y%m%dT%H%M%SZ)-$$"
@@ -354,9 +405,15 @@ run_migration() {
         return 1
     fi
     if ! validate_file_results \
-        || ! preserve_file_metadata "$backup" \
-        || ! restore_units "$backup" \
-        || ! record_completed "$id"; then
+        || ! preserve_file_metadata "$backup"; then
+        migration_failed "$id" "$backup" 1
+        return 1
+    fi
+    if [[ $restore_after_apply -eq 1 ]] && ! restore_units "$backup"; then
+        migration_failed "$id" "$backup" 1
+        return 1
+    fi
+    if ! record_completed "$id"; then
         migration_failed "$id" "$backup" 1
         return 1
     fi

--- a/tests/hardening.sh
+++ b/tests/hardening.sh
@@ -192,8 +192,22 @@ pass "zfs-replication locks and fixups fail closed"
     if _zs_enable tank >/dev/null 2>&1; then
         fail "scrub timer enable failure was swallowed"
     fi
+
+    state_set zfs-scrub POOLS 'tank backup'
+    state_set zfs-scrub SCHEDULE_OWNER native
+    state_set zfs-scrub NATIVE_TIMER_TEMPLATE zfs-scrub-weekly@.timer
+    require_root() { :; }
+    if ( module_install ) >/dev/null 2>&1; then
+        fail "migrated native schedules could be claimed by module install"
+    fi
+    native_update=$(module_update --check)
+    [[ $native_update == *'managed by native ZFS timers'* ]] \
+        || fail "module update did not preserve migrated native schedules"
+    systemctl() { [[ $1 == is-enabled && $2 == --quiet ]]; }
+    [[ $(module_status) == 'native timers  [tank backup]' ]] \
+        || fail "module status did not report native schedule ownership"
 ) || exit 1
-pass "zfs-scrub rejects schedule collisions and timer failures"
+pass "zfs-scrub rejects unsafe timers and preserves native ownership"
 
 # --- scrutiny collector install and update transactions --------------------
 

--- a/tests/native-zfs-scrub-migration.sh
+++ b/tests/native-zfs-scrub-migration.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# Upgrade fixtures for moving toolbox scrub schedules to native ZFS timers.
+set -Eeuo pipefail
+
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
+ROOT=$PWD
+WORK=$(mktemp -d)
+trap 'rm -rf -- "$WORK"' EXIT
+
+pass() { printf 'ok  %s\n' "$1"; }
+fail() { printf 'FAIL %s\n' "$1" >&2; exit 1; }
+
+write_fake_systemctl() {
+    local bin=$1
+    cat > "$bin/systemctl" <<'SYSTEMCTL'
+#!/usr/bin/env bash
+set -euo pipefail
+root=$PVE_TOOLBOX_SYSTEMCTL_ROOT
+action=${1:-}
+shift || true
+printf '%s' "$action" >> "$PVE_TOOLBOX_SYSTEMCTL_LOG"
+printf '\t%s' "$@" >> "$PVE_TOOLBOX_SYSTEMCTL_LOG"
+printf '\n' >> "$PVE_TOOLBOX_SYSTEMCTL_LOG"
+unit=${*: -1}
+case $action in
+    cat)
+        [[ -f $root/templates/$unit ]]
+        ;;
+    is-enabled)
+        if [[ -f $root/enabled/$unit ]]; then
+            [[ ${1:-} == --quiet ]] || printf 'enabled\n'
+            exit 0
+        fi
+        [[ ${1:-} == --quiet ]] || printf 'disabled\n'
+        exit 1
+        ;;
+    is-active)
+        [[ -f $root/active/$unit ]]
+        ;;
+    enable)
+        [[ ${PVE_TOOLBOX_FAIL_ENABLE_UNIT:-} != "$unit" ]] || exit 5
+        : > "$root/enabled/$unit"
+        ;;
+    disable)
+        [[ ${PVE_TOOLBOX_FAIL_DISABLE_UNIT:-} != "$unit" ]] || exit 6
+        rm -f -- "$root/enabled/$unit"
+        [[ " $* " != *' --now '* ]] || rm -f -- "$root/active/$unit"
+        ;;
+    start)
+        [[ ${PVE_TOOLBOX_FAIL_START_UNIT:-} != "$unit" ]] || exit 7
+        : > "$root/active/$unit"
+        ;;
+    stop)
+        rm -f -- "$root/active/$unit"
+        ;;
+    daemon-reload) : ;;
+    *) exit 64 ;;
+esac
+SYSTEMCTL
+    chmod 0755 "$bin/systemctl"
+    cat > "$bin/systemd-analyze" <<'ANALYZE'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ ${1:-} == calendar && -n ${2:-} && $2 != invalid ]]
+ANALYZE
+    chmod 0755 "$bin/systemd-analyze"
+}
+
+setup_case() { # setup_case <dir> <pool|schedule|active>...
+    local case_dir=$1 fixture pool schedule active pools=""
+    shift
+    mkdir -p "$case_dir"/{bin,config,state,systemd,migrations,backups,run} \
+        "$case_dir/systemctl"/{enabled,active,templates}
+    cp -- "$ROOT/migrations/020-native-zfs-scrub-schedules.sh" \
+        "$case_dir/migrations/"
+    chmod 0644 "$case_dir/migrations/020-native-zfs-scrub-schedules.sh"
+    write_fake_systemctl "$case_dir/bin"
+    : > "$case_dir/systemctl/templates/zfs-scrub@.service"
+    : > "$case_dir/systemctl/templates/zfs-scrub-weekly@.timer"
+    printf 'DISCORD_WEBHOOK=%q\n' 'https://discord.com/api/webhooks/id/token' \
+        > "$case_dir/config/zfs-scrub.conf"
+    chmod 0600 "$case_dir/config/zfs-scrub.conf"
+    for fixture in "$@"; do
+        pool=${fixture%%|*}
+        active=${fixture##*|}
+        schedule=${fixture#*|}
+        schedule=${schedule%|*}
+        pools+="${pools:+ }$pool"
+        cat > "$case_dir/systemd/pve-toolbox-zfs-scrub@$pool.timer" <<EOF
+[Timer]
+OnCalendar=$schedule
+RandomizedDelaySec=1800
+Persistent=true
+Unit=pve-toolbox-zfs-scrub@$pool.service
+EOF
+        chmod 0644 "$case_dir/systemd/pve-toolbox-zfs-scrub@$pool.timer"
+        : > "$case_dir/systemctl/enabled/pve-toolbox-zfs-scrub@$pool.timer"
+        if [[ $active == active ]]; then
+            : > "$case_dir/systemctl/active/pve-toolbox-zfs-scrub@$pool.timer"
+        fi
+    done
+    {
+        printf 'POOLS=%q\n' "$pools"
+        printf 'INTERVAL=300\nNOTIFY_START=y\n'
+    } > "$case_dir/state/zfs-scrub.state"
+    chmod 0644 "$case_dir/state/zfs-scrub.state"
+}
+
+run_case() { # run_case <dir> [environment assignments...]
+    local case_dir=$1
+    shift
+    env \
+        PATH="$case_dir/bin:$PATH" \
+        PVE_TOOLBOX_MIGRATION_DIR="$case_dir/migrations" \
+        PVE_TOOLBOX_CONF_DIR="$case_dir/config" \
+        PVE_TOOLBOX_STATE_DIR="$case_dir/state" \
+        PVE_TOOLBOX_SYSTEMD_DIR="$case_dir/systemd" \
+        PVE_TOOLBOX_MIGRATION_BACKUP_DIR="$case_dir/backups" \
+        PVE_TOOLBOX_RUN_DIR="$case_dir/run" \
+        PVE_TOOLBOX_SYSTEMCTL_ROOT="$case_dir/systemctl" \
+        PVE_TOOLBOX_SYSTEMCTL_LOG="$case_dir/systemctl.log" \
+        "$@" "$ROOT/scripts/run-migrations.sh" 0.6.0
+}
+
+assert_enabled() { [[ -f $1/systemctl/enabled/$2 ]]; }
+assert_disabled() { [[ ! -e $1/systemctl/enabled/$2 ]]; }
+assert_active() { [[ -f $1/systemctl/active/$2 ]]; }
+assert_inactive() { [[ ! -e $1/systemctl/active/$2 ]]; }
+
+success="$WORK/success"
+setup_case "$success" \
+    'tank|Sun *-*-01..07 03:00:00|active' \
+    'backup|Mon *-*-15..21 04:30:00|inactive'
+tank_before=$(sha256sum "$success/systemd/pve-toolbox-zfs-scrub@tank.timer")
+backup_before=$(sha256sum "$success/systemd/pve-toolbox-zfs-scrub@backup.timer")
+run_case "$success" >/dev/null || fail "multi-pool native timer migration failed"
+for fixture in \
+    'tank|Sun *-*-01..07 03:00:00' \
+    'backup|Mon *-*-15..21 04:30:00'; do
+    pool=${fixture%%|*}
+    schedule=${fixture#*|}
+    override="$success/systemd/zfs-scrub-weekly@$pool.timer.d/override.conf"
+    grep -Fxq "OnCalendar=$schedule" "$override" \
+        || fail "native timer lost the exact $pool schedule"
+    [[ $(grep -c '^OnCalendar=' "$override") -eq 2 \
+        && $(sed -n '2p' "$override") == OnCalendar= \
+        && $(sed -n '4p' "$override") == RandomizedDelaySec=1800 ]] \
+        || fail "native timer override for $pool is incomplete"
+    assert_enabled "$success" "zfs-scrub-weekly@$pool.timer" \
+        || fail "native timer for $pool is not enabled"
+    assert_inactive "$success" "zfs-scrub-weekly@$pool.timer" \
+        || fail "migration started native timer for $pool"
+    assert_disabled "$success" "zfs-scrub-monthly@$pool.timer" \
+        || fail "monthly duplicate remains enabled for $pool"
+    assert_disabled "$success" "pve-toolbox-zfs-scrub@$pool.timer" \
+        || fail "legacy duplicate remains enabled for $pool"
+done
+[[ $(sha256sum "$success/systemd/pve-toolbox-zfs-scrub@tank.timer") == "$tank_before" \
+    && $(sha256sum "$success/systemd/pve-toolbox-zfs-scrub@backup.timer") == "$backup_before" ]] \
+    || fail "migration rewrote the legacy timer files"
+grep -Fxq SCHEDULE_OWNER=native "$success/state/zfs-scrub.state" \
+    || fail "migration did not record native schedule ownership"
+grep -Fxq 020-native-zfs-scrub-schedules "$success/state/migrations.state" \
+    || fail "migration was not recorded"
+if grep -E $'^(start|enable)\t.*--now|^(start|stop)\t.*\.service' \
+    "$success/systemctl.log" >/dev/null; then
+    fail "migration could start or interrupt a pool scrub"
+fi
+native_line=$(grep -n $'^enable\tzfs-scrub-weekly@tank.timer$' \
+    "$success/systemctl.log" | head -n1 | cut -d: -f1)
+old_line=$(grep -n $'^disable\tpve-toolbox-zfs-scrub@tank.timer$' \
+    "$success/systemctl.log" | head -n1 | cut -d: -f1)
+[[ $native_line -lt $old_line ]] \
+    || fail "legacy timer was disabled before the native timer was verified"
+log_lines=$(wc -l < "$success/systemctl.log")
+run_case "$success" >/dev/null || fail "repeat migration failed"
+[[ $(wc -l < "$success/systemctl.log") -eq $log_lines ]] \
+    || fail "completed migration changed timer state again"
+pass "multiple pools preserve exact schedules without starting a scrub"
+pass "completed native timer migration is idempotent"
+
+conflict="$WORK/conflict"
+setup_case "$conflict" 'tank|weekly|active'
+: > "$conflict/systemctl/enabled/zfs-scrub-weekly@tank.timer"
+conflict_state=$(sha256sum "$conflict/state/zfs-scrub.state")
+conflict_output=""
+conflict_rc=0
+conflict_output=$(run_case "$conflict" 2>&1) || conflict_rc=$?
+[[ $conflict_rc -ne 0 && $conflict_output == *'already enabled'* \
+    && $(sha256sum "$conflict/state/zfs-scrub.state") == "$conflict_state" \
+    && ! -e $conflict/systemd/zfs-scrub-weekly@tank.timer.d ]] \
+    || fail "pre-existing native timer conflict changed the schedule"
+assert_enabled "$conflict" pve-toolbox-zfs-scrub@tank.timer \
+    || fail "conflict disabled the legacy timer"
+assert_active "$conflict" pve-toolbox-zfs-scrub@tank.timer \
+    || fail "conflict stopped the legacy timer"
+pass "pre-existing native scheduling fails before timer changes"
+
+missing="$WORK/missing"
+setup_case "$missing" 'tank|weekly|inactive'
+rm -- "$missing/systemctl/templates/zfs-scrub@.service"
+missing_output=""
+missing_rc=0
+missing_output=$(run_case "$missing" 2>&1) || missing_rc=$?
+[[ $missing_rc -ne 0 && $missing_output == *'service and weekly timer are required'* \
+    && ! -e $missing/systemd/zfs-scrub-weekly@tank.timer.d ]] \
+    || fail "missing native units did not stop before changes"
+pass "native service and timer presence is required"
+
+rollback="$WORK/rollback"
+setup_case "$rollback" \
+    'tank|Sun *-*-01..07 03:00:00|active' \
+    'backup|Mon *-*-15..21 04:30:00|inactive'
+rollback_state=$(sha256sum "$rollback/state/zfs-scrub.state")
+rollback_output=""
+rollback_rc=0
+rollback_output=$(run_case "$rollback" \
+    PVE_TOOLBOX_FAIL_DISABLE_UNIT=pve-toolbox-zfs-scrub@backup.timer \
+    2>&1) || rollback_rc=$?
+[[ $rollback_rc -ne 0 && $rollback_output == *'disable legacy scrub timer'* \
+    && $rollback_output == *'restored files'* ]] \
+    || fail "timer switch failure did not report rollback"
+[[ $(sha256sum "$rollback/state/zfs-scrub.state") == "$rollback_state" \
+    && ! -e $rollback/state/migrations.state ]] \
+    || fail "timer switch failure changed or recorded legacy state"
+for pool in tank backup; do
+    assert_enabled "$rollback" "pve-toolbox-zfs-scrub@$pool.timer" \
+        || fail "rollback did not re-enable legacy timer for $pool"
+    assert_disabled "$rollback" "zfs-scrub-weekly@$pool.timer" \
+        || fail "rollback retained native timer for $pool"
+    [[ ! -e $rollback/systemd/zfs-scrub-weekly@$pool.timer.d ]] \
+        || fail "rollback retained native override for $pool"
+done
+assert_active "$rollback" pve-toolbox-zfs-scrub@tank.timer \
+    || fail "rollback did not restart the previously active timer"
+assert_inactive "$rollback" pve-toolbox-zfs-scrub@backup.timer \
+    || fail "rollback started the previously inactive timer"
+backup_state=$(find "$rollback/backups" \
+    -path '*/files/*/zfs-scrub.state' -type f -print -quit)
+[[ -n $backup_state \
+    && $(sha256sum "$backup_state" | awk '{print $1}') == "${rollback_state%% *}" ]] \
+    || fail "rollback did not retain the original configuration backup"
+pass "timer switch failures restore files and exact enabled state"


### PR DESCRIPTION
## What

Migrates every installed toolbox ZFS scrub schedule to Debian's native ZFS scrub service and timer. Each pool keeps its exact calendar and randomized delay.

## Why

The custom toolbox timer duplicates scheduling already supplied by `zfsutils-linux`. Existing installations need to move without losing schedules or launching a scrub during package configuration.

Closes #55

## How

The migration validates the legacy pool list, timer files, schedules, native units, and conflicts before changing systemd. It creates guarded native timer overrides, enables and verifies every native timer, then disables the old timers. The migration runner now backs up approved systemd overrides and can retain intentional unit-state changes while restoring them on failure or interruption.

## Testing

- `make lint`
- `mkdocs build --strict`
- `TUI_TEST_REQUIRED=1 ZSH_TEST_REQUIRED=1 CB_GATE_TESTS_REQUIRED=1 PACKAGING_TEST_REQUIRED=1 PACKAGING_INSTALL_TEST_REQUIRED=1 REPOSITORY_TEST_REQUIRED=1 make test`

## Notes

This changes package migration and systemd timer state. Native timers are enabled without being started, preventing persistent timers from launching a missed scrub during the upgrade; they activate at the next boot or when the operator starts them after the upgrade. Version and release files are unchanged.
