### PR TITLE
fix(zfs-scrub): recover missing state during package upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ the independent `pve-toolbox-native-notify` sender. See
 [Native notifications](https://quwisky.github.io/pve-toolbox/native-notifications/).
 Existing toolbox ZFS scrub schedules are also validated and preserved through
 native Debian ZFS timer overrides without starting a scrub during the upgrade.
+Missing derived scrub state can be recovered from validated legacy timers and
+service configuration; unsafe or inconsistent existing state still stops the
+migration.
 The trusted repository signing key has fingerprint
 `C354 8BC5 2A3D 5375 57DB 2A7F 84A4 3B72 AE04 34F2`.
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,7 @@
 pve-toolbox (0.7.0) unstable; urgency=medium
 
+  * Recover missing ZFS scrub state from validated legacy timer and service
+    configuration during upgrades, preserving schedules and rollback.
   * **notifications:** remove target provisioning ([#65](https://github.com/quwisky/pve-toolbox/issues/65)) ([f36b667](https://github.com/quwisky/pve-toolbox/commit/f36b667501f8bee970c20714cd0c66a83cb48a4b))
   * **package:** add guarded upgrade migrations ([#62](https://github.com/quwisky/pve-toolbox/issues/62)) ([d2a5f97](https://github.com/quwisky/pve-toolbox/commit/d2a5f97a54dcc58694727e2731f4101d6b6487a3))
   * **package:** migrate notification ownership ([#64](https://github.com/quwisky/pve-toolbox/issues/64)) ([e7e3d57](https://github.com/quwisky/pve-toolbox/commit/e7e3d57ecac4f41d4922fdb1a741a13c5999fbd9)), closes [#53](https://github.com/quwisky/pve-toolbox/issues/53)

--- a/docs/modules/zfs-scrub.md
+++ b/docs/modules/zfs-scrub.md
@@ -57,6 +57,23 @@ the original schedule and 30-minute randomized delay. The migration refuses
 missing native units, mismatched pool state, unsafe timer files, existing
 native overrides, or an already enabled native schedule.
 
+If `/var/lib/pve-toolbox/zfs-scrub.state` is missing but the protected scrub
+configuration and legacy timers remain, the migration can reconstruct the
+pool list. It requires the original protected scrub service, the expected
+timer-to-service links, and loaded unit files without drop-ins or pending
+edits. It writes only the verified pool list and native ownership markers;
+credentials and calendars are preserved. An unsafe or inconsistent existing
+state file is still rejected. Failed recovery restores the original absence
+of state along with the previous timer states.
+
+If 0.7.0 package configuration stopped with `legacy config and state must both
+be protected regular files`, install a package containing this recovery fix.
+If that corrected package has already been unpacked, retry as root:
+
+```bash
+dpkg --configure pve-toolbox
+```
+
 Each native timer is enabled and verified before its old toolbox timer is
 disabled. Neither timer nor service is started during package configuration,
 so a persistent timer cannot launch a missed scrub in the middle of an

--- a/migrations/020-native-zfs-scrub-schedules.sh
+++ b/migrations/020-native-zfs-scrub-schedules.sh
@@ -13,6 +13,7 @@ MIGRATION_KEEP_UNIT_STATE=1
 
 _M020_POOLS=()
 _M020_SCHEDULES=()
+_M020_RECOVER_STATE=0
 
 _m020_error() {
     printf 'pve-toolbox: native ZFS scrub migration: %s\n' "$1" >&2
@@ -52,9 +53,38 @@ _m020_schedule_from() {
     printf '%s' "${calendars[0]}"
 }
 
+_m020_recovery_unit() { # require the protected, unmodified file systemd loaded
+    local unit=$1 file=$2 value
+    _m020_safe_file "$file" 0 || return 1
+    value=$(systemctl show --property=FragmentPath --value "$unit" 2>/dev/null) \
+        && [[ $value == "$file" ]] || return 1
+    value=$(systemctl show --property=DropInPaths --value "$unit" 2>/dev/null) \
+        && [[ -z $value ]] || return 1
+    value=$(systemctl show --property=NeedDaemonReload --value "$unit" 2>/dev/null) \
+        && [[ $value == no ]]
+}
+
+_m020_recovery_service() {
+    local file=$1 conf=$2
+    # Recognize the legacy runner and its config without sourcing credentials
+    # or interpreting arbitrary service files as shell code.
+    awk -v conf="Environment=SCRUB_CONF=$conf" \
+        -v runner="ExecStart=${TOOLBOX_BIN_DIR:-/usr/local/bin}/pve-toolbox-zfs-scrub %i" '
+        /^\[/ { service = ($0 == "[Service]") }
+        service && /^[[:space:]]*ExecStart[[:space:]]*=/ {
+            starts++; if ($0 != runner) bad = 1
+        }
+        service && /^[[:space:]]*Environment[[:space:]]*=/ && /SCRUB_CONF/ {
+            configs++; if ($0 != conf) bad = 1
+        }
+        service && /^[[:space:]]*(EnvironmentFile|UnsetEnvironment)[[:space:]]*=/ { bad = 1 }
+        END { exit !(starts == 1 && configs == 1 && !bad) }
+    ' "$file"
+}
+
 migration_prepare() {
     local conf state systemd_dir timer pool schedule native monthly override
-    local state_value state_pool old_state native_state monthly_state
+    local state_value state_pool old_state native_state monthly_state service target
     local -a timer_pools=() state_pools=()
     local -A timer_seen=() state_seen=()
 
@@ -63,6 +93,7 @@ migration_prepare() {
     systemd_dir=${PVE_TOOLBOX_SYSTEMD_DIR:-/etc/systemd/system}
     _M020_POOLS=()
     _M020_SCHEDULES=()
+    _M020_RECOVER_STATE=0
     MIGRATION_SYSTEMD_FILES=()
     MIGRATION_UNITS=()
 
@@ -99,15 +130,49 @@ migration_prepare() {
         && ! -e $state && ! -L $state ]]; then
         return 0
     fi
-    _m020_safe_file "$conf" 1 && _m020_safe_file "$state" 0 || {
-        _m020_error "legacy config and state must both be protected regular files"
+    _m020_safe_file "$conf" 1 || {
+        _m020_error "legacy config is missing or unsafe; expected a protected regular file: $conf"
         return 1
     }
-    state_value=$(_m020_state_pools "$state") || {
-        _m020_error "could not read the installed pool list from legacy state"
-        return 1
-    }
-    read -r -a state_pools <<<"$state_value"
+    if [[ ! -e $state && ! -L $state ]]; then
+        [[ ${#timer_pools[@]} -gt 0 ]] || {
+            _m020_error "legacy state is missing and no timers establish installed pools; review the retained configuration: $conf"
+            return 1
+        }
+        service="$systemd_dir/pve-toolbox-zfs-scrub@.service"
+        _m020_safe_file "$service" 0 && _m020_recovery_service "$service" "$conf" || {
+            _m020_error "legacy state is missing and the scrub service is missing, unsafe, or unrecognized; restore the original service and retry"
+            return 1
+        }
+        for pool in "${timer_pools[@]}"; do
+            timer="pve-toolbox-zfs-scrub@$pool.timer"
+            target="pve-toolbox-zfs-scrub@$pool.service"
+            _m020_recovery_unit "$timer" "$systemd_dir/$timer" \
+                && _m020_recovery_unit "$target" "$service" || {
+                _m020_error "cannot recover missing state for '$pool': legacy units have overrides, changed paths, or pending edits; review them before retrying"
+                return 1
+            }
+            state_value=$(systemctl show --property=Unit --value "$timer" 2>/dev/null) \
+                && [[ $state_value == "$target" ]] || {
+                _m020_error "cannot recover missing state for '$pool': legacy timer does not target the expected scrub service"
+                return 1
+            }
+        done
+        # Legacy module status/update already use timer files as the pool
+        # inventory. Rebuild only the derived facts needed by this migration.
+        state_pools=("${timer_pools[@]}")
+        _M020_RECOVER_STATE=1
+    else
+        _m020_safe_file "$state" 0 || {
+            _m020_error "legacy state is unsafe; expected a protected regular file: $state"
+            return 1
+        }
+        state_value=$(_m020_state_pools "$state") || {
+            _m020_error "could not read the installed pool list from legacy state"
+            return 1
+        }
+        read -r -a state_pools <<<"$state_value"
+    fi
     [[ ${#state_pools[@]} -gt 0 ]] || {
         _m020_error "legacy state contains no installed pool list"
         return 1
@@ -175,6 +240,10 @@ migration_apply() {
     systemd_dir=${PVE_TOOLBOX_SYSTEMD_DIR:-/etc/systemd/system}
     state="${PVE_TOOLBOX_STATE_DIR}/zfs-scrub.state"
     [[ ${#_M020_POOLS[@]} -gt 0 ]] || return 0
+    if [[ $_M020_RECOVER_STATE -eq 1 && ( -e $state || -L $state ) ]]; then
+        _m020_error "legacy state appeared after recovery preparation; refusing to replace it"
+        return 1
+    fi
 
     for i in "${!_M020_POOLS[@]}"; do
         pool=${_M020_POOLS[$i]}
@@ -228,10 +297,19 @@ EOF
         }
     done
 
-    tmp=$(mktemp "${state%/*}/.zfs-scrub.state.XXXXXX")
-    grep -Ev '^(SCHEDULE_OWNER|NATIVE_TIMER_TEMPLATE)=' "$state" > "$tmp" || true
-    printf 'SCHEDULE_OWNER=%q\n' native >> "$tmp"
-    printf 'NATIVE_TIMER_TEMPLATE=%q\n' zfs-scrub-weekly@.timer >> "$tmp"
-    chmod 0644 -- "$tmp"
-    mv -f -- "$tmp" "$state"
+    tmp=$(mktemp "${state%/*}/.zfs-scrub.state.XXXXXX") || return 1
+    if [[ $_M020_RECOVER_STATE -eq 1 ]]; then
+        printf 'POOLS=%q\n' "${_M020_POOLS[*]}" > "$tmp" \
+            || { rm -f -- "$tmp"; return 1; }
+    else
+        sed '/^SCHEDULE_OWNER=/d; /^NATIVE_TIMER_TEMPLATE=/d' "$state" > "$tmp" \
+            || { rm -f -- "$tmp"; return 1; }
+    fi
+    if ! printf '%s\n' 'SCHEDULE_OWNER=native' \
+        'NATIVE_TIMER_TEMPLATE=zfs-scrub-weekly@.timer' >> "$tmp" \
+        || ! chmod 0644 -- "$tmp" || ! mv -f -- "$tmp" "$state"; then
+        rm -f -- "$tmp"
+        _m020_error "could not write native scrub ownership state"
+        return 1
+    fi
 }

--- a/tests/native-zfs-scrub-migration.sh
+++ b/tests/native-zfs-scrub-migration.sh
@@ -23,6 +23,26 @@ printf '\t%s' "$@" >> "$PVE_TOOLBOX_SYSTEMCTL_LOG"
 printf '\n' >> "$PVE_TOOLBOX_SYSTEMCTL_LOG"
 unit=${*: -1}
 case $action in
+    show)
+        property=${1#--property=}
+        case $property in
+            FragmentPath)
+                if [[ ${PVE_TOOLBOX_FAKE_FRAGMENT:-} ]]; then
+                    printf '%s\n' "$PVE_TOOLBOX_FAKE_FRAGMENT"
+                    exit 0
+                fi
+                if [[ $unit == *.service ]]; then
+                    printf '%s/pve-toolbox-zfs-scrub@.service\n' "$PVE_TOOLBOX_SYSTEMD_DIR"
+                else
+                    printf '%s/%s\n' "$PVE_TOOLBOX_SYSTEMD_DIR" "$unit"
+                fi
+                ;;
+            DropInPaths) printf '%s' "${PVE_TOOLBOX_FAKE_DROP_INS:-}" ;;
+            NeedDaemonReload) printf '%s\n' "${PVE_TOOLBOX_FAKE_RELOAD:-no}" ;;
+            Unit) printf '%s\n' "${PVE_TOOLBOX_FAKE_TIMER_UNIT:-${unit%.timer}.service}" ;;
+            *) exit 64 ;;
+        esac
+        ;;
     cat)
         [[ -f $root/templates/$unit ]]
         ;;
@@ -64,6 +84,16 @@ set -euo pipefail
 [[ ${1:-} == calendar && -n ${2:-} && $2 != invalid ]]
 ANALYZE
     chmod 0755 "$bin/systemd-analyze"
+    cat > "$bin/mv" <<'MOVE'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ ${PVE_TOOLBOX_FAIL_RECORD:-0} == 1 \
+    && ${!#} == "$PVE_TOOLBOX_STATE_DIR/migrations.state" ]]; then
+    exit 9
+fi
+exec "$PVE_TOOLBOX_TEST_REAL_MV" "$@"
+MOVE
+    chmod 0755 "$bin/mv"
 }
 
 setup_case() { # setup_case <dir> <pool|schedule|active>...
@@ -80,6 +110,13 @@ setup_case() { # setup_case <dir> <pool|schedule|active>...
     printf 'DISCORD_WEBHOOK=%q\n' 'https://discord.com/api/webhooks/id/token' \
         > "$case_dir/config/zfs-scrub.conf"
     chmod 0600 "$case_dir/config/zfs-scrub.conf"
+    cat > "$case_dir/systemd/pve-toolbox-zfs-scrub@.service" <<EOF
+[Service]
+Type=oneshot
+Environment=SCRUB_CONF=$case_dir/config/zfs-scrub.conf
+ExecStart=/usr/local/bin/pve-toolbox-zfs-scrub %i
+EOF
+    chmod 0644 "$case_dir/systemd/pve-toolbox-zfs-scrub@.service"
     for fixture in "$@"; do
         pool=${fixture%%|*}
         active=${fixture##*|}
@@ -119,6 +156,7 @@ run_case() { # run_case <dir> [environment assignments...]
         PVE_TOOLBOX_RUN_DIR="$case_dir/run" \
         PVE_TOOLBOX_SYSTEMCTL_ROOT="$case_dir/systemctl" \
         PVE_TOOLBOX_SYSTEMCTL_LOG="$case_dir/systemctl.log" \
+        PVE_TOOLBOX_TEST_REAL_MV="$(command -v mv)" \
         "$@" "$ROOT/scripts/run-migrations.sh" 0.6.0
 }
 
@@ -178,6 +216,107 @@ run_case "$success" >/dev/null || fail "repeat migration failed"
     || fail "completed migration changed timer state again"
 pass "multiple pools preserve exact schedules without starting a scrub"
 pass "completed native timer migration is idempotent"
+
+recovered="$WORK/recovered"
+setup_case "$recovered" \
+    'data-pool|Sun *-*-01..07 03:00:00|active' \
+    'fast-data-pool|Mon *-*-15..21 04:30:00|inactive'
+rm -- "$recovered/state/zfs-scrub.state"
+recovered_conf=$(sha256sum "$recovered/config/zfs-scrub.conf")
+run_case "$recovered" >/dev/null || fail "missing state blocked valid legacy timers"
+grep -Fxq 'POOLS=data-pool\ fast-data-pool' "$recovered/state/zfs-scrub.state" \
+    || fail "recovered pool list does not match legacy timers"
+grep -Fxq SCHEDULE_OWNER=native "$recovered/state/zfs-scrub.state" \
+    || fail "recovered state omitted native ownership"
+[[ $(wc -l < "$recovered/state/zfs-scrub.state") -eq 3 \
+    && $(stat -c '%a' "$recovered/state/zfs-scrub.state") == 644 \
+    && $(sha256sum "$recovered/config/zfs-scrub.conf") == "$recovered_conf" ]] \
+    || fail "state recovery invented metadata or changed private configuration"
+grep -Fxq 'OnCalendar=Sun *-*-01..07 03:00:00' \
+    "$recovered/systemd/zfs-scrub-weekly@data-pool.timer.d/override.conf" \
+    || fail "state recovery changed the data-pool calendar"
+grep -Fxq 'OnCalendar=Mon *-*-15..21 04:30:00' \
+    "$recovered/systemd/zfs-scrub-weekly@fast-data-pool.timer.d/override.conf" \
+    || fail "state recovery changed the fast-data-pool calendar"
+if grep -E $'^start\t|^(enable|stop)\t.*(\.service|--now)' \
+    "$recovered/systemctl.log" >/dev/null; then
+    fail "state recovery started a timer or affected a scrub service"
+fi
+recovered_sum=$(sha256sum "$recovered/state/zfs-scrub.state")
+log_lines=$(wc -l < "$recovered/systemctl.log")
+run_case "$recovered" >/dev/null || fail "recovered migration retry failed"
+[[ $(sha256sum "$recovered/state/zfs-scrub.state") == "$recovered_sum" \
+    && $(wc -l < "$recovered/systemctl.log") -eq $log_lines ]] \
+    || fail "completed recovery was not idempotent"
+pass "missing state is recovered from legacy schedules without starting a scrub"
+
+for unsafe_case in state-link state-directory state-writable state-mismatch \
+    missing-config missing-service service-writable foreign-service \
+    foreign-timer drop-ins pending-edits wrong-fragment native-conflict; do
+    unsafe="$WORK/$unsafe_case"
+    setup_case "$unsafe" 'data-pool|weekly|active'
+    rm -- "$unsafe/state/zfs-scrub.state"
+    extra_env=()
+    case $unsafe_case in
+        state-link) ln -s "$unsafe/state/absent" "$unsafe/state/zfs-scrub.state" ;;
+        state-directory) mkdir "$unsafe/state/zfs-scrub.state" ;;
+        state-writable)
+            printf 'POOLS=data-pool\n' > "$unsafe/state/zfs-scrub.state"
+            chmod 0666 "$unsafe/state/zfs-scrub.state"
+            ;;
+        state-mismatch) printf 'POOLS=other-pool\n' > "$unsafe/state/zfs-scrub.state" ;;
+        missing-config) rm -- "$unsafe/config/zfs-scrub.conf" ;;
+        missing-service) rm -- "$unsafe/systemd/pve-toolbox-zfs-scrub@.service" ;;
+        service-writable) chmod 0666 "$unsafe/systemd/pve-toolbox-zfs-scrub@.service" ;;
+        foreign-service)
+            sed -i 's|^ExecStart=.*|ExecStart=/bin/true|' \
+                "$unsafe/systemd/pve-toolbox-zfs-scrub@.service"
+            ;;
+        foreign-timer) extra_env+=(PVE_TOOLBOX_FAKE_TIMER_UNIT=operator.service) ;;
+        drop-ins) extra_env+=(PVE_TOOLBOX_FAKE_DROP_INS=/run/systemd/system/timer.d/custom.conf) ;;
+        pending-edits) extra_env+=(PVE_TOOLBOX_FAKE_RELOAD=yes) ;;
+        wrong-fragment) extra_env+=(PVE_TOOLBOX_FAKE_FRAGMENT=/run/systemd/system/other.timer) ;;
+        native-conflict) : > "$unsafe/systemctl/enabled/zfs-scrub-weekly@data-pool.timer" ;;
+    esac
+    unsafe_timer=$(sha256sum "$unsafe/systemd/pve-toolbox-zfs-scrub@data-pool.timer")
+    unsafe_rc=0
+    run_case "$unsafe" "${extra_env[@]}" > "$unsafe/output" 2>&1 || unsafe_rc=$?
+    [[ $unsafe_rc -ne 0 && ! -e $unsafe/state/migrations.state \
+        && ! -e $unsafe/systemd/zfs-scrub-weekly@data-pool.timer.d \
+        && $(sha256sum "$unsafe/systemd/pve-toolbox-zfs-scrub@data-pool.timer") == "$unsafe_timer" ]] \
+        || fail "$unsafe_case was accepted or changed timer files"
+    if [[ -f $unsafe/systemctl.log ]] \
+        && grep -E '^(enable|disable|start|stop|daemon-reload)' "$unsafe/systemctl.log" >/dev/null; then
+        fail "$unsafe_case changed systemd before validation completed"
+    fi
+    [[ $(<"$unsafe/output") != *api/webhooks/id/token* ]] || fail "$unsafe_case leaked configuration"
+done
+pass "state recovery rejects unsafe, inconsistent, foreign, overridden, and conflicting installations"
+
+recover_rollback="$WORK/recover-rollback"
+setup_case "$recover_rollback" 'data-pool|weekly|active' 'fast-data-pool|monthly|inactive'
+rm -- "$recover_rollback/state/zfs-scrub.state"
+recover_rc=0
+run_case "$recover_rollback" PVE_TOOLBOX_FAIL_RECORD=1 \
+    > "$recover_rollback/output" 2>&1 || recover_rc=$?
+[[ $recover_rc -ne 0 && $(<"$recover_rollback/output") == *'restored files'* \
+    && ! -e $recover_rollback/state/zfs-scrub.state \
+    && ! -e $recover_rollback/state/migrations.state ]] \
+    || fail "failed completion did not restore the original absence of state"
+for pool in data-pool fast-data-pool; do
+    assert_enabled "$recover_rollback" "pve-toolbox-zfs-scrub@$pool.timer" \
+        || fail "recovery rollback did not restore the legacy timer"
+    assert_disabled "$recover_rollback" "zfs-scrub-weekly@$pool.timer" \
+        || fail "recovery rollback retained a native timer"
+    [[ ! -e $recover_rollback/systemd/zfs-scrub-weekly@$pool.timer.d ]] \
+        || fail "recovery rollback retained an override"
+done
+assert_active "$recover_rollback" pve-toolbox-zfs-scrub@data-pool.timer \
+    || fail "recovery rollback lost the previously active timer"
+assert_inactive "$recover_rollback" pve-toolbox-zfs-scrub@fast-data-pool.timer \
+    || fail "recovery rollback started a previously inactive timer"
+run_case "$recover_rollback" >/dev/null || fail "missing-state recovery could not retry after rollback"
+pass "failed recovery removes reconstructed state, restores schedules, and remains retryable"
 
 conflict="$WORK/conflict"
 setup_case "$conflict" 'tank|weekly|active'


### PR DESCRIPTION
## What
Recover missing ZFS scrub state during package upgrades from protected legacy configuration and validated timer/service files. Preserve each pool's calendar and restore the original absence of state if the migration fails.

## Why
The 0.6.0 → 0.7.0 upgrade fails with `legacy config and state must both be protected regular files` when the configuration and pool timers remain but the derived state file is missing, leaving dpkg half-configured.

## How
Recover only when state is absent and systemd uses the expected protected legacy files without overrides or pending edits. Existing unsafe or inconsistent state, foreign services, and native scheduling conflicts remain errors; reconstruction happens within the existing rollback transaction.

## Testing
- Passed `make lint` and `mkdocs build --strict`.
- Passed the complete Debian 13 `make test` suite with all six required gates enabled against one checksummed package, including package lifecycle and signed APT consumer checks.
- Regression tests cover two-pool recovery, exact calendars, unsafe/foreign/conflicting inputs, rollback, and retry.
- A real-dpkg fixture reproduced the half-configured upgrade failure, then successfully reinstalled the corrected 0.7.0 package; a subsequent reinstall also succeeded.
- Passed `git diff --check`.
- [CI passed](https://github.com/quwisky/pve-toolbox/actions/runs/33964877851): portable lint/tests, strict documentation, and Debian 13 package/repository validation.

## Notes
Changes packaged migration behavior and systemd timer configuration. It preserves credentials and never starts native timers during configuration. Tests simulate systemd responses; no live PVE/ZFS host was tested. Two existing unreadable-file cases skip when the Debian suite runs as root; no required dependency gates skipped.

For an affected installation, install the corrected package; if already unpacked, run `dpkg --configure pve-toolbox` as root. No manual state-file creation is needed.
